### PR TITLE
Fix RSpec suite loading on Sidekiq 7 (Sidekiq.logger=)

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,7 +14,16 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 WebMock.disable_net_connect!(allow: Chewy.settings[:host])
 Sidekiq::Testing.inline!
-Sidekiq.logger = nil
+
+# Silence Sidekiq logging during the test run. Sidekiq 7 removed the
+# module-level `Sidekiq.logger=` setter in favour of the configuration blocks,
+# so guard for both to stay compatible across versions.
+if Sidekiq.respond_to?(:logger=)
+  Sidekiq.logger = nil
+else
+  Sidekiq.configure_client { |config| config.logger = nil }
+  Sidekiq.configure_server { |config| config.logger = nil }
+end
 
 Devise::Test::ControllerHelpers.module_eval do
   alias_method :original_sign_in, :sign_in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The whole RSpec suite currently fails to load on the pinned Sidekiq (`~> 7.3`, resolved 7.3.10). `spec/rails_helper.rb` calls:

```ruby
Sidekiq.logger = nil
```

Sidekiq 7 removed the module-level `Sidekiq.logger=` setter, so requiring `rails_helper` raises:

```
undefined method `logger=' for Sidekiq:Module
# ./spec/rails_helper.rb:17:in `<top (required)>'
```

Because this happens at load time, **no specs can run at all** (the error occurs outside of examples).

## Fix

Silence the Sidekiq logger the Sidekiq 7 way — via the configuration blocks — and keep the old setter path guarded for compatibility:

```ruby
if Sidekiq.respond_to?(:logger=)
  Sidekiq.logger = nil
else
  Sidekiq.configure_client { |config| config.logger = nil }
  Sidekiq.configure_server { |config| config.logger = nil }
end
```

On Sidekiq 7 `config.logger = nil` yields a default logger at `FATAL` level, preserving the original intent of keeping the test output quiet. Single-file change to `spec/rails_helper.rb`; no application code touched.

## Testing

Same command, before and after the change:

[rails_helper_fix_before_after.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frails_helper_fix_before_after.log)

- **Before:** `undefined method 'logger=' for Sidekiq:Module`, `0 examples, 0 failures, 1 error occurred outside of examples`.
- **After:** the suite loads and examples execute (e.g. `spec/models/tag_spec.rb` → `27 examples`).

Note: there are separate, pre-existing spec failures on this branch that are unrelated to loading (e.g. a Redis pipelining deprecation affecting feed population, and a tag-dedup expectation). Those are out of scope for this fix, which only unblocks the suite from loading.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

