### PR TITLE
Moderation signal core interaction hooks (Phase 2)

### DIFF
--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -16,6 +16,9 @@ class BlockService < BaseService
 
     BlockWorker.perform_async(account.id, target_account.id)
     create_notification(block) if !target_account.local? && target_account.activitypub?
+
+    Moderation::EventRecorder.record_rejection(rejector: account, rejected: target_account, event_type: :block)
+
     block
   end
 

--- a/app/services/favourite_service.rb
+++ b/app/services/favourite_service.rb
@@ -20,6 +20,14 @@ class FavouriteService < BaseService
     create_notification(favourite)
     bump_potential_friendship(account, status)
 
+    Moderation::EventRecorder.record_interaction(
+      actor: account,
+      target: status.account,
+      event_type: :favourite,
+      status: status,
+      source_record: favourite
+    )
+
     favourite
   end
 

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -45,11 +45,15 @@ class FollowService < BaseService
     # and the feeds are being merged
     mark_home_feed_as_partial! if @source_account.not_following_anyone?
 
-    if ((@target_account.locked? || @target_account.local? && @source_account.bot? && @target_account.user.setting_confirm_follow_from_bot) && !@options[:bypass_locked]) || @source_account.silenced? || @target_account.activitypub?
-      request_follow!
-    elsif @target_account.local?
-      direct_follow!
-    end
+    follow = if ((@target_account.locked? || @target_account.local? && @source_account.bot? && @target_account.user.setting_confirm_follow_from_bot) && !@options[:bypass_locked]) || @source_account.silenced? || @target_account.activitypub?
+               request_follow!
+             elsif @target_account.local?
+               direct_follow!
+             end
+
+    Moderation::EventRecorder.record_interaction(actor: @source_account, target: @target_account, event_type: :follow, source_record: follow) if follow
+
+    follow
   end
 
   private

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -6,6 +6,13 @@ class MuteService < BaseService
 
     mute = account.mute!(target_account, notifications: notifications, duration: duration)
 
+    Moderation::EventRecorder.record_rejection(
+      rejector: account,
+      rejected: target_account,
+      event_type: :mute,
+      metadata: { hide_notifications: mute.hide_notifications? }
+    )
+
     if mute.hide_notifications?
       BlockWorker.perform_async(account.id, target_account.id)
     else

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -51,6 +51,7 @@ class PostStatusService < BaseService
       process_status!
       postprocess_status!
       bump_potential_friendship!
+      record_moderation_quote!
     end
 
     redis.setex(idempotency_key, 3_600, @status.id) if idempotency_given?
@@ -64,6 +65,22 @@ class PostStatusService < BaseService
 
   def create_notification!
     NotifyService.new.call(@status.account, :scheduled_status, @status) if @options[:notify] && @status.account.local?
+  end
+
+  # Record a quote of another account's status as an interaction signal.
+  def record_moderation_quote!
+    return if @status.nil? || @status.quote_id.blank?
+
+    quoted = @status.quote
+    return if quoted.nil?
+
+    Moderation::EventRecorder.record_interaction(
+      actor: @account,
+      target: quoted.account,
+      event_type: :quote,
+      status: @status,
+      source_record: quoted
+    )
   end
 
   def status_from_uri(uri)

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -64,11 +64,29 @@ class ProcessMentionsService < BaseService
 
     status.save!
 
+    record_moderation_mentions!(mentions)
+
     # Silent mentions need to be delivered separately
     mentions.each { |mention| create_notification(mention) }
   end
 
   private
+
+  # Record explicit (non-silent) mentions as interaction signals. A mention
+  # aimed at the account being replied to is recorded as a reply.
+  def record_moderation_mentions!(mentions)
+    mentions.each do |mention|
+      event_type = @status.in_reply_to_account_id.present? && @status.in_reply_to_account_id == mention.account_id ? :reply : :mention
+
+      Moderation::EventRecorder.record_interaction(
+        actor: @status.account,
+        target: mention.account,
+        event_type: event_type,
+        status: @status,
+        source_record: mention
+      )
+    end
+  end
 
   def mention_undeliverable?(mentioned_account)
     mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus?)

