### PR TITLE
Record reaction and reference interaction signals (Phase 2 follow-up)

### DIFF
--- a/app/services/emoji_reaction_service.rb
+++ b/app/services/emoji_reaction_service.rb
@@ -15,15 +15,29 @@ class EmojiReactionService < BaseService
 
     return if custom_emoji.present? && domain.present? && !EmojiReaction.where(status_id: status.id, custom_emoji_id: custom_emoji.id).present?
 
-    emoji_reaction = EmojiReaction.find_or_create_by!(account_id: account.id, status_id: status.id, name: shortcode, custom_emoji: custom_emoji)
+    newly_reacted = false
+    emoji_reaction = EmojiReaction.find_or_create_by!(account_id: account.id, status_id: status.id, name: shortcode, custom_emoji: custom_emoji) do
+      newly_reacted = true
+    end
 
     emoji_reaction.tap do |emoji_reaction|
       create_notification(emoji_reaction)
       bump_potential_friendship(account, status)
+      record_moderation_reaction!(status, emoji_reaction) if newly_reacted
     end
   end
 
-  private 
+  private
+
+  def record_moderation_reaction!(status, emoji_reaction)
+    Moderation::EventRecorder.record_interaction(
+      actor: @account,
+      target: status.account,
+      event_type: :reaction,
+      status: status,
+      source_record: emoji_reaction
+    )
+  end
 
   def create_notification(emoji_reaction)
     status = emoji_reaction.status

--- a/app/services/emoji_reaction_service.rb
+++ b/app/services/emoji_reaction_service.rb
@@ -15,9 +15,22 @@ class EmojiReactionService < BaseService
 
     return if custom_emoji.present? && domain.present? && !EmojiReaction.where(status_id: status.id, custom_emoji_id: custom_emoji.id).present?
 
+    # Look up first so a sequential retry does not re-run validations on
+    # create. Rescue RecordNotUnique for the concurrent create race — the
+    # losing racer must not be treated as a new reaction (the old
+    # find_or_create_by! block set newly_reacted=true before the insert lost).
+    attrs = { account_id: account.id, status_id: status.id, name: shortcode }
+    emoji_reaction = EmojiReaction.find_by(attrs)
     newly_reacted = false
-    emoji_reaction = EmojiReaction.find_or_create_by!(account_id: account.id, status_id: status.id, name: shortcode, custom_emoji: custom_emoji) do
-      newly_reacted = true
+
+    if emoji_reaction.nil?
+      begin
+        emoji_reaction = EmojiReaction.create!(attrs.merge(custom_emoji: custom_emoji))
+        newly_reacted = true
+      rescue ActiveRecord::RecordNotUnique
+        emoji_reaction = EmojiReaction.find_by!(attrs)
+        newly_reacted = false
+      end
     end
 
     emoji_reaction.tap do |emoji_reaction|

--- a/app/services/process_status_reference_service.rb
+++ b/app/services/process_status_reference_service.rb
@@ -47,6 +47,8 @@ class ProcessStatusReferenceService
       StatusReference.create(status_id: status_id, target_status_id: target_status.id)
     end
 
+    record_moderation_references!(references)
+
     references.group_by{|reference| reference.target_status.account}.each do |account, grouped_references|
       create_notification(grouped_references.sort_by(&:id).first) if account.local?
     end
@@ -54,6 +56,29 @@ class ProcessStatusReferenceService
 
   def create_notification(reference)
     NotifyService.new.call(reference.target_status.account, :status_reference, reference)
+  end
+
+  # Record references as interaction signals. The quoted status is skipped here
+  # because it is recorded as a `quote` interaction by PostStatusService, so it
+  # would otherwise be double-counted.
+  def record_moderation_references!(references)
+    quote_target_id = @status.quote_id
+
+    references.each do |reference|
+      next unless reference.persisted?
+      next if quote_target_id.present? && reference.target_status_id == quote_target_id
+
+      target_status = reference.target_status
+      next if target_status.nil?
+
+      Moderation::EventRecorder.record_interaction(
+        actor: @status.account,
+        target: target_status.account,
+        event_type: :reference,
+        status: @status,
+        source_record: reference
+      )
+    end
   end
 
   def parse_local_urls(text)

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -159,6 +159,16 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
 
       expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
     end
