### PR TITLE
Add Cloud Agent development environment (fedibird)

### DIFF
--- a/.cursor/dev_admin.rb
+++ b/.cursor/dev_admin.rb
@@ -1,0 +1,23 @@
+# Idempotently create a confirmed development admin account.
+# Email is intentionally port-free (admin@localhost) so it passes validation
+# even though LOCAL_DOMAIN carries a :3000 port for correct local URLs.
+email = "admin@localhost"
+
+unless User.exists?(email: email)
+  account = Account.where(username: "admin").first_or_initialize(username: "admin")
+  account.save(validate: false)
+
+  User.create!(
+    email: email,
+    password: "mastodonadmin",
+    password_confirmation: "mastodonadmin",
+    confirmed_at: Time.now.utc,
+    admin: true,
+    account: account,
+    agreement: true,
+    approved: true
+  )
+  puts "[dev_admin] Created #{email} (password: mastodonadmin)"
+else
+  puts "[dev_admin] #{email} already exists"
+end

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,30 @@
+{
+  "name": "Fedibird / Mastodon",
+  "user": "ubuntu",
+  "snapshot": "snapshot-20260908-3a443b31-b900-44a5-930a-18a3f1ef0448",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start-services.sh",
+  "terminals": [
+    {
+      "name": "web",
+      "command": "source .cursor/mastodon-env.sh && PORT=3000 bundle _2.6.9_ exec puma -C config/puma.rb"
+    },
+    {
+      "name": "sidekiq",
+      "command": "source .cursor/mastodon-env.sh && bundle _2.6.9_ exec sidekiq"
+    },
+    {
+      "name": "streaming",
+      "command": "source .cursor/mastodon-env.sh && PORT=4000 node ./streaming/index.js"
+    },
+    {
+      "name": "webpack",
+      "command": "source .cursor/mastodon-env.sh && NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development ./bin/webpack-dev-server --listen-host 0.0.0.0"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 },
+    { "name": "streaming", "port": 4000 },
+    { "name": "webpack", "port": 3035 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Idempotent repository bootstrap for the Fedibird/Mastodon Cloud Agent.
+# Runs after the source tree is checked out. Toolchains (Ruby 3.2.8, Node 20,
+# system packages, PostgreSQL, Redis) are already baked into the base snapshot;
+# this script only refreshes source-derived state.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/.cursor/mastodon-env.sh"
+
+BUNDLER_VERSION="2.6.9"
+
+echo "[install] Ruby: $(ruby -v)"
+echo "[install] Node: $(node -v)"
+echo "[install] Yarn: $(yarn -v)"
+
+# 1. Development .env (gitignored). Create with sensible local defaults if absent.
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  echo "[install] Writing development .env ..."
+  cat > "$REPO_ROOT/.env" <<'ENVEOF'
+# Development environment configuration for Cloud Agent
+LOCAL_DOMAIN=localhost:3000
+LOCAL_HTTPS=false
+RAILS_ENV=development
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=mastodon
+DB_PASS=mastodon
+DB_NAME=mastodon_development
+REDIS_HOST=localhost
+REDIS_PORT=6379
+ES_ENABLED=false
+STREAMING_CLUSTER_NUM=1
+ENVEOF
+fi
+
+# 2. Ruby dependencies (installed into the persistent rbenv global gem path).
+echo "[install] Installing Ruby gems (bundle install)..."
+gem list -i bundler -v "$BUNDLER_VERSION" >/dev/null 2>&1 || gem install bundler -v "$BUNDLER_VERSION"
+bundle "_${BUNDLER_VERSION}_" install --jobs "$(nproc)"
+
+# 3. JavaScript dependencies. Node 20 satisfies package.json engines (>=20) and
+#    the streaming server's jsdom 25; --ignore-engines is kept defensively for
+#    any transitively stricter engine constraints.
+echo "[install] Installing JS dependencies (yarn install)..."
+yarn install --frozen-lockfile --ignore-engines
+
+# 4. Database: start services, then create/load schema + migrate idempotently.
+echo "[install] Ensuring PostgreSQL and Redis are up..."
+bash "$REPO_ROOT/.cursor/start-services.sh"
+
+echo "[install] Preparing database (create + load schema if needed, then migrate)..."
+# NB: we avoid `db:prepare`/`db:setup` because their seed step builds an admin
+# whose email is admin@$LOCAL_DOMAIN, which fails validation when LOCAL_DOMAIN
+# has a port. Load the schema explicitly, then migrate (both idempotent).
+if ! bundle "_${BUNDLER_VERSION}_" exec rails db:version >/dev/null 2>&1; then
+  bundle "_${BUNDLER_VERSION}_" exec rails db:create
+  bundle "_${BUNDLER_VERSION}_" exec rails db:schema:load
+fi
+bundle "_${BUNDLER_VERSION}_" exec rails db:migrate
+
+# 5. Development admin account (idempotent). Uses a port-free, valid email so it
+#    passes validation; log in at http://localhost:3000 with admin@localhost.
+echo "[install] Ensuring development admin account exists..."
+bundle "_${BUNDLER_VERSION}_" exec rails runner "$REPO_ROOT/.cursor/dev_admin.rb"
+
+echo "[install] Done."

--- a/.cursor/mastodon-env.sh
+++ b/.cursor/mastodon-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Shared shell environment for the Fedibird/Mastodon Cloud Agent setup.
+# Sourced by install.sh, start-services.sh, and each terminal command.
+#
+# It puts the project's pinned toolchains ahead of anything else on PATH:
+#   - Ruby 3.2.8 via rbenv (builds against the system OpenSSL 3)
+#   - Node.js 20 via nvm (streaming needs jsdom 25 / Node >= 18; webpack 4 runs
+#     with NODE_OPTIONS=--openssl-legacy-provider, set in the webpack command)
+#
+# nvm.sh and `rbenv init` are not safe under `set -u`/`set -e`, so we relax
+# those options while loading them and restore the caller's settings after.
+
+MASTODON_NODE_VERSION="20.20.2"
+
+__mastodon_saved_opts="$(set +o)"
+set +eu
+
+# rbenv (Ruby 3.2.8)
+export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+if command -v rbenv >/dev/null 2>&1; then
+  eval "$(rbenv init - bash)"
+fi
+
+# Node 20 via nvm. Prepend explicitly because the base image places another
+# Node build early on PATH.
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+NODE_BIN="$NVM_DIR/versions/node/v${MASTODON_NODE_VERSION}/bin"
+if [ -d "$NODE_BIN" ]; then
+  export PATH="$NODE_BIN:$PATH"
+fi
+
+# Restore the caller's shell options.
+eval "$__mastodon_saved_opts"
+unset __mastodon_saved_opts
+
+export RAILS_ENV="${RAILS_ENV:-development}"

--- a/.cursor/start-services.sh
+++ b/.cursor/start-services.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Start (or reconcile) the infrastructure services Mastodon depends on:
+# PostgreSQL and Redis. Idempotent and safe to run on every boot.
+set -euo pipefail
+
+echo "[start-services] Ensuring PostgreSQL is running..."
+if ! sudo pg_isready -q; then
+  # pg_ctlcluster is the Debian/Ubuntu wrapper; fall back to the service script.
+  sudo pg_ctlcluster 16 main start 2>/dev/null || sudo service postgresql start || true
+fi
+# Wait for readiness.
+for _ in $(seq 1 30); do
+  if sudo pg_isready -q; then break; fi
+  sleep 1
+done
+sudo pg_isready && echo "[start-services] PostgreSQL is ready."
+
+# Ensure the 'mastodon' role exists (persisted in the snapshot, but re-create if missing).
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='mastodon'" | grep -q 1; then
+  echo "[start-services] Creating 'mastodon' PostgreSQL role..."
+  sudo -u postgres psql -c "CREATE USER mastodon WITH PASSWORD 'mastodon' CREATEDB SUPERUSER;"
+fi
+
+echo "[start-services] Ensuring Redis is running..."
+if ! redis-cli ping >/dev/null 2>&1; then
+  sudo service redis-server start || true
+fi
+for _ in $(seq 1 30); do
+  if redis-cli ping >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+redis-cli ping >/dev/null 2>&1 && echo "[start-services] Redis is ready."
+
+echo "[start-services] Done."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent development environment for the Fedibird/Mastodon stack, targeting the **`fedibird`** branch, so future agents boot into a ready-to-run workspace.

The `fedibird` branch's toolchain differs from `main`, and this setup matches it:
- **Ruby 3.2.8** via `rbenv`, built against the system **OpenSSL 3** (no custom OpenSSL needed, unlike `main`'s Ruby 2.7.4).
- **Node.js 20** via `nvm` — the streaming server depends on `jsdom ^25` (needs Node ≥ 18), and webpack 4 runs with `NODE_OPTIONS=--openssl-legacy-provider`. (The stale `.nvmrc`/Dockerfile Node 14 hints are superseded by `package.json` `engines: >=20` + `jsdom ^25`.)
- **Bundler 2.6.9**, **PostgreSQL 16**, **Redis**.

Heavy toolchains (Ruby/Node/PostgreSQL/Redis + system packages) are baked into a base **snapshot** pinned in `environment.json`, so `install.sh` only refreshes source-derived state (gems, JS deps, DB) and stays fast and idempotent.

## Files

- `.cursor/environment.json` — pins the base snapshot and declares `install`/`start` phases, four terminals (`web`, `sidekiq`, `streaming`, `webpack` with the legacy OpenSSL provider), and ports (3000/4000/3035).
- `.cursor/mastodon-env.sh` — shared shell env pinning Ruby 3.2.8 and Node 20 on `PATH`.
- `.cursor/install.sh` — idempotent bootstrap: dev `.env`, `bundle install`, `yarn install`, ensure services, load schema + migrate, ensure a dev admin.
- `.cursor/dev_admin.rb` — creates a confirmed dev admin (`admin@localhost` / `mastodonadmin`). A port-free email is used because fedibird rejects `admin@localhost:3000` (the stock seed's email), which is why `install.sh` avoids `db:setup`/`db:prepare` seeding.
- `.cursor/start-services.sh` — starts/reconciles PostgreSQL + Redis each boot.

## Validation

| Check | Result |
| --- | --- |
| Compose + publish a post via the web UI (login `admin@localhost`) | Passed — posts appear in home timeline; `status_count` reached 2 |
| `GET /health` | 200 OK |
| `GET /api/v1/instance` | Valid JSON (v3.4.1, DB + Redis connected) |
| Streaming `GET /api/v1/streaming/health` | 200 OK (Node 20 + jsdom 25, no `||=` crash) |
| web / sidekiq / streaming / webpack | All running; webpack "Compiled successfully" with `--openssl-legacy-provider` |
| `install.sh` idempotence | Passed twice (Ruby 3.2.8, Node 20.20.2, 314 gems) |
| Environment build from pinned snapshot | SUCCEEDED (clean fresh checkout + install) |
| Fresh Cloud Agent from tested build | PASS 7/7 — toolchains, deps, services, web + streaming e2e, dev admin |

### End-to-end demo (login → compose → publish, on the fedibird branch)

[fedibird_login_and_post_e2e.mp4](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffedibird_login_and_post_e2e.mp4)

[Published posts in the fedibird home timeline](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffedibird_published_post_timeline.webp)

## Notes

- `.env` is intentionally not committed (gitignored); `install.sh` recreates it with local dev defaults if missing.
- Merging this PR activates the setup for future agents on `fedibird`; the repository-managed `.cursor/environment.json` (highest-precedence config) carries the snapshot base plus the terminals and ports.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment configuration for running the application locally.
  * Added automated setup for required Ruby and JavaScript tooling and dependencies.
  * Added scripts to initialize environment variables, prepare the database, and start required PostgreSQL and Redis services.
  * Added predefined local service configurations for the web application, background processing, streaming, and asset development servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->