### PR TITLE
Moderation signal ledger foundation (Phase 1)

### DIFF
--- a/app/models/moderation_interaction_event.rb
+++ b/app/models/moderation_interaction_event.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_interaction_events
+#
+#  id                 :bigint(8)        not null, primary key
+#  actor_subject_id   :bigint(8)        not null
+#  target_subject_id  :bigint(8)        not null
+#  event_type         :integer          not null
+#  status_id          :bigint(8)
+#  source_record_type :string
+#  source_record_id   :bigint(8)
+#  import_batch_id    :bigint(8)
+#  occurred_at        :datetime         not null
+#  observed_at        :datetime         not null
+#  metadata           :jsonb            not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# An observed contact from one subject to another (mention, reply, follow,
+# quote, reference, reaction, favourite, follow import).
+#
+# This is an append-only observation ledger: a single interaction is not judged
+# good or bad here. +status_id+/+source_record_id+ are non-foreign-key pointers
+# kept only for short-term investigation, so deleting the source never removes
+# the recorded event.
+class ModerationInteractionEvent < ApplicationRecord
+  self.table_name = 'moderation_interaction_events'
+
+  enum event_type: {
+    mention: 0,
+    reply: 1,
+    follow: 2,
+    quote: 3,
+    reference: 4,
+    reaction: 5,
+    favourite: 6,
+    follow_import: 7,
+  }, _suffix: :event
+
+  belongs_to :actor_subject, class_name: 'ModerationSubject', inverse_of: :actor_interaction_events
+  belongs_to :target_subject, class_name: 'ModerationSubject', inverse_of: :target_interaction_events
+
+  has_many :caused_rejections,
+           class_name: 'ModerationRejectionEvent',
+           foreign_key: :preceding_interaction_event_id,
+           inverse_of: :preceding_interaction_event,
+           dependent: :nullify
+
+  validates :event_type, presence: true
+  validates :occurred_at, :observed_at, presence: true
+
+  scope :between, ->(actor_subject, target_subject) { where(actor_subject: actor_subject, target_subject: target_subject) }
+end

