### PR TITLE
Follow Import Ledger (PR 4)

### DIFF
--- a/app/models/follow_import_batch.rb
+++ b/app/models/follow_import_batch.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: follow_import_batches
+#
+#  id                      :bigint(8)        not null, primary key
+#  subject_id              :bigint(8)        not null
+#  import_id               :bigint(8)
+#  imported_at             :datetime         not null
+#  mode                    :integer          default("unknown"), not null
+#  target_count            :integer          default(0), not null
+#  resolved_target_count   :integer          default(0), not null
+#  unresolved_target_count :integer          default(0), not null
+#  account_age_seconds     :bigint(8)
+#  migration_evidence      :integer          default("none"), not null
+#  metadata                :jsonb            not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# A single follow-import event, recorded before the follows are executed.
+#
+# Follow import is an especially valuable observation point because the entire
+# target set is presented to the server up front. The batch stores the summary
+# (counts, mode, account age, migration evidence) and its `targets` capture the
+# individual contacted accounts.
+class FollowImportBatch < ApplicationRecord
+  self.table_name = 'follow_import_batches'
+
+  enum mode: { unknown: 0, merge: 1, overwrite: 2 }, _suffix: :mode
+  enum migration_evidence: { none: 0, weak: 1, strong: 2 }, _prefix: :migration
+
+  belongs_to :subject, class_name: 'ModerationSubject'
+
+  has_many :targets, class_name: 'FollowImportTarget', foreign_key: :batch_id, inverse_of: :batch, dependent: :destroy
+
+  validates :imported_at, presence: true
+  validates :target_count, :resolved_target_count, :unresolved_target_count, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/models/follow_import_batch.rb
+++ b/app/models/follow_import_batch.rb
@@ -36,4 +36,5 @@ class FollowImportBatch < ApplicationRecord
 
   validates :imported_at, presence: true
   validates :target_count, :resolved_target_count, :unresolved_target_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :import_id, uniqueness: { allow_nil: true }
 end

--- a/app/models/follow_import_target.rb
+++ b/app/models/follow_import_target.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: follow_import_targets
+#
+#  id                       :bigint(8)        not null, primary key
+#  batch_id                 :bigint(8)        not null
+#  target_subject_id        :bigint(8)
+#  target_key_hash          :string
+#  position                 :integer
+#  prior_relationship_state :jsonb
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# A single target within a follow-import batch. `target_subject` is set when the
+# imported account address resolves to a known account at import time; otherwise
+# `target_key_hash` holds a pseudonymous stable key for the unresolved address.
+class FollowImportTarget < ApplicationRecord
+  self.table_name = 'follow_import_targets'
+
+  belongs_to :batch, class_name: 'FollowImportBatch', inverse_of: :targets
+  belongs_to :target_subject, class_name: 'ModerationSubject', optional: true
+
+  validates :target_subject_id, presence: true, unless: -> { target_key_hash.present? }
+
+  def resolved?
+    target_subject_id.present?
+  end
+end

--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -29,7 +29,16 @@ class ImportService < BaseService
 
   def import_follows!
     parse_import_data!(['Account address'])
+    record_follow_import_batch!
     import_relationships!('follow', 'unfollow', @account.following.map { |account| { acct: account.acct }}, ROWS_PROCESSING_LIMIT, show_reblogs: { header: 'Show boosts', default: true }, notify: { header: 'Notify on new posts', default: false }, languages: { header: 'Languages', default: nil }, delivery: { header: 'Delivery to home', default: true })
+  end
+
+  # Record the follow-import target set into the moderation ledger before the
+  # follows are executed (the whole set is known here after CSV parsing).
+  def record_follow_import_batch!
+    accts = @data.take(ROWS_PROCESSING_LIMIT).filter_map { |row| row['Account address']&.strip.presence }
+
+    Moderation::FollowImportRecorder.record_batch(account: @account, accts: accts, import: @import, mode: @import.mode)
   end
 
   def import_account_subscribings!

--- a/app/services/moderation/follow_import_recorder.rb
+++ b/app/services/moderation/follow_import_recorder.rb
@@ -22,6 +22,13 @@ module Moderation
 
     def record_batch(account:, accts:, import: nil, mode: nil, imported_at: nil)
       imported_at ||= Time.now.utc
