### PR TITLE
Accept array value in `rel` property of FEP-e232 object links

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -202,7 +202,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def process_link(tag)
-    return if tag['mediaType'] != 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' || tag['rel'] != "https://misskey-hub.net/ns#_misskey_quote" || tag['href'].blank?
+    return unless tag['mediaType'] == 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' && as_array(tag['rel']).include?('https://misskey-hub.net/ns#_misskey_quote') && tag['href'].present?
     
     @object_links << tag['href']
   end


### PR DESCRIPTION
本PRはFEP-e232 object linksの`Link`オブジェクトの`rel`プロパティの値として配列が渡された場合にも正しく処理できるようにするものです。

Activity Vocabularyの規格において[`rel`](https://www.w3.org/TR/2017/REC-activitystreams-vocabulary-20170523/#dfn-rel)プロパティは<q>functional</q>として定義されていないので、これは複数の値を配列として取ることが可能です。実際に、規格内の例においても`"rel": ["canonical", "preview"]`という形で例示されています。

現実にMitraがこのような形のオブジェクトを配信するようです。

<https://mitra.social/objects/01a06953-5976-7453-8847-069f0e2c903f>:

```json
  "tag": [
    {
      "type": "Link",
      "name": null,
      "href": "https://mitra.social/objects/01a04a26-eede-72b0-a5e9-f244c3ff2142",
      "mediaType": "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"",
      "rel": [
        "https://misskey-hub.net/ns#_misskey_quote"
      ]
    }
  ],
```

なお、本PRのコードが実際に期待通りに動作するかのテストはしていないのでご了承ください。