--- a/app/models/moderation_rejection_event.rb
+++ b/app/models/moderation_rejection_event.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_rejection_events
+#
+#  id                             :bigint(8)        not null, primary key
+#  rejector_subject_id            :bigint(8)        not null
+#  rejected_subject_id            :bigint(8)        not null
+#  event_type                     :integer          not null
+#  preceding_interaction_event_id :bigint(8)
+#  occurred_at                    :datetime         not null
+#  observed_at                    :datetime         not null
+#  metadata                       :jsonb            not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#
+# An observed negative/rejection signal returned by the contacted side
+# (follow reject, remove follower, mute, mute notifications, block, report).
+#
+# "Doing nothing" is never recorded as a positive signal. When possible the
+# recorder links back to the interaction that immediately preceded the
+# rejection via +preceding_interaction_event+ so time-to-rejection can be
+# analysed later.
+class ModerationRejectionEvent < ApplicationRecord
+  self.table_name = 'moderation_rejection_events'
+
+  enum event_type: {
+    follow_reject: 0,
+    remove_follower: 1,
+    mute: 2,
+    mute_notifications: 3,
+    block: 4,
+    report: 5,
+  }, _suffix: :event
+
+  belongs_to :rejector_subject, class_name: 'ModerationSubject', inverse_of: :rejections_made
+  belongs_to :rejected_subject, class_name: 'ModerationSubject', inverse_of: :rejections_received
+  belongs_to :preceding_interaction_event, class_name: 'ModerationInteractionEvent', optional: true, inverse_of: :caused_rejections
+
+  validates :event_type, presence: true
+  validates :occurred_at, :observed_at, presence: true
+
+  # Seconds between the preceding contact and this rejection, when known.
+  def time_to_rejection
+    return nil if preceding_interaction_event.nil?
+
+    occurred_at - preceding_interaction_event.occurred_at
+  end
+end

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_subjects
+#
+#  id              :bigint(8)        not null, primary key
+#  account_id      :bigint(8)
+#  origin          :integer          default("local"), not null
+#  domain          :string
+#  actor_uri_hash  :string
+#  first_seen_at   :datetime         not null
+#  last_seen_at    :datetime         not null
+#  deleted_at      :datetime
+#  retention_until :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# A moderation-analysis subject, intentionally decoupled from Account.
+#
+# Interaction and rejection events reference subjects (never Account directly)
+# so the observed history can outlive the underlying Account per the retention
+# policy. When an Account is deleted/purged the database foreign key nullifies
+# +account_id+ (ON DELETE SET NULL); the subject row and its events remain.
+class ModerationSubject < ApplicationRecord
+  self.table_name = 'moderation_subjects'
+
+  enum origin: { local: 0, remote: 1 }, _suffix: :origin
+
+  belongs_to :account, optional: true
+
+  has_many :actor_interaction_events,
+           class_name: 'ModerationInteractionEvent',
+           foreign_key: :actor_subject_id,
+           inverse_of: :actor_subject,
+           dependent: :destroy
+  has_many :target_interaction_events,
+           class_name: 'ModerationInteractionEvent',
+           foreign_key: :target_subject_id,
+           inverse_of: :target_subject,
+           dependent: :destroy
+  has_many :rejections_made,
+           class_name: 'ModerationRejectionEvent',
+           foreign_key: :rejector_subject_id,
+           inverse_of: :rejector_subject,
+           dependent: :destroy
+  has_many :rejections_received,
+           class_name: 'ModerationRejectionEvent',
+           foreign_key: :rejected_subject_id,
+           inverse_of: :rejected_subject,
+           dependent: :destroy
+
+  validates :origin, presence: true
+  validates :first_seen_at, :last_seen_at, presence: true
+
+  scope :active, -> { where(deleted_at: nil) }
+  scope :tombstoned, -> { where.not(deleted_at: nil) }
+
+  # Resolve (or create) the subject that represents +account+, keeping the
+  # denormalized origin/domain and +last_seen_at+ fresh. Accepts either an
+  # Account or an already-resolved ModerationSubject for caller convenience.
+  def self.for_account!(account, observed_at: Time.now.utc)
+    return account if account.is_a?(ModerationSubject)
+
+    raise ArgumentError, 'account is required' if account.nil?
+
+    subject = find_or_create_by!(account_id: account.id) do |s|
+      s.origin        = account.local? ? :local : :remote
+      s.domain        = account.domain
+      s.first_seen_at = observed_at
+      s.last_seen_at  = observed_at
+    end
+
+    subject.refresh_from_account!(account, observed_at: observed_at)
+    subject
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+
+  def refresh_from_account!(account, observed_at: Time.now.utc)
+    self.origin      = account.local? ? :local : :remote
+    self.domain      = account.domain
+    self.last_seen_at = observed_at
+    save! if changed?
+  end
+
+  def tombstone!(now: Time.now.utc)
+    update!(deleted_at: now)
+  end
+
+  def tombstoned?
+    deleted_at.present?
+  end
+end

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Records moderation-signal ledger events (interactions and rejections).
+#
+# This is the single entry point future interaction/rejection hooks should call.
+# Design goals (see docs/moderation-signal-design.md, Phase 1):
+#
+#   * Never break a normal Mastodon operation because recording failed — the
+#     class-level helpers swallow and log errors and return +nil+.
+#   * Never lose a failure silently — every swallowed error is logged so gaps
+#     are observable.
+#   * Record only behavioural metadata (who / whom / what / when), never raw
+#     post/DM/profile content.
+#
+# This phase performs recording only: no scoring, throttling, or enforcement.
+module Moderation
+  class EventRecorder
+    class << self
+      # Failure-tolerant wrappers intended for call sites on hot paths.
+      def record_interaction(**options)
+        new.record_interaction(**options)
+      rescue StandardError => e
+        handle_error(:interaction, e)
+        nil
+      end
+
+      def record_rejection(**options)
+        new.record_rejection(**options)
+      rescue StandardError => e
+        handle_error(:rejection, e)
+        nil
+      end
+
+      def handle_error(kind, error)
+        Rails.logger.warn("[Moderation::EventRecorder] failed to record #{kind} event: #{error.class}: #{error.message}")
+        nil
+      end
+    end
+
+    # Record a contact (actor -> target). +actor+/+target+ may be an Account or
+    # an already-resolved ModerationSubject. Raises on failure; prefer the
+    # class-level Moderation::EventRecorder.record_interaction at call sites.
+    def record_interaction(actor:, target:, event_type:, status: nil, source_record: nil, import_batch_id: nil, occurred_at: nil, observed_at: nil, metadata: {})
+      observed_at ||= Time.now.utc
+      actor_subject  = ModerationSubject.for_account!(actor, observed_at: observed_at)
+      target_subject = ModerationSubject.for_account!(target, observed_at: observed_at)
+
+      ModerationInteractionEvent.create!(
+        actor_subject: actor_subject,
+        target_subject: target_subject,
+        event_type: event_type,
+        status_id: status&.id,
+        source_record_type: source_record&.class&.base_class&.name,
+        source_record_id: source_record&.id,
+        import_batch_id: import_batch_id,
+        occurred_at: occurred_at || observed_at,
+        observed_at: observed_at,
+        metadata: metadata || {}
+      )
+    end
+
+    # Record a negative signal (rejector -> rejected). +preceding_interaction+
+    # optionally links the contact this rejection responded to.
+    def record_rejection(rejector:, rejected:, event_type:, preceding_interaction: nil, occurred_at: nil, observed_at: nil, metadata: {})
+      observed_at ||= Time.now.utc
+      rejector_subject = ModerationSubject.for_account!(rejector, observed_at: observed_at)
+      rejected_subject = ModerationSubject.for_account!(rejected, observed_at: observed_at)
+
+      ModerationRejectionEvent.create!(
+        rejector_subject: rejector_subject,
+        rejected_subject: rejected_subject,
+        event_type: event_type,
+        preceding_interaction_event: preceding_interaction,
+        occurred_at: occurred_at || observed_at,
+        observed_at: observed_at,
+        metadata: metadata || {}
+      )
+    end
+  end
+end