--- a/app/services/reject_follow_service.rb
+++ b/app/services/reject_follow_service.rb
@@ -7,6 +7,10 @@ class RejectFollowService < BaseService
     follow_request = FollowRequest.find_by!(account: source_account, target_account: target_account)
     follow_request.reject!
     create_notification(follow_request) if !source_account.local? && source_account.activitypub?
+
+    # source_account is the requester; target_account is the account rejecting.
+    Moderation::EventRecorder.record_rejection(rejector: target_account, rejected: source_account, event_type: :follow_reject)
+
     follow_request
   end
 

--- a/app/services/remove_from_followers_service.rb
+++ b/app/services/remove_from_followers_service.rb
@@ -5,9 +5,12 @@ class RemoveFromFollowersService < BaseService
 
   def call(source_account, target_accounts)
     source_account.passive_relationships.where(account_id: target_accounts).find_each do |follow|
+      follower = follow.account
       follow.destroy
 
-      if source_account.local? && !follow.account.local? && follow.account.activitypub?
+      Moderation::EventRecorder.record_rejection(rejector: source_account, rejected: follower, event_type: :remove_follower)
+
+      if source_account.local? && !follower.local? && follower.activitypub?
         create_notification(follow)
       end
     end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -13,6 +13,7 @@ class ReportService < BaseService
     raise ActiveRecord::RecordNotFound if @target_account.suspended?
 
     create_report!
+    record_moderation_rejection!
     notify_staff!
     forward_to_origin! if !@target_account.local? && ActiveModel::Type::Boolean.new.cast(@options[:forward])
 
@@ -20,6 +21,15 @@ class ReportService < BaseService
   end
 
   private
