### PR TITLE
Fix: 500 Error

### DIFF
--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -44,7 +44,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
   end
 
   def thumbnail
-    instance_presenter.thumbnail ? full_asset_url(instance_presenter.thumbnail.file.url(:'@1x')) : full_pack_url('media/images/preview.png')
+    instance_presenter.thumbnail ? full_asset_url(instance_presenter.thumbnail.file.url(:'@1x')) : full_pack_url('media/images/preview.jpg')
   end
 
   def stats

--- a/app/views/application/_sidebar.html.haml
+++ b/app/views/application/_sidebar.html.haml
@@ -1,6 +1,6 @@
 .hero-widget
   .hero-widget__img
-    = image_tag @instance_presenter.thumbnail&.file&.url(:'@1x') || asset_pack_path('media/images/preview.png'), alt: @instance_presenter.title
+    = image_tag @instance_presenter.thumbnail&.file&.url(:'@1x') || asset_pack_path('media/images/preview.jpg'), alt: @instance_presenter.title
 
   .hero-widget__text
     %p= @instance_presenter.description.html_safe.presence || t('about.about_mastodon_html')

--- a/app/views/shared/_og.html.haml
+++ b/app/views/shared/_og.html.haml
@@ -8,7 +8,7 @@
 = opengraph 'og:type', 'website'
 = opengraph 'og:title', @instance_presenter.title
 = opengraph 'og:description', description
-= opengraph 'og:image', full_asset_url(thumbnail&.file&.url(:'@1x') || asset_pack_path('media/images/preview.png', protocol: :request))
+= opengraph 'og:image', full_asset_url(thumbnail&.file&.url(:'@1x') || asset_pack_path('media/images/preview.jpg', protocol: :request))
 = opengraph 'og:image:width', thumbnail ? thumbnail.meta['width'] : '1200'
 = opengraph 'og:image:height', thumbnail ? thumbnail.meta['height'] : '630'
 = opengraph 'twitter:card', 'summary_large_image'


### PR DESCRIPTION
May 28 08:19:30 fedi bundle[33395]: [c365f9cb-b18c-410b-bfbd-463607932587] method=GET path=/about format=html controller=AboutController action=show status=500 error='ActionView::Template::Error: Webpacker can't find media/images/preview.png in /home/mastodon/live/public/packs/manifest.json. Possible causes:
と出て 500が出るエラーを修正します。

https://fedi.ktn.cat で動作確認しました。