+
+      # Sidekiq retries the same Import row; import_id is the idempotency key.
+      if import&.id
+        existing = FollowImportBatch.find_by(import_id: import.id)
+        return existing if existing
+      end
+
       subject = ModerationSubject.for_account!(account, observed_at: imported_at)
 
       resolved_count   = 0
@@ -70,6 +77,10 @@ module Moderation
       end
 
       batch
+    rescue ActiveRecord::RecordNotUnique
+      raise if import&.id.blank?
+
+      FollowImportBatch.find_by!(import_id: import.id)
     end
 
     private

--- a/app/services/moderation/follow_import_recorder.rb
+++ b/app/services/moderation/follow_import_recorder.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Records a follow-import batch and its target set into the moderation ledger.
+#
+# Follow import is a high-value observation point: the whole target set is
+# presented to the server before any follow is executed, so it is recorded up
+# front. Resolvable addresses are linked to a ModerationSubject; unresolved ones
+# keep a pseudonymous target_key_hash so they can still be correlated later.
+#
+# Recording only — no scoring or enforcement. The class-level entry point is
+# failure-tolerant so a recording error never breaks the import.
+module Moderation
+  class FollowImportRecorder
+    class << self
+      def record_batch(**options)
+        new.record_batch(**options)
+      rescue StandardError => e
+        Rails.logger.warn("[Moderation::FollowImportRecorder] failed to record follow import batch: #{e.class}: #{e.message}")
+        nil
+      end
+    end
+
+    def record_batch(account:, accts:, import: nil, mode: nil, imported_at: nil)
+      imported_at ||= Time.now.utc
+      subject = ModerationSubject.for_account!(account, observed_at: imported_at)
+
+      resolved_count   = 0
+      unresolved_count = 0
+      target_rows      = []
+
+      accts.each_with_index do |raw_acct, index|
+        acct = raw_acct.to_s.strip
+        next if acct.blank?
+
+        target_account = resolve_account(acct)
+
+        if target_account
+          resolved_count += 1
+          target_subject = ModerationSubject.for_account!(target_account, observed_at: imported_at)
+          target_rows << {
+            target_subject_id: target_subject.id,
+            position: index,
+            prior_relationship_state: { following: account.following?(target_account) },
+          }
+        else
+          unresolved_count += 1
+          target_rows << {
+            target_key_hash: hash_acct(acct),
+            position: index,
+          }
+        end
+      end
+
+      batch = nil
+
+      ApplicationRecord.transaction do
+        batch = FollowImportBatch.create!(
+          subject: subject,
+          import_id: import&.id,
+          imported_at: imported_at,
+          mode: normalize_mode(mode),
+          target_count: target_rows.size,
+          resolved_target_count: resolved_count,
+          unresolved_target_count: unresolved_count,
+          account_age_seconds: account_age_seconds(account, imported_at),
+          migration_evidence: migration_evidence(account)
+        )
+
+        target_rows.each { |attrs| batch.targets.create!(attrs) }
+      end
+
+      batch
+    end
+
+    private
+
+    # Resolve an account address to a known account without hitting the network.
+    def resolve_account(acct)
+      username, domain = acct.split('@', 2)
+      return if username.blank?
+
+      domain = nil if domain.blank? || TagManager.instance.local_domain?(domain)
+
+      if domain.nil?
+        Account.find_local(username)
+      else
+        Account.find_remote(username, domain)
+      end
+    rescue StandardError
+      nil
+    end
+
+    def hash_acct(acct)
+      username, domain = acct.split('@', 2)
+      domain = Rails.configuration.x.local_domain if domain.blank?
+      Digest::SHA256.hexdigest("#{username.to_s.downcase}@#{domain.to_s.downcase}")
+    end
+
+    def normalize_mode(mode)
+      case mode&.to_sym
+      when :merge then :merge
+      when :overwrite then :overwrite
+      else :unknown
+      end
+    end
+
+    def account_age_seconds(account, at)
+      return if account.created_at.nil?
+
+      (at - account.created_at).to_i
+    end
+
+    def migration_evidence(account)
+      account.aliases.exists? ? :weak : :none
+    rescue StandardError
+      :none
+    end
+  end
+end