+
+    it 'does not record a duplicate event when create loses a uniqueness race' do
+      status = Fabricate(:status, account: bob)
+      existing = EmojiReaction.create!(account: alice, status: status, name: '👍')
+
+      allow(EmojiReaction).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'index_emoji_reactions_on_account_id_and_status_id')
+
+      expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
+      expect(EmojiReaction.find_by(account: alice, status: status, name: '👍')).to eq existing
+    end
   end
 
   describe ProcessStatusReferenceService do

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -161,13 +161,25 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
     end
 
     it 'does not record a duplicate event when create loses a uniqueness race' do
-      status = Fabricate(:status, account: bob)
+      status   = Fabricate(:status, account: bob)
       existing = EmojiReaction.create!(account: alice, status: status, name: '👍')
+      attrs    = { account_id: alice.id, status_id: status.id, name: '👍' }
 
-      allow(EmojiReaction).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'index_emoji_reactions_on_account_id_and_status_id')
+      # Genuinely drive the race-loser path: the initial lookup misses, the
+      # concurrent insert loses (RecordNotUnique), and the re-read returns the
+      # winner. The loser must not be counted as a new reaction.
+      allow(EmojiReaction).to receive(:find_by).and_call_original
+      allow(EmojiReaction).to receive(:find_by).with(attrs).and_return(nil)
+      allow(EmojiReaction).to receive(:find_by!).and_call_original
+      allow(EmojiReaction).to receive(:find_by!).with(attrs).and_return(existing)
+      allow(EmojiReaction).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'duplicate key value violates unique constraint "index_emoji_reactions_on_account_id_and_status_id"')
 
       expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
-      expect(EmojiReaction.find_by(account: alice, status: status, name: '👍')).to eq existing
+
+      # Prove the rescue path actually executed (create! attempted, re-read used).
+      expect(EmojiReaction).to have_received(:create!)
+      expect(EmojiReaction).to have_received(:find_by!).with(attrs)
+      expect(EmojiReaction.where(attrs).count).to eq 1
     end
   end
 

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -139,4 +139,46 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
       expect(event.rejected_subject.account_id).to eq bob.id
     end
   end
+
+  describe EmojiReactionService do
+    it 'records a reaction interaction toward the status author' do
+      status = Fabricate(:status, account: bob)
+
+      expect { EmojiReactionService.new.call(alice, status, '👍') }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reaction'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+      expect(event.status_id).to eq status.id
+    end
+
+    it 'does not record a duplicate reaction when the same emoji already exists' do
+      status = Fabricate(:status, account: bob)
+      EmojiReactionService.new.call(alice, status, '👍')
+
+      expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
+
+  describe ProcessStatusReferenceService do
+    it 'records a reference interaction toward the referenced author' do
+      referenced = Fabricate(:status, account: bob)
+      status = Fabricate(:status, account: alice)
+
+      expect { ProcessStatusReferenceService.new.call(status, status_reference_ids: [referenced.id]) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reference'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+    end
+
+    it 'does not record a reference for the quoted status (recorded as a quote instead)' do
+      quoted = Fabricate(:status, account: bob)
+      status = Fabricate(:status, account: alice, quote_id: quoted.id)
+
+      expect { ProcessStatusReferenceService.new.call(status, status_reference_ids: [quoted.id]) }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the interaction-signal coverage started in Phase 2 (#28) by wiring the two remaining fedibird-specific interaction types into the moderation ledger. Still **recording only** — no scoring or enforcement — and all recording goes through the failure-tolerant `Moderation::EventRecorder`, so a recording error never breaks the underlying operation.

| Service | Event | actor → target | Notes |
| --- | --- | --- | --- |
| `EmojiReactionService` | `reaction` | reacting account → reacted status's author | Recorded only when the reaction is **newly created** (the block form of `find_or_create_by!` sets a flag), so repeat/idempotent calls don't double-record. |
| `ProcessStatusReferenceService` | `reference` | referencing author → referenced author | The **quoted** status is skipped here (its `target_status_id == status.quote_id`) because `PostStatusService` already records it as a `quote`, avoiding double-counting. |

With this, all interaction `event_type`s except `follow_import` are now populated (`follow_import` belongs to the Follow Import Ledger, PR 4).

## Testing

Extends `spec/services/moderation/interaction_hooks_spec.rb`; full file is green (14 examples, 0 failures):

[moderation_reaction_reference_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderation_reaction_reference_rspec.log)

New cases specifically cover:
- a reaction records a `reaction` event toward the status author;
- a repeated identical reaction records nothing;
- a reference records a `reference` event toward the referenced author;
- a reference to the quoted status records nothing (it's a `quote`).

Regression check: the Phase 1 moderation specs still pass. (The two touched services have no dedicated spec files in the repo; behaviour is covered by the hook specs above.)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