--- a/db/migrate/20260908230001_create_moderation_subjects.rb
+++ b/db/migrate/20260908230001_create_moderation_subjects.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateModerationSubjects < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_subjects do |t|
+      # Deliberately ON DELETE SET NULL (never cascade): a subject and its
+      # recorded events must outlive the underlying Account per the retention
+      # policy, so account deletion/purge only detaches the link.
+      t.references :account, foreign_key: { on_delete: :nullify }, index: false
+
+      t.integer :origin, null: false, default: 0
+      t.string :domain
+      t.string :actor_uri_hash
+
+      t.datetime :first_seen_at, null: false
+      t.datetime :last_seen_at, null: false
+      t.datetime :deleted_at
+      t.datetime :retention_until
+
+      t.timestamps
+    end
+
+    add_index :moderation_subjects, :account_id, unique: true, where: 'account_id IS NOT NULL', name: :index_moderation_subjects_on_account_id
+    add_index :moderation_subjects, :actor_uri_hash, where: 'actor_uri_hash IS NOT NULL', name: :index_moderation_subjects_on_actor_uri_hash
+    add_index :moderation_subjects, :retention_until, name: :index_moderation_subjects_on_retention_until
+    add_index :moderation_subjects, :deleted_at, name: :index_moderation_subjects_on_deleted_at
+  end
+end