--- a/db/migrate/20260909020001_create_follow_import_batches.rb
+++ b/db/migrate/20260909020001_create_follow_import_batches.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CreateFollowImportBatches < ActiveRecord::Migration[6.1]
+  def change
+    create_table :follow_import_batches do |t|
+      t.references :subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      # fedibird destroys the Import row after processing, so this is a plain
+      # (non-FK) short-term correlation id, not a foreign key.
+      t.bigint :import_id
+
+      t.datetime :imported_at, null: false
+      t.integer :mode, null: false, default: 0
+      t.integer :target_count, null: false, default: 0
+      t.integer :resolved_target_count, null: false, default: 0
+      t.integer :unresolved_target_count, null: false, default: 0
+      t.bigint :account_age_seconds
+      t.integer :migration_evidence, null: false, default: 0
+      t.jsonb :metadata, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :follow_import_batches, [:subject_id, :imported_at], name: :index_follow_import_batches_on_subject_and_imported_at
+  end
+end

--- a/db/migrate/20260909020002_create_follow_import_targets.rb
+++ b/db/migrate/20260909020002_create_follow_import_targets.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateFollowImportTargets < ActiveRecord::Migration[6.1]
+  def change
+    create_table :follow_import_targets do |t|
+      t.references :batch, null: false, foreign_key: { to_table: :follow_import_batches, on_delete: :cascade }, index: false
+
+      # Nullable: an imported target may not resolve to a known account at
+      # import time. ON DELETE SET NULL keeps the target row if the subject is
+      # later removed.
+      t.references :target_subject, foreign_key: { to_table: :moderation_subjects, on_delete: :nullify }, index: false
+
+      t.string :target_key_hash
+      t.integer :position
+      t.jsonb :prior_relationship_state
+
+      t.timestamps
+    end
+
+    add_index :follow_import_targets, [:batch_id, :target_subject_id], name: :index_follow_import_targets_on_batch_and_target
+    add_index :follow_import_targets, :target_subject_id, where: 'target_subject_id IS NOT NULL', name: :index_follow_import_targets_on_target_subject
+    add_index :follow_import_targets, :target_key_hash, where: 'target_key_hash IS NOT NULL', name: :index_follow_import_targets_on_target_key_hash
+  end
+end

--- a/db/migrate/20260909120001_add_unique_import_id_to_follow_import_batches.rb
+++ b/db/migrate/20260909120001_add_unique_import_id_to_follow_import_batches.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUniqueImportIdToFollowImportBatches < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_index :follow_import_batches, :import_id,
+                unique: true,
+                where: 'import_id IS NOT NULL',
+                name: :index_follow_import_batches_on_import_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2026_09_09_120001) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -777,8 +776,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   end
 
   create_table "moderation_interaction_events", force: :cascade do |t|
-    t.bigint "actor_subject_id"
-    t.bigint "target_subject_id"
+    t.bigint "actor_subject_id", null: false
+    t.bigint "target_subject_id", null: false
     t.integer "event_type", null: false
     t.bigint "status_id"
     t.string "source_record_type"
@@ -796,8 +795,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   end
 
   create_table "moderation_rejection_events", force: :cascade do |t|
-    t.bigint "rejector_subject_id"
-    t.bigint "rejected_subject_id"
+    t.bigint "rejector_subject_id", null: false
+    t.bigint "rejected_subject_id", null: false
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
     t.datetime "occurred_at", null: false
@@ -1183,10 +1182,10 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.bigint "generator_id"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20210710", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL))"
-    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["account_id", "id"], name: "index_statuses_private_searchable", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL) AND (reblog_of_id IS NULL) AND (searchability = ANY (ARRAY[0, 1, 2])))"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
+    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["quote_id"], name: "index_statuses_on_quote_id"
@@ -1208,15 +1207,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "tag_account_mutes", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "account_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
-    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
-  end
-
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
@@ -1230,6 +1220,15 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.float "max_score"
     t.datetime "max_score_at"
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
+  end
+
+  create_table "tag_account_mutes", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
+    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
   end
 
   create_table "tombstones", force: :cascade do |t|
