### PR TITLE
Add Cloud Agent development environment configuration

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,7 @@
 {
   "name": "Fedibird / Mastodon",
   "user": "ubuntu",
+  "snapshot": "snapshot-20260908-1789de1b-e23e-4859-9641-63ee99b265d1",
   "install": "bash .cursor/install.sh",
   "start": "bash .cursor/start-services.sh",
   "terminals": [

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,29 @@
+{
+  "name": "Fedibird / Mastodon",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start-services.sh",
+  "terminals": [
+    {
+      "name": "web",
+      "command": "source .cursor/mastodon-env.sh && PORT=3000 bundle _2.4.22_ exec puma -C config/puma.rb"
+    },
+    {
+      "name": "sidekiq",
+      "command": "source .cursor/mastodon-env.sh && bundle _2.4.22_ exec sidekiq"
+    },
+    {
+      "name": "streaming",
+      "command": "source .cursor/mastodon-env.sh && PORT=4000 node ./streaming/index.js"
+    },
+    {
+      "name": "webpack",
+      "command": "source .cursor/mastodon-env.sh && NODE_ENV=development ./bin/webpack-dev-server --listen-host 0.0.0.0"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 },
+    { "name": "streaming", "port": 4000 },
+    { "name": "webpack", "port": 3035 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Idempotent repository bootstrap for the Fedibird/Mastodon Cloud Agent.
+# Runs after the source tree is checked out. Toolchains (Ruby 2.7.4, Node 14,
+# OpenSSL 1.1, system packages, PostgreSQL, Redis) are already baked into the
+# base snapshot; this script only refreshes source-derived state.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/.cursor/mastodon-env.sh"
+
+echo "[install] Ruby: $(ruby -v)"
+echo "[install] Node: $(node -v)"
+echo "[install] Yarn: $(yarn -v)"
+
+# 1. Development .env (gitignored). Create with sensible local defaults if absent.
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  echo "[install] Writing development .env ..."
+  cat > "$REPO_ROOT/.env" <<'ENVEOF'
+# Development environment configuration for Cloud Agent
+LOCAL_DOMAIN=localhost:3000
+LOCAL_HTTPS=false
+REDIS_HOST=localhost
+REDIS_PORT=6379
+DB_HOST=localhost
+DB_USER=mastodon
+DB_NAME=mastodon_development
+DB_PASS=mastodon
+DB_PORT=5432
+ES_ENABLED=false
+ENVEOF
+fi
+
+# 2. Ruby dependencies (installed into the persistent rbenv global gem path).
+echo "[install] Installing Ruby gems (bundle install)..."
+gem list -i bundler -v 2.4.22 >/dev/null 2>&1 || gem install bundler -v 2.4.22
+bundle _2.4.22_ install --jobs "$(nproc)"
+
+# 3. JavaScript dependencies.
+echo "[install] Installing JS dependencies (yarn install)..."
+yarn install --frozen-lockfile
+
+# 4. Database: start services, then create/migrate idempotently.
+echo "[install] Ensuring PostgreSQL and Redis are up..."
+bash "$REPO_ROOT/.cursor/start-services.sh"
+
+echo "[install] Preparing database (create if needed + migrate)..."
+# db:prepare creates and loads the schema if the DB is missing, otherwise migrates.
+bundle _2.4.22_ exec rails db:prepare
+
+echo "[install] Done."

--- a/.cursor/mastodon-env.sh
+++ b/.cursor/mastodon-env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Shared shell environment for the Fedibird/Mastodon Cloud Agent setup.
+# Sourced by install.sh, start-services.sh, and each terminal command.
+#
+# It puts the project's pinned toolchains ahead of anything else on PATH:
+#   - Ruby 2.7.4 via rbenv (built against OpenSSL 1.1 at /opt/openssl-1.1)
+#   - Node.js 14 via nvm (required by webpack 4 / the streaming server)
+#
+# nvm.sh and `rbenv init` are not safe under `set -u`/`set -e`, so we relax
+# those options while loading them and restore the caller's settings after.
+
+MASTODON_NODE_VERSION="14.21.3"
+
+__mastodon_saved_opts="$(set +o)"
+set +eu
+
+# rbenv (Ruby 2.7.4)
+export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+if command -v rbenv >/dev/null 2>&1; then
+  eval "$(rbenv init - bash)"
+fi
+
+# Node 14 via nvm. Prepend explicitly because the base image places another
+# Node build early on PATH; webpack 4 breaks on Node >= 17 (OpenSSL 3).
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+NODE14_BIN="$NVM_DIR/versions/node/v${MASTODON_NODE_VERSION}/bin"
+if [ -d "$NODE14_BIN" ]; then
+  export PATH="$NODE14_BIN:$PATH"
+fi
+
+# Restore the caller's shell options.
+eval "$__mastodon_saved_opts"
+unset __mastodon_saved_opts
+
+export RAILS_ENV="${RAILS_ENV:-development}"

--- a/.cursor/start-services.sh
+++ b/.cursor/start-services.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Start (or reconcile) the infrastructure services Mastodon depends on:
+# PostgreSQL and Redis. Idempotent and safe to run on every boot.
+set -euo pipefail
+
+echo "[start-services] Ensuring PostgreSQL is running..."
+if ! sudo pg_isready -q; then
+  # pg_ctlcluster is the Debian/Ubuntu wrapper; fall back to the service script.
+  sudo pg_ctlcluster 16 main start 2>/dev/null || sudo service postgresql start || true
+fi
+# Wait for readiness.
+for i in $(seq 1 30); do
+  if sudo pg_isready -q; then break; fi
+  sleep 1
+done
+sudo pg_isready && echo "[start-services] PostgreSQL is ready."
+
+# Ensure the 'mastodon' role exists (persisted in the snapshot, but re-create if missing).
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='mastodon'" | grep -q 1; then
+  echo "[start-services] Creating 'mastodon' PostgreSQL role..."
+  sudo -u postgres psql -c "CREATE USER mastodon WITH PASSWORD 'mastodon' CREATEDB SUPERUSER;"
+fi
+
+echo "[start-services] Ensuring Redis is running..."
+if ! redis-cli ping >/dev/null 2>&1; then
+  sudo service redis-server start || true
+fi
+for i in $(seq 1 30); do
+  if redis-cli ping >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+redis-cli ping >/dev/null 2>&1 && echo "[start-services] Redis is ready."
+
+echo "[start-services] Done."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `.cursor/` development environment configuration so Cloud Agents can run this Fedibird/Mastodon fork end-to-end (Rails web, Node streaming server, Sidekiq, and webpack-dev-server).

The app targets an older stack (Ruby 2.7.4, Node 14, PostgreSQL, Redis). Ruby 2.7.4 predates OpenSSL 3 (which ships on Ubuntu 24.04), so the base environment builds Ruby against OpenSSL 1.1, and Node 14 is pinned via nvm because webpack 4 / the streaming server break on Node ≥ 17 (`ERR_OSSL_EVP_UNSUPPORTED`).

This is a **repo-file managed** environment: `.cursor/environment.json` fully defines the base (a pre-provisioned snapshot), install/start scripts, service terminals, and ports. Merging this PR makes the setup available to future Cloud Agents on the default branch.

## What's included

- `.cursor/environment.json` — base `snapshot`, `install`/`start` commands, four service terminals (`web`, `sidekiq`, `streaming`, `webpack`), and exposed ports (3000, 4000, 3035).
- `.cursor/mastodon-env.sh` — shared shell setup putting Ruby 2.7.4 (rbenv) and Node 14 (nvm) ahead on `PATH`. Node 14 is forced ahead of the base image's newer Node build to avoid `ERR_OSSL_EVP_UNSUPPORTED` in webpack. Relaxes `set -u`/`set -e` while loading nvm/rbenv init, which aren't strict-mode safe.
- `.cursor/install.sh` — idempotent bootstrap: writes a dev `.env` if missing, `bundle install`, `yarn install`, ensures services are up, then `rails db:prepare`.
- `.cursor/start-services.sh` — per-boot reconciliation that starts PostgreSQL and Redis and ensures the `mastodon` DB role exists.

## Base snapshot provisioning (toolchain baked into the base)

- System packages (build tools, `libicu`, `libidn`, protobuf, `libpq`, ImageMagick, ffmpeg, etc.)
- OpenSSL 1.1.1 built to `/opt/openssl-1.1`
- Ruby 2.7.4 via rbenv (compiled against OpenSSL 1.1) + bundler 2.4.22 (gems installed to the persistent rbenv global path)
- Node 14 via nvm + yarn 1.x
- PostgreSQL 16 and Redis 7

## Validation

| Check | Result |
|---|---|
| Login + post a status (browser, end-to-end) | Passed |
| `GET /health` | 200 |
| `GET /api/v1/streaming/health` | 200 |
| `GET /api/v1/instance` | Returns instance JSON (version 3.4.1) |
| webpack-dev-server compile (Node 14) | Compiled successfully |
| `install.sh` idempotence | Passed (re-run clean, exit 0) |
| Draft environment build (fresh checkout on snapshot) | SUCCEEDED |
| Fresh Cloud Agent booted from the build | Ruby 2.7.4 / Node 14.21.3 / Yarn 1.22.22, deps satisfied, all services + health checks passed |

### Demo

[mastodon_login_and_post_status.mp4](https://cursor.com/agents/bc-1cf8f7ca-be86-45a3-a3fa-ea59267acc0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmastodon_login_and_post_status.mp4)

[Mastodon login page](https://cursor.com/agents/bc-1cf8f7ca-be86-45a3-a3fa-ea59267acc0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmastodon_login_page.webp)
[Posted status visible in the home timeline](https://cursor.com/agents/bc-1cf8f7ca-be86-45a3-a3fa-ea59267acc0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmastodon_posted_status.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cf8f7ca-be86-45a3-a3fa-ea59267acc0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cf8f7ca-be86-45a3-a3fa-ea59267acc0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated development-environment setup and startup support.
  * Added configuration for web, background-processing, streaming, and asset-building services.
  * Added automatic installation of required Ruby and JavaScript dependencies.
  * Added PostgreSQL and Redis readiness checks and startup handling.
  * Added automatic database preparation during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->