### PR TITLE
Add minWidth to avator-test snapshot that fix test-webui failure

### DIFF
--- a/app/javascript/mastodon/components/__tests__/__snapshots__/avatar-test.js.snap
+++ b/app/javascript/mastodon/components/__tests__/__snapshots__/avatar-test.js.snap
@@ -10,6 +10,7 @@ exports[`<Avatar /> Autoplay renders a animated avatar 1`] = `
       "backgroundImage": "url(/animated/alice.gif)",
       "backgroundSize": "100px 100px",
       "height": "100px",
+      "minWidth": "100px",
       "width": "100px",
     }
   }
@@ -26,6 +27,7 @@ exports[`<Avatar /> Still renders a still avatar 1`] = `
       "backgroundImage": "url(/static/alice.jpg)",
       "backgroundSize": "100px 100px",
       "height": "100px",
+      "minWidth": "100px",
       "width": "100px",
     }
   }


### PR DESCRIPTION
Fedibirdで利用している Ruby のアップデート対応を進めていた際に、CircleCI でテストが落ちていたため先にそちらを修正できればと思い、PRを作成しました。

今回のPRでは  test-webui での jest のテストがパスするように修正しています。

またCircleCIがパスしていることは以下のPR経由で確認できると思います。
https://github.com/S-H-GAMELINKS/mastodon/pull/1443

またこのPR以降にもいくつか Fedibird のCI修正やRubyのアップデート対応をPRにしたいと考えています。
個人的にRubyのアップデート対応をしたいと思い対応している感じですので、このPRと今後作る予定のPRについてマージするなどの判断はお任せします。