@@ -1435,11 +1434,11 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :nullify
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :nullify
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :cascade
   add_foreign_key "moderation_subjects", "accounts", on_delete: :nullify
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
@@ -1488,53 +1487,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users"
 
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT account_id,
-      sum(rank) AS rank,
-      array_agg(reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM (((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM (((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
-    GROUP BY account_id
-    ORDER BY (sum(rank)) DESC;
-  SQL
-  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
-
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (
            SELECT accounts.domain,
@@ -1558,5 +1510,52 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
        LEFT JOIN domain_counts ON (((domain_counts.domain)::text = (domain_allows.domain)::text)));
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
+
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
+      SELECT t0.account_id,
+      sum(t0.rank) AS rank,
+      array_agg(t0.reason) AS reason
+     FROM ( SELECT account_summaries.account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM (((follows
+               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT account_summaries.account_id,
+              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM (((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
+    GROUP BY t0.account_id
+    ORDER BY (sum(t0.rank)) DESC;
+  SQL
+  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_08_230003) do
+ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -547,6 +547,35 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
     t.string "url"
     t.index ["account_id"], name: "index_featured_tags_on_account_id"
     t.index ["tag_id"], name: "index_featured_tags_on_tag_id"
+  end
+
+  create_table "follow_import_batches", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.bigint "import_id"
+    t.datetime "imported_at", null: false
+    t.integer "mode", default: 0, null: false
+    t.integer "target_count", default: 0, null: false
+    t.integer "resolved_target_count", default: 0, null: false
+    t.integer "unresolved_target_count", default: 0, null: false
+    t.bigint "account_age_seconds"
+    t.integer "migration_evidence", default: 0, null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject_id", "imported_at"], name: "index_follow_import_batches_on_subject_and_imported_at"
+  end
+
+  create_table "follow_import_targets", force: :cascade do |t|
+    t.bigint "batch_id", null: false
+    t.bigint "target_subject_id"
+    t.string "target_key_hash"
+    t.integer "position"
+    t.jsonb "prior_relationship_state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["batch_id", "target_subject_id"], name: "index_follow_import_targets_on_batch_and_target"
+    t.index ["target_key_hash"], name: "index_follow_import_targets_on_target_key_hash", where: "(target_key_hash IS NOT NULL)"
+    t.index ["target_subject_id"], name: "index_follow_import_targets_on_target_subject", where: "(target_subject_id IS NOT NULL)"
   end
 
   create_table "follow_recommendation_suppressions", force: :cascade do |t|
@@ -1377,6 +1406,9 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
   add_foreign_key "featured_tags", "accounts", on_delete: :cascade
   add_foreign_key "featured_tags", "tags", on_delete: :cascade
+  add_foreign_key "follow_import_batches", "moderation_subjects", column: "subject_id", on_delete: :cascade
+  add_foreign_key "follow_import_targets", "follow_import_batches", column: "batch_id", on_delete: :cascade
+  add_foreign_key "follow_import_targets", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "follow_recommendation_suppressions", "accounts", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", column: "target_account_id", name: "fk_9291ec025d", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", name: "fk_76d644b0e7", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_09_020002) do
+ActiveRecord::Schema.define(version: 2026_09_09_120001) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -562,6 +563,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["import_id"], name: "index_follow_import_batches_on_import_id", unique: true, where: "(import_id IS NOT NULL)"
     t.index ["subject_id", "imported_at"], name: "index_follow_import_batches_on_subject_and_imported_at"
   end
 
@@ -775,8 +777,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   end
 
   create_table "moderation_interaction_events", force: :cascade do |t|
-    t.bigint "actor_subject_id", null: false
-    t.bigint "target_subject_id", null: false
+    t.bigint "actor_subject_id"
+    t.bigint "target_subject_id"
     t.integer "event_type", null: false
     t.bigint "status_id"
     t.string "source_record_type"
@@ -794,8 +796,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   end
 
   create_table "moderation_rejection_events", force: :cascade do |t|
-    t.bigint "rejector_subject_id", null: false
-    t.bigint "rejected_subject_id", null: false
+    t.bigint "rejector_subject_id"
+    t.bigint "rejected_subject_id"
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
     t.datetime "occurred_at", null: false
@@ -1181,10 +1183,10 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.bigint "generator_id"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20210710", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL))"
+    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["account_id", "id"], name: "index_statuses_private_searchable", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL) AND (reblog_of_id IS NULL) AND (searchability = ANY (ARRAY[0, 1, 2])))"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
-    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["quote_id"], name: "index_statuses_on_quote_id"
@@ -1206,6 +1208,15 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tag_account_mutes", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
+    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
@@ -1219,15 +1230,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.float "max_score"
     t.datetime "max_score_at"
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
-  end
-
-  create_table "tag_account_mutes", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "account_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
-    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
   end
 
   create_table "tombstones", force: :cascade do |t|
@@ -1433,11 +1435,11 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :nullify
   add_foreign_key "moderation_subjects", "accounts", on_delete: :nullify
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
@@ -1486,6 +1488,53 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users"
 
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
+      SELECT account_id,
+      sum(rank) AS rank,
+      array_agg(reason) AS reason
+     FROM ( SELECT account_summaries.account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM (((follows
+               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT account_summaries.account_id,
+              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM (((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
+    GROUP BY account_id
+    ORDER BY (sum(rank)) DESC;
+  SQL
+  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
+
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (
            SELECT accounts.domain,
@@ -1509,52 +1558,5 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
        LEFT JOIN domain_counts ON (((domain_counts.domain)::text = (domain_allows.domain)::text)));
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
-
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT t0.account_id,
-      sum(t0.rank) AS rank,
-      array_agg(t0.reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM (((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM (((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
-    GROUP BY t0.account_id
-    ORDER BY (sum(t0.rank)) DESC;
-  SQL
-  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
 
 end

--- a/spec/services/moderation/follow_import_hook_spec.rb
+++ b/spec/services/moderation/follow_import_hook_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+# Integration: a real following import records a FollowImportBatch (and its
+# targets) before the follows are executed.
+RSpec.describe 'Follow import moderation hook', type: :service do
+  include RoutingHelper
+
+  let!(:account) { Fabricate(:account, locked: false) }
+  let!(:bob)     { Fabricate(:account, username: 'bob', locked: false) }
+  let!(:eve)     { Fabricate(:account, username: 'eve', domain: 'example.com', locked: false, protocol: :activitypub, inbox_url: 'https://example.com/inbox') }
+  let(:csv)      { attachment_fixture('mute-imports.txt') }
+  let(:import)   { Import.create(account: account, type: 'following', data: csv) }
+
+  before { stub_request(:post, 'https://example.com/inbox').to_return(status: 200) }
+
+  it 'records a follow import batch with resolved targets' do
+    expect { ImportService.new.call(import) }.to change(FollowImportBatch, :count).by(1)
+
+    batch = FollowImportBatch.last
+    expect(batch.subject.account_id).to eq account.id
+    expect(batch.target_count).to eq 2
+    expect(batch.resolved_target_count).to eq 2
+    expect(batch.targets.count).to eq 2
+    expect(batch.targets.filter_map { |t| t.target_subject&.account_id }).to match_array([bob.id, eve.id])
+  end
+end

--- a/spec/services/moderation/follow_import_hook_spec.rb
+++ b/spec/services/moderation/follow_import_hook_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe 'Follow import moderation hook', type: :service do
     expect(batch.targets.count).to eq 2
     expect(batch.targets.filter_map { |t| t.target_subject&.account_id }).to match_array([bob.id, eve.id])
   end
+
+  it 'does not create a second logical batch when the same import job is retried' do
+    expect { ImportService.new.call(import) }.to change(FollowImportBatch, :count).by(1)
+    expect { ImportService.new.call(import) }.to_not change(FollowImportBatch, :count)
+    expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+  end
 end

--- a/spec/services/moderation/follow_import_recorder_spec.rb
+++ b/spec/services/moderation/follow_import_recorder_spec.rb
@@ -60,11 +60,33 @@ RSpec.describe Moderation::FollowImportRecorder, type: :service do
       import = instance_double(Import, id: 880_001)
 
       first = described_class.record_batch(account: account, accts: ['bob', 'eve@example.com'], import: import, mode: :merge)
-      second = described_class.record_batch(account: account, accts: ['bob', 'eve@example.com'], import: import, mode: :merge)
+      second = described_class.record_batch(account: account, accts: ['ghost@unknown.example'], import: import, mode: :overwrite)
 
       expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
       expect(second.id).to eq first.id
+      expect(second.mode).to eq 'merge'
       expect(FollowImportTarget.where(batch_id: first.id).count).to eq 2
+    end
+
+    it 'rejects a second row with the same import_id at the database' do
+      import = instance_double(Import, id: 880_003)
+      first = described_class.record_batch(account: account, accts: ['bob'], import: import)
+
+      expect {
+        FollowImportBatch.insert!({
+          subject_id: first.subject_id,
+          import_id: import.id,
+          imported_at: Time.now.utc,
+          mode: 0,
+          target_count: 0,
+          resolved_target_count: 0,
+          unresolved_target_count: 0,
+          migration_evidence: 0,
+          metadata: {},
+          created_at: Time.now.utc,
+          updated_at: Time.now.utc,
+        })
+      }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'returns the existing batch when a uniqueness race loses the insert' do
@@ -72,6 +94,7 @@ RSpec.describe Moderation::FollowImportRecorder, type: :service do
       first = described_class.record_batch(account: account, accts: ['bob'], import: import)
       lookups = 0
 
+      # Simulate the race window: the pre-insert lookup misses the committed row.
       allow(FollowImportBatch).to receive(:find_by).and_wrap_original do |method, *args|
         attrs = args.first
         if attrs.is_a?(Hash) && attrs[:import_id] == import.id
@@ -81,10 +104,18 @@ RSpec.describe Moderation::FollowImportRecorder, type: :service do
           method.call(*args)
         end
       end
-      allow(FollowImportBatch).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'index_follow_import_batches_on_import_id')
+
+      # Sequential specs see the committed row in the uniqueness validator; a
+      # real race under READ COMMITTED would not. Skip validations so the
+      # INSERT hits the unique index on import_id.
+      allow_any_instance_of(FollowImportBatch).to receive(:valid?).and_return(true)
+      expect(FollowImportBatch).to receive(:create!).and_call_original
 
       raced = described_class.new.record_batch(account: account, accts: ['bob'], import: import)
+
       expect(raced.id).to eq first.id
+      expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+      expect(lookups).to be >= 1
     end
   end
 end

--- a/spec/services/moderation/follow_import_recorder_spec.rb
+++ b/spec/services/moderation/follow_import_recorder_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::FollowImportRecorder, type: :service do
+  let(:account) { Fabricate(:account, username: 'importer') }
+  let!(:bob)    { Fabricate(:account, username: 'bob') }
+  let!(:eve)    { Fabricate(:account, username: 'eve', domain: 'example.com') }
+
+  describe '.record_batch' do
+    it 'records a batch with resolved and unresolved targets' do
+      accts = ['bob', 'eve@example.com', 'ghost@unknown.example']
+
+      batch = nil
+      expect { batch = described_class.record_batch(account: account, accts: accts, mode: :merge) }
+        .to change(FollowImportBatch, :count).by(1)
+        .and change(FollowImportTarget, :count).by(3)
+
+      expect(batch.subject.account_id).to eq account.id
+      expect(batch.mode).to eq 'merge'
+      expect(batch.target_count).to eq 3
+      expect(batch.resolved_target_count).to eq 2
+      expect(batch.unresolved_target_count).to eq 1
+      expect(batch.account_age_seconds).to be_present
+
+      resolved = batch.targets.where.not(target_subject_id: nil)
+      expect(resolved.map { |t| t.target_subject.account_id }).to match_array([bob.id, eve.id])
+
+      unresolved = batch.targets.find_by(target_subject_id: nil)
+      expect(unresolved.target_key_hash).to eq Digest::SHA256.hexdigest('ghost@unknown.example')
+      expect(unresolved.position).to eq 2
+    end
+
+    it 'records prior following relationship state for resolved targets' do
+      account.follow!(bob)
+
+      batch = described_class.record_batch(account: account, accts: ['bob'], mode: :overwrite)
+
+      expect(batch.mode).to eq 'overwrite'
+      expect(batch.targets.first.prior_relationship_state).to eq('following' => true)
+    end
+
+    it 'defaults mode to unknown' do
+      batch = described_class.record_batch(account: account, accts: ['bob'])
+      expect(batch.mode).to eq 'unknown'
+    end
+
+    it 'marks migration evidence weak when the account has aliases' do
+      # Insert directly to avoid AccountAlias#set_uri resolving over the network.
+      AccountAlias.insert!({ account_id: account.id, acct: 'old@example.com', uri: 'https://example.com/users/old', created_at: Time.now.utc, updated_at: Time.now.utc })
+
+      batch = described_class.record_batch(account: account, accts: [])
+      expect(batch.migration_evidence).to eq 'weak'
+    end
+
+    it 'is failure-tolerant and returns nil on error' do
+      allow(Rails.logger).to receive(:warn)
+      expect(described_class.record_batch(account: nil, accts: ['bob'])).to be_nil
+    end
+  end
+end

--- a/spec/services/moderation/follow_import_recorder_spec.rb
+++ b/spec/services/moderation/follow_import_recorder_spec.rb
@@ -55,5 +55,36 @@ RSpec.describe Moderation::FollowImportRecorder, type: :service do
       allow(Rails.logger).to receive(:warn)
       expect(described_class.record_batch(account: nil, accts: ['bob'])).to be_nil
     end
+
+    it 'does not create a second batch when the same import is retried' do
+      import = instance_double(Import, id: 880_001)
+
+      first = described_class.record_batch(account: account, accts: ['bob', 'eve@example.com'], import: import, mode: :merge)
+      second = described_class.record_batch(account: account, accts: ['bob', 'eve@example.com'], import: import, mode: :merge)
+
+      expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+      expect(second.id).to eq first.id
+      expect(FollowImportTarget.where(batch_id: first.id).count).to eq 2
+    end
+
+    it 'returns the existing batch when a uniqueness race loses the insert' do
+      import = instance_double(Import, id: 880_002)
+      first = described_class.record_batch(account: account, accts: ['bob'], import: import)
+      lookups = 0
+
+      allow(FollowImportBatch).to receive(:find_by).and_wrap_original do |method, *args|
+        attrs = args.first
+        if attrs.is_a?(Hash) && attrs[:import_id] == import.id
+          lookups += 1
+          lookups == 1 ? nil : method.call(*args)
+        else
+          method.call(*args)
+        end
+      end
+      allow(FollowImportBatch).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'index_follow_import_batches_on_import_id')
+
+      raced = described_class.new.record_batch(account: account, accts: ['bob'], import: import)
+      expect(raced.id).to eq first.id
+    end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 4 of the moderation-signal foundation (design memo §6 / Phase 3 "Follow Import Ledger"). Follow import is a high-value observation point because **the entire target set is presented to the server before any follow runs**, so this records that set up front. Recording only — no scoring or enforcement.

### Schema

- **`follow_import_batches`** — one row per follow import: `subject_id` (→ `moderation_subjects`, `ON DELETE CASCADE`), non-FK `import_id` correlation (fedibird destroys the `Import` after processing), `imported_at`, `mode` (`unknown`/`merge`/`overwrite`), `target_count` / `resolved_target_count` / `unresolved_target_count`, `account_age_seconds`, `migration_evidence` (`none`/`weak`/`strong`), `metadata`.
- **`follow_import_targets`** — one row per imported address: `batch_id` (`ON DELETE CASCADE`), nullable `target_subject_id` (→ `moderation_subjects`, `ON DELETE SET NULL`), `target_key_hash` (pseudonymous key for addresses that don't resolve at import time), `position` (CSV order), `prior_relationship_state` (jsonb).

### Behaviour

- `Moderation::FollowImportRecorder` resolves each address **without hitting the network** (`find_local` / `find_remote` only). Resolvable addresses are linked to a `ModerationSubject` and record `{ following: <already following?> }` as prior state; unresolved ones store a SHA-256 `target_key_hash`. It also records mode, `account_age_seconds`, and a lightweight `migration_evidence` (`weak` when the account has aliases, else `none`).
- `ImportService#import_follows!` calls the recorder right after CSV parsing and before enqueuing the follow workers.
- The class-level recorder is failure-tolerant: a recording error is logged and returns `nil`, never breaking the import.

### Scope / deferrals

- Only `following` imports are recorded (the design's focus). Other import types and the follow-import → campaign aggregation are future work.
- Target rows are created per-row for correctness; bulk-insert optimisation for very large imports is a noted follow-up (this already runs inside the import Sidekiq job).

## Testing

New specs (6 examples, 0 failures):

[follow_import_ledger_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffollow_import_ledger_rspec.log)

- Unit (`Moderation::FollowImportRecorder`): resolved + unresolved counts, target hashing, prior following state, mode defaulting, migration evidence, and failure tolerance.
- Integration (`ImportService`): a real `following` import records a batch with both targets resolved.

Regression: `import_service_spec.rb` has the **same 12 pre-existing failures** with and without this change (verified against the base `fedibird` `import_service.rb`); they stem from environment issues (feed/redis-pipelining and notification-mailer webpack manifest) unrelated to this hook, which records the batch before any of that runs. Phase 1 ledger specs still pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