--- a/db/migrate/20260908230002_create_moderation_interaction_events.rb
+++ b/db/migrate/20260908230002_create_moderation_interaction_events.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateModerationInteractionEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_interaction_events do |t|
+      t.references :actor_subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+      t.references :target_subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      t.integer :event_type, null: false
+
+      # Short-term investigation pointers only; intentionally NOT foreign keys so
+      # deleting the originating Status/record never removes the observed event.
+      t.bigint :status_id
+      t.string :source_record_type
+      t.bigint :source_record_id
+      t.bigint :import_batch_id
+
+      t.datetime :occurred_at, null: false
+      t.datetime :observed_at, null: false
+      t.jsonb :metadata, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :moderation_interaction_events, [:actor_subject_id, :occurred_at], name: :index_mod_interaction_events_on_actor_and_occurred
+    add_index :moderation_interaction_events, [:target_subject_id, :occurred_at], name: :index_mod_interaction_events_on_target_and_occurred
+    add_index :moderation_interaction_events, [:actor_subject_id, :target_subject_id, :occurred_at], name: :index_mod_interaction_events_on_actor_target_occurred
+    add_index :moderation_interaction_events, [:event_type, :occurred_at], name: :index_mod_interaction_events_on_type_and_occurred
+  end
+end

--- a/db/migrate/20260908230003_create_moderation_rejection_events.rb
+++ b/db/migrate/20260908230003_create_moderation_rejection_events.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateModerationRejectionEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_rejection_events do |t|
+      t.references :rejector_subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+      t.references :rejected_subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      t.integer :event_type, null: false
+
+      # Optional link to the interaction that immediately preceded the rejection.
+      # ON DELETE SET NULL so pruning an interaction never drops the rejection.
+      t.bigint :preceding_interaction_event_id
+
+      t.datetime :occurred_at, null: false
+      t.datetime :observed_at, null: false
+      t.jsonb :metadata, null: false, default: {}
+
+      t.timestamps
+    end
+
+    safety_assured do
+      add_foreign_key :moderation_rejection_events, :moderation_interaction_events, column: :preceding_interaction_event_id, on_delete: :nullify
+    end
+
+    add_index :moderation_rejection_events, [:rejected_subject_id, :occurred_at], name: :index_mod_rejection_events_on_rejected_and_occurred
+    add_index :moderation_rejection_events, [:rejector_subject_id, :occurred_at], name: :index_mod_rejection_events_on_rejector_and_occurred
+    add_index :moderation_rejection_events, [:rejected_subject_id, :rejector_subject_id, :occurred_at], name: :index_mod_rejection_events_on_rejected_rejector_occurred
+    add_index :moderation_rejection_events, [:event_type, :occurred_at], name: :index_mod_rejection_events_on_type_and_occurred
+    add_index :moderation_rejection_events, :preceding_interaction_event_id, where: 'preceding_interaction_event_id IS NOT NULL', name: :index_mod_rejection_events_on_preceding_event
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_09_183534) do
+ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -745,6 +745,59 @@ ActiveRecord::Schema.define(version: 2025_06_09_183534) do
     t.index ["status_id"], name: "index_mentions_on_status_id"
   end
 