+
+  def record_moderation_rejection!
+    Moderation::EventRecorder.record_rejection(
+      rejector: @source_account,
+      rejected: @target_account,
+      event_type: :report,
+      metadata: { status_count: @status_ids.size }
+    )
+  end
 
   def create_report!
     @report = @source_account.reports.create!(

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+# Phase 2: the core interaction/rejection services must record moderation
+# ledger events via Moderation::EventRecorder. Uses local accounts so no
+# federation/network is involved.
+RSpec.describe 'Moderation interaction hooks', type: :service do
+  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:bob)   { Fabricate(:account, username: 'bob') }
+
+  def last_interaction
+    ModerationInteractionEvent.order(:id).last
+  end
+
+  def last_rejection
+    ModerationRejectionEvent.order(:id).last
+  end
+
+  describe FollowService do
+    it 'records a follow interaction' do
+      expect { FollowService.new.call(alice, bob) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'follow'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+    end
+  end
+
+  describe FavouriteService do
+    it 'records a favourite interaction toward the status author' do
+      status = Fabricate(:status, account: bob)
+
+      expect { FavouriteService.new.call(alice, status) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'favourite'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+      expect(event.status_id).to eq status.id
+    end
+  end
+
+  describe ProcessMentionsService do
+    it 'records a mention interaction for an explicit mention' do
+      status = Fabricate(:status, account: alice, text: "@#{bob.username} hello there")
+
+      expect { ProcessMentionsService.new.call(status) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'mention'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+    end
+
+    it 'records a reply when the mention targets the replied-to account' do
+      parent = Fabricate(:status, account: bob)
+      status = Fabricate(:status, account: alice, thread: parent, text: '@bob replying')
+
+      ProcessMentionsService.new.call(status)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reply'
+      expect(event.target_subject.account_id).to eq bob.id
+    end
+  end
+
+  describe PostStatusService do
+    it 'records a quote interaction toward the quoted author' do
+      quoted = Fabricate(:status, account: bob)
+      # LinkCrawlWorker runs inline in tests and would hit the network; it runs
+      # async in production, so stub it out here to exercise the quote hook.
+      allow_any_instance_of(LinkCrawlWorker).to receive(:perform)
+
+      expect { PostStatusService.new.call(alice, text: 'nice post', quote_id: quoted.id) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'quote'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+    end
+  end
+
+  describe BlockService do
+    it 'records a block rejection' do
+      expect { BlockService.new.call(alice, bob) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = last_rejection
+      expect(event.event_type).to eq 'block'
+      expect(event.rejector_subject.account_id).to eq alice.id
+      expect(event.rejected_subject.account_id).to eq bob.id
+    end
+  end
+
+  describe MuteService do
+    it 'records a mute rejection with the notifications flag in metadata' do
+      expect { MuteService.new.call(alice, bob, notifications: true) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = last_rejection
+      expect(event.event_type).to eq 'mute'
+      expect(event.rejector_subject.account_id).to eq alice.id
+      expect(event.rejected_subject.account_id).to eq bob.id
+      expect(event.metadata['hide_notifications']).to be true
+    end
+  end
+
+  describe ReportService do
+    it 'records a report rejection' do
+      expect { ReportService.new.call(alice, bob) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = last_rejection
+      expect(event.event_type).to eq 'report'
+      expect(event.rejector_subject.account_id).to eq alice.id
+      expect(event.rejected_subject.account_id).to eq bob.id
+    end
+  end
+
+  describe RejectFollowService do
+    it 'records a follow_reject rejection from the rejecting account' do
+      bob.request_follow!(alice)
+
+      expect { RejectFollowService.new.call(bob, alice) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = last_rejection
+      expect(event.event_type).to eq 'follow_reject'
+      expect(event.rejector_subject.account_id).to eq alice.id
+      expect(event.rejected_subject.account_id).to eq bob.id
+    end
+  end
+
+  describe RemoveFromFollowersService do
+    it 'records a remove_follower rejection for each removed follower' do
+      bob.follow!(alice)
+
+      expect { RemoveFromFollowersService.new.call(alice, [bob.id]) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = last_rejection
+      expect(event.event_type).to eq 'remove_follower'
+      expect(event.rejector_subject.account_id).to eq alice.id
+      expect(event.rejected_subject.account_id).to eq bob.id
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 of the moderation-signal foundation (design memo "PR 2 — Core interaction hooks"). Builds on the Phase 1 ledger (#26) by wiring `Moderation::EventRecorder` into the canonical local services so the ledger records **live** interaction and rejection signals.

Still **recording only** — no scoring, throttling, or enforcement. All recording goes through the failure-tolerant class-level recorder, so a recording failure logs and returns `nil` and never breaks the underlying Mastodon operation.

### Interaction hooks

| Service | Event | actor → target |
| --- | --- | --- |
| `FollowService` | `follow` | follower → followee (covers follow + follow request) |
| `ProcessMentionsService` | `mention` / `reply` | author → mentioned (only explicit, non-silent mentions; `reply` when the mention targets the replied-to account) |
| `FavouriteService` | `favourite` | favouriting account → status author |
| `PostStatusService` | `quote` | quoting account → quoted author |

### Rejection hooks

| Service | Event | rejector → rejected |
| --- | --- | --- |
| `BlockService` | `block` | blocker → blocked |
| `MuteService` | `mute` | muter → muted (`hide_notifications` in metadata) |
| `ReportService` | `report` | reporter → reported (`status_count` in metadata) |
| `RejectFollowService` | `follow_reject` | account rejecting → requester |
| `RemoveFromFollowersService` | `remove_follower` | remover → removed follower (per follower) |

### Design notes

- Hooks live in the **services** (the canonical entry points), not as callbacks on core models, per the design memo's guidance to isolate recording.
- Scope is deliberately local-action coverage via services (also covers follow-import, which drives these services). Inbound ActivityPub-only paths and fedibird's emoji `reaction` / `reference` signals are intentionally deferred to a follow-up.
- No preceding-interaction linkage yet (the memo allows deferring that to async processing).

## Testing

New spec exercises every hooked service with local accounts and asserts the recorded event (10 examples, 0 failures):

[moderation_hooks_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderation_hooks_rspec.log)

Regression check: the Phase 1 moderation specs and the hooked services' existing specs still pass. Two pre-existing failures in `follow_service_spec` (locked-account follow requests) are unrelated — they come from the notification-mailer view needing a webpack test manifest (`public/packs-test/manifest.json`) that isn't compiled in this environment; they reproduce identically on the base `fedibird` branch without this change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