+  create_table "moderation_interaction_events", force: :cascade do |t|
+    t.bigint "actor_subject_id", null: false
+    t.bigint "target_subject_id", null: false
+    t.integer "event_type", null: false
+    t.bigint "status_id"
+    t.string "source_record_type"
+    t.bigint "source_record_id"
+    t.bigint "import_batch_id"
+    t.datetime "occurred_at", null: false
+    t.datetime "observed_at", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["actor_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_actor_and_occurred"
+    t.index ["actor_subject_id", "target_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_actor_target_occurred"
+    t.index ["event_type", "occurred_at"], name: "index_mod_interaction_events_on_type_and_occurred"
+    t.index ["target_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_target_and_occurred"
+  end
+
+  create_table "moderation_rejection_events", force: :cascade do |t|
+    t.bigint "rejector_subject_id", null: false
+    t.bigint "rejected_subject_id", null: false
+    t.integer "event_type", null: false
+    t.bigint "preceding_interaction_event_id"
+    t.datetime "occurred_at", null: false
+    t.datetime "observed_at", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_type", "occurred_at"], name: "index_mod_rejection_events_on_type_and_occurred"
+    t.index ["preceding_interaction_event_id"], name: "index_mod_rejection_events_on_preceding_event", where: "(preceding_interaction_event_id IS NOT NULL)"
+    t.index ["rejected_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejected_and_occurred"
+    t.index ["rejected_subject_id", "rejector_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejected_rejector_occurred"
+    t.index ["rejector_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejector_and_occurred"
+  end
+
+  create_table "moderation_subjects", force: :cascade do |t|
+    t.bigint "account_id"
+    t.integer "origin", default: 0, null: false
+    t.string "domain"
+    t.string "actor_uri_hash"
+    t.datetime "first_seen_at", null: false
+    t.datetime "last_seen_at", null: false
+    t.datetime "deleted_at"
+    t.datetime "retention_until"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_moderation_subjects_on_account_id", unique: true, where: "(account_id IS NOT NULL)"
+    t.index ["actor_uri_hash"], name: "index_moderation_subjects_on_actor_uri_hash", where: "(actor_uri_hash IS NOT NULL)"
+    t.index ["deleted_at"], name: "index_moderation_subjects_on_deleted_at"
+    t.index ["retention_until"], name: "index_moderation_subjects_on_retention_until"
+  end
+
   create_table "mutes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1348,6 +1401,12 @@ ActiveRecord::Schema.define(version: 2025_06_09_183534) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_subjects", "accounts", on_delete: :nullify
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
   add_foreign_key "notifications", "accounts", column: "from_account_id", name: "fk_fbd6b0bf9e", on_delete: :cascade

--- a/spec/fabricators/moderation_interaction_event_fabricator.rb
+++ b/spec/fabricators/moderation_interaction_event_fabricator.rb
@@ -1,0 +1,7 @@
+Fabricator(:moderation_interaction_event) do
+  actor_subject  { Fabricate(:moderation_subject) }
+  target_subject { Fabricate(:moderation_subject) }
+  event_type     :follow
+  occurred_at    { Time.now.utc }
+  observed_at    { Time.now.utc }
+end

--- a/spec/fabricators/moderation_rejection_event_fabricator.rb
+++ b/spec/fabricators/moderation_rejection_event_fabricator.rb
@@ -1,0 +1,7 @@
+Fabricator(:moderation_rejection_event) do
+  rejector_subject { Fabricate(:moderation_subject) }
+  rejected_subject { Fabricate(:moderation_subject) }
+  event_type       :block
+  occurred_at      { Time.now.utc }
+  observed_at      { Time.now.utc }
+end

--- a/spec/fabricators/moderation_subject_fabricator.rb
+++ b/spec/fabricators/moderation_subject_fabricator.rb
@@ -1,0 +1,6 @@
+Fabricator(:moderation_subject) do
+  account
+  origin        :local
+  first_seen_at { Time.now.utc }
+  last_seen_at  { Time.now.utc }
+end

--- a/spec/models/moderation/ledger_durability_spec.rb
+++ b/spec/models/moderation/ledger_durability_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+# The most important guarantee of the moderation ledger (Phase 1/2 design):
+# observed events must survive deletion/purge of the underlying Mastodon
+# records. The ledger references ModerationSubject (never Account directly),
+# and the only Account link (moderation_subjects.account_id) is ON DELETE SET
+# NULL, so nothing in the ledger is cascade-deleted by Mastodon's lifecycle.
+RSpec.describe 'Moderation ledger durability', type: :model do
+  let(:actor)  { Fabricate(:account) }
+  let(:target) { Fabricate(:account) }
+
+  describe 'when the acting account is deleted' do
+    it 'keeps the subject and interaction event, only nullifying account_id' do
+      event = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :follow)
+      actor_subject_id = event.actor_subject_id
+
+      expect { actor.destroy! }.to_not change(ModerationInteractionEvent, :count)
+
+      expect(ModerationSubject.exists?(actor_subject_id)).to be true
+      expect(ModerationSubject.find(actor_subject_id).account_id).to be_nil
+      expect(ModerationInteractionEvent.exists?(event.id)).to be true
+      expect(event.reload.actor_subject_id).to eq actor_subject_id
+    end
+  end
+
+  describe 'when the rejecting account is deleted' do
+    it 'keeps the rejection event, only nullifying account_id' do
+      contact = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :mention)
+      rejection = Moderation::EventRecorder.record_rejection(rejector: target, rejected: actor, event_type: :block, preceding_interaction: contact)
+      rejector_subject_id = rejection.rejector_subject_id
+
+      expect { target.destroy! }.to_not change(ModerationRejectionEvent, :count)
+
+      expect(ModerationSubject.find(rejector_subject_id).account_id).to be_nil
+      expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+    end
+  end
+
+  describe 'when the source status is deleted' do
+    it 'keeps the interaction event and its status_id pointer' do
+      status = Fabricate(:status, account: actor)
+      event = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :mention, status: status)
+
+      expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)
+
+      expect(ModerationInteractionEvent.exists?(event.id)).to be true
+      expect(event.reload.status_id).to eq status.id
+    end
+  end
+
+  describe 'when both accounts are deleted' do
+    it 'preserves the interaction event with both subjects detached' do
+      event = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :follow)
+
+      actor.destroy!
+      target.destroy!
+
+      event.reload
+      expect(event.actor_subject.account_id).to be_nil
+      expect(event.target_subject.account_id).to be_nil
+    end
+  end
+end

--- a/spec/models/moderation_interaction_event_spec.rb
+++ b/spec/models/moderation_interaction_event_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe ModerationInteractionEvent, type: :model do
+  it 'is valid with the required attributes' do
+    expect(Fabricate.build(:moderation_interaction_event)).to be_valid
+  end
+
+  it 'requires an event_type, occurred_at and observed_at' do
+    event = Fabricate.build(:moderation_interaction_event, event_type: nil, occurred_at: nil, observed_at: nil)
+    expect(event).to_not be_valid
+    expect(event.errors.attribute_names).to include(:event_type, :occurred_at, :observed_at)
+  end
+
+  it 'belongs to actor and target subjects' do
+    actor = Fabricate(:moderation_subject)
+    target = Fabricate(:moderation_subject)
+    event = Fabricate(:moderation_interaction_event, actor_subject: actor, target_subject: target)
+
+    expect(event.actor_subject).to eq actor
+    expect(event.target_subject).to eq target
+    expect(actor.actor_interaction_events).to include(event)
+    expect(target.target_interaction_events).to include(event)
+  end
+
+  it 'exposes the interaction event types' do
+    expect(described_class.event_types.keys).to match_array(%w(mention reply follow quote reference reaction favourite follow_import))
+  end
+end

--- a/spec/models/moderation_rejection_event_spec.rb
+++ b/spec/models/moderation_rejection_event_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ModerationRejectionEvent, type: :model do
+  it 'is valid with the required attributes' do
+    expect(Fabricate.build(:moderation_rejection_event)).to be_valid
+  end
+
+  it 'requires an event_type, occurred_at and observed_at' do
+    event = Fabricate.build(:moderation_rejection_event, event_type: nil, occurred_at: nil, observed_at: nil)
+    expect(event).to_not be_valid
+    expect(event.errors.attribute_names).to include(:event_type, :occurred_at, :observed_at)
+  end
+
+  it 'exposes the rejection event types' do
+    expect(described_class.event_types.keys).to match_array(%w(follow_reject remove_follower mute mute_notifications block report))
+  end
+
+  describe '#time_to_rejection' do
+    it 'is nil without a preceding interaction' do
+      expect(Fabricate(:moderation_rejection_event, preceding_interaction_event: nil).time_to_rejection).to be_nil
+    end
+
+    it 'is the elapsed seconds since the preceding interaction' do
+      contact = Fabricate(:moderation_interaction_event, occurred_at: Time.utc(2026, 1, 1, 10, 0, 0))
+      rejection = Fabricate(:moderation_rejection_event, preceding_interaction_event: contact, occurred_at: Time.utc(2026, 1, 1, 10, 15, 0))
+
+      expect(rejection.time_to_rejection).to eq 15.minutes.to_i
+    end
+  end
+end

--- a/spec/models/moderation_subject_spec.rb
+++ b/spec/models/moderation_subject_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe ModerationSubject, type: :model do
+  describe 'validations' do
+    it 'is valid with the required attributes' do
+      expect(Fabricate.build(:moderation_subject)).to be_valid
+    end
+
+    it 'requires first_seen_at and last_seen_at' do
+      subject = Fabricate.build(:moderation_subject, first_seen_at: nil, last_seen_at: nil)
+      expect(subject).to_not be_valid
+      expect(subject.errors.attribute_names).to include(:first_seen_at, :last_seen_at)
+    end
+  end
+
+  describe '.for_account!' do
+    let(:account) { Fabricate(:account, domain: nil) }
+
+    it 'creates a subject linked to the account with derived origin/domain' do
+      expect { ModerationSubject.for_account!(account) }.to change(ModerationSubject, :count).by(1)
+
+      subject = ModerationSubject.find_by(account_id: account.id)
+      expect(subject.origin).to eq 'local'
+      expect(subject.domain).to be_nil
+      expect(subject.first_seen_at).to be_present
+      expect(subject.last_seen_at).to be_present
+    end
+
+    it 'is idempotent for the same account and refreshes last_seen_at' do
+      first = ModerationSubject.for_account!(account, observed_at: 1.hour.ago)
+      second = nil
+
+      expect { second = ModerationSubject.for_account!(account, observed_at: Time.now.utc) }.to_not change(ModerationSubject, :count)
+      expect(second.id).to eq first.id
+      expect(second.reload.last_seen_at).to be > first.first_seen_at
+    end
+
+    it 'marks remote accounts as remote origin' do
+      remote = Fabricate(:account, domain: 'remote.example', uri: 'https://remote.example/users/bob')
+      subject = ModerationSubject.for_account!(remote)
+      expect(subject.origin).to eq 'remote'
+      expect(subject.domain).to eq 'remote.example'
+    end
+
+    it 'returns the argument unchanged when already a ModerationSubject' do
+      existing = Fabricate(:moderation_subject)
+      expect(ModerationSubject.for_account!(existing)).to eq existing
+    end
+  end
+
+  describe '#tombstone!' do
+    it 'sets deleted_at without destroying the row' do
+      subject = Fabricate(:moderation_subject)
+      subject.tombstone!
+      expect(subject.reload).to be_tombstoned
+      expect(ModerationSubject.exists?(subject.id)).to be true
+    end
+  end
+end

--- a/spec/services/moderation/event_recorder_spec.rb
+++ b/spec/services/moderation/event_recorder_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::EventRecorder, type: :service do
+  let(:actor)  { Fabricate(:account) }
+  let(:target) { Fabricate(:account) }
+
+  describe '.record_interaction' do
+    it 'records an interaction event, resolving accounts to subjects' do
+      status = Fabricate(:status, account: actor)
+
+      event = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :mention,
+        status: status,
+        source_record: status
+      )
+
+      expect(event).to be_persisted
+      expect(event.event_type).to eq 'mention'
+      expect(event.actor_subject.account_id).to eq actor.id
+      expect(event.target_subject.account_id).to eq target.id
+      expect(event.status_id).to eq status.id
+      expect(event.source_record_type).to eq 'Status'
+      expect(event.source_record_id).to eq status.id
+    end
+
+    it 'reuses the same subject for repeated interactions by the same account' do
+      described_class.record_interaction(actor: actor, target: target, event_type: :follow)
+      described_class.record_interaction(actor: actor, target: target, event_type: :mention)
+
+      expect(ModerationSubject.where(account_id: actor.id).count).to eq 1
+      expect(ModerationInteractionEvent.count).to eq 2
+    end
+
+    it 'does not raise and returns nil on failure, and records no event' do
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      result = nil
+      expect do
+        result = described_class.record_interaction(actor: actor, target: nil, event_type: :follow)
+      end.to_not change(ModerationInteractionEvent, :count)
+
+      expect(result).to be_nil
+      expect(Rails.logger).to have_received(:warn).with(/Moderation::EventRecorder/)
+    end
+  end
+
+  describe '.record_rejection' do
+    it 'records a rejection event and links the preceding interaction' do
+      contact = described_class.record_interaction(actor: actor, target: target, event_type: :mention)
+
+      event = described_class.record_rejection(
+        rejector: target,
+        rejected: actor,
+        event_type: :block,
+        preceding_interaction: contact
+      )
+
+      expect(event).to be_persisted
+      expect(event.event_type).to eq 'block'
+      expect(event.rejector_subject.account_id).to eq target.id
+      expect(event.rejected_subject.account_id).to eq actor.id
+      expect(event.preceding_interaction_event).to eq contact
+    end
+
+    it 'does not raise and returns nil on failure' do
+      allow(Rails.logger).to receive(:warn)
+
+      result = nil
+      expect do
+        result = described_class.record_rejection(rejector: nil, rejected: actor, event_type: :block)
+      end.to_not change(ModerationRejectionEvent, :count)
+
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First step of the moderation-signal recording/evaluation foundation described in the design memo (Phase 1 / "PR 1 — Moderation Ledger foundation"). This PR adds the **append-only observation ledger only** — no risk scoring, no automatic limiting, no auto-ban, and **no hooks into core services yet** (those are Phase 2).

The guiding requirement: observed events must survive deletion/purge of the underlying Mastodon records. The ledger references its own `ModerationSubject` (never `Account` directly), and the single `Account` link is `ON DELETE SET NULL`, so nothing in the ledger is cascade-deleted by Mastodon's lifecycle.

### What's included

- **Migrations** (`db/migrate/`):
  - `moderation_subjects` — analysis subject decoupled from `Account`. `account_id` FK is `ON DELETE SET NULL`; keeps `origin`, `domain`, `first_seen_at`, `last_seen_at`, `deleted_at` (tombstone), `retention_until`.
  - `moderation_interaction_events` — observed contacts (actor→target): `mention`, `reply`, `follow`, `quote`, `reference`, `reaction`, `favourite`, `follow_import`. `status_id` / `source_record_id` / `import_batch_id` are **non-FK** pointers so deleting the source never removes the event.
  - `moderation_rejection_events` — negative signals: `follow_reject`, `remove_follower`, `mute`, `mute_notifications`, `block`, `report`, optionally linked to the preceding interaction (`ON DELETE SET NULL`).
  - Composite `(subject, occurred_at)` indexes per the design's index plan.
- **Models**: `ModerationSubject` (with `.for_account!` resolver, origin derivation, `tombstone!`), `ModerationInteractionEvent`, `ModerationRejectionEvent` (with `time_to_rejection`).
- **`Moderation::EventRecorder`** — the single entry point future hooks will call. Class-level helpers are **failure-tolerant** (log and return `nil` so recording never breaks a normal Mastodon operation); instance methods raise. Records behavioural metadata only, never raw post/DM/profile content.
- **Specs** (RSpec + Fabrication): model validations/enums, recorder behaviour incl. failure tolerance, and **ledger durability** (deleting the acting/rejecting account or the source status preserves the ledger and only nullifies `account_id`).

### Explicitly out of scope (later phases)

Scoring, follow-import ledger, evidence snapshots, retention cleanup worker, moderator UI, and any enforcement. `Account` and other core models are intentionally left untouched in this PR.

## Testing

All new specs pass (25 examples, 0 failures):

[moderation_ledger_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderation_ledger_rspec.log)

> Note: the fedibird branch's `spec/rails_helper.rb` currently calls `Sidekiq.logger = nil`, which raises on the pinned Sidekiq 7.3 (the method was removed in Sidekiq 7). This breaks the whole suite from loading (reproduced with a pre-existing spec) and is unrelated to this change. To run these specs locally I applied a temporary, **un-committed** compatibility shim to `rails_helper.rb` and reverted it before committing. A separate small fix to `rails_helper.rb` is likely warranted so CI can run.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

