### PR TITLE
Deletion/purge durability and retention cleanup (PR 3)

### DIFF
--- a/app/lib/moderation/retention_cleanup.rb
+++ b/app/lib/moderation/retention_cleanup.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# SQL-only predicates for ledger retention cleanup.
+#
+# Kept out of Ruby on purpose: loading retained subject ids and interpolating
+# them into `NOT IN (...)` does not scale, and `WHERE column NOT IN (...)`
+# does not match NULL under SQL three-valued logic. Counterpart FKs are
+# ON DELETE SET NULL, so a leftover event may have one or both participants
+# already nullified.
+#
+# An event is deletable when it has no retained participant — each side is
+# either NULL or an expired subject. NOT EXISTS treats a NULL FK as "this
+# side is not a retained participant", which is the desired eligibility rule.
+module Moderation
+  module RetentionCleanup
+    module_function
+
+    def events_without_retained_participant(klass, left_column, right_column, now)
+      table = klass.arel_table
+      klass.where(
+        <<~SQL.squish,
+          NOT EXISTS (
+            SELECT 1
+              FROM moderation_subjects
+             WHERE moderation_subjects.id IN (#{table[left_column].to_sql}, #{table[right_column].to_sql})
+               AND (moderation_subjects.retention_until IS NULL OR moderation_subjects.retention_until > ?)
+          )
+        SQL
+        now
+      )
+    end
+
+    # Expired subjects that no remaining event still needs as shared evidence.
+    # A subject is held past +retention_until+ while it appears on an event
+    # that still has a retained counterpart.
+    def expired_subjects_without_retained_evidence(now)
+      ModerationSubject.expired(now).where(
+        <<~SQL.squish,
+          NOT EXISTS (
+            SELECT 1
+              FROM moderation_interaction_events e
+             WHERE (e.actor_subject_id = moderation_subjects.id OR e.target_subject_id = moderation_subjects.id)
+               AND EXISTS (
+                 SELECT 1
+                   FROM moderation_subjects r
+                  WHERE r.id IN (e.actor_subject_id, e.target_subject_id)
+                    AND (r.retention_until IS NULL OR r.retention_until > ?)
+               )
+          )
+          AND NOT EXISTS (
+            SELECT 1
+              FROM moderation_rejection_events e
+             WHERE (e.rejector_subject_id = moderation_subjects.id OR e.rejected_subject_id = moderation_subjects.id)
+               AND EXISTS (
+                 SELECT 1
+                   FROM moderation_subjects r
+                  WHERE r.id IN (e.rejector_subject_id, e.rejected_subject_id)
+                    AND (r.retention_until IS NULL OR r.retention_until > ?)
+               )
+          )
+        SQL
+        now, now
+      )
+    end
+  end
+end

--- a/app/lib/moderation/retention_cleanup.rb
+++ b/app/lib/moderation/retention_cleanup.rb
@@ -16,13 +16,17 @@ module Moderation
     module_function
 
     def events_without_retained_participant(klass, left_column, right_column, now)
-      table = klass.arel_table
+      conn = klass.connection
+      # Rails 6.1 Arel attributes do not implement +to_sql+; quote the
+      # identifier pair explicitly so the predicate stays SQL-only.
+      left = "#{conn.quote_table_name(klass.table_name)}.#{conn.quote_column_name(left_column)}"
+      right = "#{conn.quote_table_name(klass.table_name)}.#{conn.quote_column_name(right_column)}"
       klass.where(
         <<~SQL.squish,
           NOT EXISTS (
             SELECT 1
               FROM moderation_subjects
-             WHERE moderation_subjects.id IN (#{table[left_column].to_sql}, #{table[right_column].to_sql})
+             WHERE moderation_subjects.id IN (#{left}, #{right})
                AND (moderation_subjects.retention_until IS NULL OR moderation_subjects.retention_until > ?)
           )
         SQL

--- a/app/lib/moderation/retention_policy.rb
+++ b/app/lib/moderation/retention_policy.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Configurable retention policy for the moderation ledger. The retention period
+# is intentionally not hardcoded: it is read from the environment so operators
+# can tune it after privacy/legal review.
+#
+# A tombstoned subject (its account was deleted/purged) is kept until
+# +retention_until+, after which the retention cleanup scheduler removes it and,
+# via foreign keys, its recorded events. A non-positive value disables
+# expiry (records are kept indefinitely).
+module Moderation
+  module RetentionPolicy
+    DEFAULT_RETENTION_DAYS = 365
+
+    module_function
+
+    def retention_days
+      value = ENV.fetch('MODERATION_LEDGER_RETENTION_DAYS', DEFAULT_RETENTION_DAYS).to_i
+      value.negative? ? 0 : value
+    rescue ArgumentError, TypeError
+      DEFAULT_RETENTION_DAYS
+    end
+
+    def enabled?
+      retention_days.positive?
+    end
+
+    def duration
+      retention_days.days
+    end
+
+    # When a subject tombstoned at +from+ should expire, or nil when retention
+    # is disabled (kept indefinitely).
+    def expire_at(from = Time.now.utc)
+      return nil unless enabled?
+
+      from + duration
+    end
+  end
+end

--- a/app/lib/moderation/retention_policy.rb
+++ b/app/lib/moderation/retention_policy.rb
@@ -4,11 +4,15 @@
 # is intentionally not hardcoded: it is read from the environment so operators
 # can tune it after privacy/legal review.
 #
-# A tombstoned subject (its account was deleted/purged) is kept until
-# +retention_until+. The scheduler then expires it only when no shared
-# event still involves a retained counterpart — so one participant's
-# expiry cannot erase another subject's evidence. A non-positive value
-# disables expiry (records are kept indefinitely).
+# Operational semantics of MODERATION_LEDGER_RETENTION_DAYS / +retention_until+:
+#
+#   * The value is the *earliest eligibility* for deleting a tombstoned
+#     subject — not a hard deletion deadline. Rows are not guaranteed gone
+#     on day N.
+#   * After +retention_until+, the scheduler still holds that subject (and
+#     any shared events) while a retained counterpart needs the evidence.
+#     One participant's expiry must not erase another subject's history.
+#   * A non-positive value disables expiry (records are kept indefinitely).
 module Moderation
   module RetentionPolicy
     DEFAULT_RETENTION_DAYS = 365
@@ -30,8 +34,10 @@ module Moderation
       retention_days.days
     end
 
-    # When a subject tombstoned at +from+ should expire, or nil when retention
-    # is disabled (kept indefinitely).
+    # Earliest time a subject tombstoned at +from+ becomes eligible for
+    # deletion, or nil when retention is disabled (kept indefinitely).
+    # Eligibility is not a hard deadline: shared evidence may hold the
+    # subject longer. See the module comment.
     def expire_at(from = Time.now.utc)
       return nil unless enabled?
 

--- a/app/lib/moderation/retention_policy.rb
+++ b/app/lib/moderation/retention_policy.rb
@@ -5,9 +5,10 @@
 # can tune it after privacy/legal review.
 #
 # A tombstoned subject (its account was deleted/purged) is kept until
-# +retention_until+, after which the retention cleanup scheduler removes it and,
-# via foreign keys, its recorded events. A non-positive value disables
-# expiry (records are kept indefinitely).
+# +retention_until+. The scheduler then expires it only when no shared
+# event still involves a retained counterpart — so one participant's
+# expiry cannot erase another subject's evidence. A non-positive value
+# disables expiry (records are kept indefinitely).
 module Moderation
   module RetentionPolicy
     DEFAULT_RETENTION_DAYS = 365

--- a/app/models/moderation_interaction_event.rb
+++ b/app/models/moderation_interaction_event.rb
@@ -5,8 +5,8 @@
 # Table name: moderation_interaction_events
 #
 #  id                 :bigint(8)        not null, primary key
-#  actor_subject_id   :bigint(8)        not null
-#  target_subject_id  :bigint(8)        not null
+#  actor_subject_id   :bigint(8)
+#  target_subject_id  :bigint(8)
 #  event_type         :integer          not null
 #  status_id          :bigint(8)
 #  source_record_type :string
@@ -39,8 +39,8 @@ class ModerationInteractionEvent < ApplicationRecord
     follow_import: 7,
   }, _suffix: :event
 
-  belongs_to :actor_subject, class_name: 'ModerationSubject', inverse_of: :actor_interaction_events
-  belongs_to :target_subject, class_name: 'ModerationSubject', inverse_of: :target_interaction_events
+  belongs_to :actor_subject, class_name: 'ModerationSubject', inverse_of: :actor_interaction_events, optional: true
+  belongs_to :target_subject, class_name: 'ModerationSubject', inverse_of: :target_interaction_events, optional: true
 
   has_many :caused_rejections,
            class_name: 'ModerationRejectionEvent',

--- a/app/models/moderation_rejection_event.rb
+++ b/app/models/moderation_rejection_event.rb
@@ -5,8 +5,8 @@
 # Table name: moderation_rejection_events
 #
 #  id                             :bigint(8)        not null, primary key
-#  rejector_subject_id            :bigint(8)        not null
-#  rejected_subject_id            :bigint(8)        not null
+#  rejector_subject_id            :bigint(8)
+#  rejected_subject_id            :bigint(8)
 #  event_type                     :integer          not null
 #  preceding_interaction_event_id :bigint(8)
 #  occurred_at                    :datetime         not null
@@ -34,8 +34,8 @@ class ModerationRejectionEvent < ApplicationRecord
     report: 5,
   }, _suffix: :event
 
-  belongs_to :rejector_subject, class_name: 'ModerationSubject', inverse_of: :rejections_made
-  belongs_to :rejected_subject, class_name: 'ModerationSubject', inverse_of: :rejections_received
+  belongs_to :rejector_subject, class_name: 'ModerationSubject', inverse_of: :rejections_made, optional: true
+  belongs_to :rejected_subject, class_name: 'ModerationSubject', inverse_of: :rejections_received, optional: true
   belongs_to :preceding_interaction_event, class_name: 'ModerationInteractionEvent', optional: true, inverse_of: :caused_rejections
 
   validates :event_type, presence: true

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -33,22 +33,22 @@ class ModerationSubject < ApplicationRecord
            class_name: 'ModerationInteractionEvent',
            foreign_key: :actor_subject_id,
            inverse_of: :actor_subject,
-           dependent: :destroy
+           dependent: :nullify
   has_many :target_interaction_events,
            class_name: 'ModerationInteractionEvent',
            foreign_key: :target_subject_id,
            inverse_of: :target_subject,
-           dependent: :destroy
+           dependent: :nullify
   has_many :rejections_made,
            class_name: 'ModerationRejectionEvent',
            foreign_key: :rejector_subject_id,
            inverse_of: :rejector_subject,
-           dependent: :destroy
+           dependent: :nullify
   has_many :rejections_received,
            class_name: 'ModerationRejectionEvent',
            foreign_key: :rejected_subject_id,
            inverse_of: :rejected_subject,
-           dependent: :destroy
+           dependent: :nullify
 
   validates :origin, presence: true
   validates :first_seen_at, :last_seen_at, presence: true

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -58,7 +58,13 @@ class ModerationSubject < ApplicationRecord
   # Detached from their account (FK nullified on account deletion) but not yet
   # tombstoned — e.g. deleted through a path that bypassed the service hook.
   scope :orphaned, -> { where(account_id: nil, deleted_at: nil) }
-  # Tombstoned subjects whose retention window has elapsed.
+  # Subjects that still justify keeping shared events: never-tombstoned rows
+  # and tombstones whose +retention_until+ has not elapsed (or is nil because
+  # expiry is disabled).
+  scope :retained, ->(now = Time.now.utc) { where('retention_until IS NULL OR retention_until > ?', now) }
+  # Tombstoned subjects past +retention_until+. This is eligibility only —
+  # the scheduler may still hold the row while a retained counterpart needs
+  # shared evidence. Do not treat this as "the subject has been deleted".
   scope :expired, ->(now = Time.now.utc) { where.not(retention_until: nil).where('retention_until <= ?', now) }
 
   # Resolve (or create) the subject that represents +account+, keeping the

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -55,6 +55,11 @@ class ModerationSubject < ApplicationRecord
 
   scope :active, -> { where(deleted_at: nil) }
   scope :tombstoned, -> { where.not(deleted_at: nil) }
+  # Detached from their account (FK nullified on account deletion) but not yet
+  # tombstoned — e.g. deleted through a path that bypassed the service hook.
+  scope :orphaned, -> { where(account_id: nil, deleted_at: nil) }
+  # Tombstoned subjects whose retention window has elapsed.
+  scope :expired, ->(now = Time.now.utc) { where.not(retention_until: nil).where('retention_until <= ?', now) }
 
   # Resolve (or create) the subject that represents +account+, keeping the
   # denormalized origin/domain and +last_seen_at+ fresh. Accepts either an
@@ -84,8 +89,16 @@ class ModerationSubject < ApplicationRecord
     save! if changed?
   end
 
+  # Tombstone every live subject bound to +account+ before the account row is
+  # deleted (afterwards the FK nullifies account_id and it can't be found by id).
+  def self.tombstone_for_account!(account, now: Time.now.utc)
+    return if account.nil?
+
+    where(account_id: account.id, deleted_at: nil).find_each { |subject| subject.tombstone!(now: now) }
+  end
+
   def tombstone!(now: Time.now.utc)
-    update!(deleted_at: now)
+    update!(deleted_at: now, retention_until: Moderation::RetentionPolicy.expire_at(now))
   end
 
   def tombstoned?

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -154,7 +154,19 @@ class DeleteAccountService < BaseService
     purge_feeds!
     purge_other_associations!
 
-    @account.destroy unless keep_account_record?
+    unless keep_account_record?
+      tombstone_moderation_subject!
+      @account.destroy
+    end
+  end
+
+  # Mark the moderation subject as deleted (and set its retention window) before
+  # the account row is removed. Best-effort: never let this break account
+  # deletion. The database FK still nullifies account_id on destroy.
+  def tombstone_moderation_subject!
+    ModerationSubject.tombstone_for_account!(@account)
+  rescue StandardError => e
+    Rails.logger.warn("[Moderation] failed to tombstone subject for account #{@account.id}: #{e.class}: #{e.message}")
   end
 
   def purge_statuses!

--- a/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
+++ b/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
@@ -6,8 +6,13 @@
 #      nullified by the FK on account deletion) that were never tombstoned — for
 #      example when deletion happened through a path that bypassed the service
 #      hook. They are tombstoned so the retention window starts.
-#   2. Expire: tombstoned subjects past their retention_until are deleted; the
-#      database foreign keys cascade to their recorded events.
+#   2. Expire at the *event* level: a shared interaction/rejection is kept as
+#      long as any involved subject is still retained. An expired subject is
+#      deleted only when no remaining event references it (held otherwise so
+#      a retained counterpart's evidence stays internally consistent).
+#
+# Counterpart subject FKs are ON DELETE SET NULL as a safety net; this
+# scheduler should not need that path when it holds referenced subjects.
 #
 # Set MODERATION_LEDGER_RETENTION_DRY_RUN=true to log what would happen without
 # modifying any data.
@@ -39,13 +44,34 @@ class Scheduler::ModerationLedgerRetentionScheduler
   def expire_tombstoned!(now)
     return 0 unless Moderation::RetentionPolicy.enabled?
 
-    scope = ModerationSubject.expired(now)
-    count = scope.count
-    return count if count.zero? || dry_run?
+    expired_ids = ModerationSubject.expired(now).pluck(:id)
+    return 0 if expired_ids.empty?
+    return expired_ids.size if dry_run?
 
-    # delete_all relies on ON DELETE CASCADE to remove the subject's events.
-    scope.in_batches.delete_all
-    count
+    delete_events_without_retained_participant!(expired_ids)
+    deletable_ids = expired_ids - subject_ids_still_referenced(expired_ids)
+    return 0 if deletable_ids.empty?
+
+    ModerationSubject.where(id: deletable_ids).in_batches.delete_all
+    deletable_ids.size
+  end
+
+  # Drop events whose every participant is expired (or already null). Events
+  # that still name a retained subject are left intact.
+  def delete_events_without_retained_participant!(expired_ids)
+    retained_ids = ModerationSubject.where.not(id: expired_ids).pluck(:id)
+
+    ModerationInteractionEvent.where.not(actor_subject_id: retained_ids).where.not(target_subject_id: retained_ids).in_batches.delete_all
+    ModerationRejectionEvent.where.not(rejector_subject_id: retained_ids).where.not(rejected_subject_id: retained_ids).in_batches.delete_all
+  end
+
+  def subject_ids_still_referenced(expired_ids)
+    (
+      ModerationInteractionEvent.where(actor_subject_id: expired_ids).distinct.pluck(:actor_subject_id) +
+      ModerationInteractionEvent.where(target_subject_id: expired_ids).distinct.pluck(:target_subject_id) +
+      ModerationRejectionEvent.where(rejector_subject_id: expired_ids).distinct.pluck(:rejector_subject_id) +
+      ModerationRejectionEvent.where(rejected_subject_id: expired_ids).distinct.pluck(:rejected_subject_id)
+    ).compact.uniq
   end
 
   def dry_run?

--- a/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
+++ b/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
@@ -11,6 +11,16 @@
 #      deleted only when no remaining event references it (held otherwise so
 #      a retained counterpart's evidence stays internally consistent).
 #
+# +retention_until+ / MODERATION_LEDGER_RETENTION_DAYS is the earliest
+# eligibility time for a tombstoned subject — not a hard deletion deadline.
+# An expired subject (and the events it shares) may be held past that date
+# while a retained counterpart still needs the row.
+#
+# Evaluation stays in SQL (EXISTS / IN subqueries). Retained subject ids are
+# never loaded into Ruby. NULL participant FKs (ON DELETE SET NULL) are
+# treated as "not retained", so an event becomes deletable once every
+# remaining participant is expired or null.
+#
 # Counterpart subject FKs are ON DELETE SET NULL as a safety net; this
 # scheduler should not need that path when it holds referenced subjects.
 #
@@ -44,34 +54,25 @@ class Scheduler::ModerationLedgerRetentionScheduler
   def expire_tombstoned!(now)
     return 0 unless Moderation::RetentionPolicy.enabled?
 
-    expired_ids = ModerationSubject.expired(now).pluck(:id)
-    return 0 if expired_ids.empty?
-    return expired_ids.size if dry_run?
+    deletable_subjects = Moderation::RetentionCleanup.expired_subjects_without_retained_evidence(now)
+    return deletable_subjects.count if dry_run?
 
-    delete_events_without_retained_participant!(expired_ids)
-    deletable_ids = expired_ids - subject_ids_still_referenced(expired_ids)
-    return 0 if deletable_ids.empty?
+    delete_events_without_retained_participant!(now)
 
-    ModerationSubject.where(id: deletable_ids).in_batches.delete_all
-    deletable_ids.size
+    count = deletable_subjects.count
+    return 0 if count.zero?
+
+    deletable_subjects.in_batches.delete_all
+    count
   end
 
-  # Drop events whose every participant is expired (or already null). Events
-  # that still name a retained subject are left intact.
-  def delete_events_without_retained_participant!(expired_ids)
-    retained_ids = ModerationSubject.where.not(id: expired_ids).pluck(:id)
-
-    ModerationInteractionEvent.where.not(actor_subject_id: retained_ids).where.not(target_subject_id: retained_ids).in_batches.delete_all
-    ModerationRejectionEvent.where.not(rejector_subject_id: retained_ids).where.not(rejected_subject_id: retained_ids).in_batches.delete_all
-  end
-
-  def subject_ids_still_referenced(expired_ids)
-    (
-      ModerationInteractionEvent.where(actor_subject_id: expired_ids).distinct.pluck(:actor_subject_id) +
-      ModerationInteractionEvent.where(target_subject_id: expired_ids).distinct.pluck(:target_subject_id) +
-      ModerationRejectionEvent.where(rejector_subject_id: expired_ids).distinct.pluck(:rejector_subject_id) +
-      ModerationRejectionEvent.where(rejected_subject_id: expired_ids).distinct.pluck(:rejected_subject_id)
-    ).compact.uniq
+  def delete_events_without_retained_participant!(now)
+    Moderation::RetentionCleanup
+      .events_without_retained_participant(ModerationInteractionEvent, :actor_subject_id, :target_subject_id, now)
+      .in_batches.delete_all
+    Moderation::RetentionCleanup
+      .events_without_retained_participant(ModerationRejectionEvent, :rejector_subject_id, :rejected_subject_id, now)
+      .in_batches.delete_all
   end
 
   def dry_run?

--- a/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
+++ b/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Retention cleanup for the moderation ledger.
+#
+#   1. Reconcile orphans: subjects detached from their account (account_id
+#      nullified by the FK on account deletion) that were never tombstoned — for
+#      example when deletion happened through a path that bypassed the service
+#      hook. They are tombstoned so the retention window starts.
+#   2. Expire: tombstoned subjects past their retention_until are deleted; the
+#      database foreign keys cascade to their recorded events.
+#
+# Set MODERATION_LEDGER_RETENTION_DRY_RUN=true to log what would happen without
+# modifying any data.
+class Scheduler::ModerationLedgerRetentionScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0
+
+  def perform
+    now = Time.now.utc
+
+    reconciled = reconcile_orphans!(now)
+    expired    = expire_tombstoned!(now)
+
+    Rails.logger.info("[Scheduler::ModerationLedgerRetentionScheduler] reconciled=#{reconciled} expired=#{expired} dry_run=#{dry_run?} retention_days=#{Moderation::RetentionPolicy.retention_days}")
+  end
+
+  private
+
+  def reconcile_orphans!(now)
+    scope = ModerationSubject.orphaned
+    count = scope.count
+    return count if count.zero? || dry_run?
+
+    scope.in_batches.update_all(deleted_at: now, retention_until: Moderation::RetentionPolicy.expire_at(now))
+    count
+  end
+
+  def expire_tombstoned!(now)
+    return 0 unless Moderation::RetentionPolicy.enabled?
+
+    scope = ModerationSubject.expired(now)
+    count = scope.count
+    return count if count.zero? || dry_run?
+
+    # delete_all relies on ON DELETE CASCADE to remove the subject's events.
+    scope.in_batches.delete_all
+    count
+  end
+
+  def dry_run?
+    ENV['MODERATION_LEDGER_RETENTION_DRY_RUN'] == 'true'
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -67,3 +67,7 @@
       interval: 1 minute
       class: Scheduler::AccountsStatusesCleanupScheduler
       queue: scheduler
+    moderation_ledger_retention_scheduler:
+      cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
+      class: Scheduler::ModerationLedgerRetentionScheduler
+      queue: scheduler

--- a/db/migrate/20260909110001_nullify_moderation_event_subject_fks.rb
+++ b/db/migrate/20260909110001_nullify_moderation_event_subject_fks.rb
@@ -3,6 +3,11 @@
 # Shared ledger events must survive expiry of one participant. Counterpart
 # subject FKs become nullable and SET NULL so deleting a subject never
 # cascade-destroys evidence still needed by a retained counterpart.
+#
+# Irreversible: after this runs, ON DELETE SET NULL (and cleanup) may leave
+# NULL participant ids. Restoring NOT NULL / ON DELETE CASCADE would fail on
+# those rows or silently destroy shared evidence. Do not implement a down
+# path that deletes NULL-participant events to force the restore.
 class NullifyModerationEventSubjectFks < ActiveRecord::Migration[6.1]
   def up
     safety_assured do
@@ -24,21 +29,11 @@ class NullifyModerationEventSubjectFks < ActiveRecord::Migration[6.1]
   end
 
   def down
-    safety_assured do
-      remove_foreign_key :moderation_interaction_events, column: :actor_subject_id
-      remove_foreign_key :moderation_interaction_events, column: :target_subject_id
-      remove_foreign_key :moderation_rejection_events, column: :rejector_subject_id
-      remove_foreign_key :moderation_rejection_events, column: :rejected_subject_id
-
-      change_column_null :moderation_interaction_events, :actor_subject_id, false
-      change_column_null :moderation_interaction_events, :target_subject_id, false
-      change_column_null :moderation_rejection_events, :rejector_subject_id, false
-      change_column_null :moderation_rejection_events, :rejected_subject_id, false
-
-      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :actor_subject_id, on_delete: :cascade
-      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :target_subject_id, on_delete: :cascade
-      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejector_subject_id, on_delete: :cascade
-      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejected_subject_id, on_delete: :cascade
-    end
+    raise ActiveRecord::IrreversibleMigration, <<~MSG.squish
+      Cannot restore NOT NULL / ON DELETE CASCADE on moderation event subject
+      FKs: existing rows may have NULL participant ids (SET NULL after a
+      counterpart delete, or leftover events). Forcing NOT NULL would fail;
+      deleting those rows would destroy shared evidence.
+    MSG
   end
 end

--- a/db/migrate/20260909110001_nullify_moderation_event_subject_fks.rb
+++ b/db/migrate/20260909110001_nullify_moderation_event_subject_fks.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Shared ledger events must survive expiry of one participant. Counterpart
+# subject FKs become nullable and SET NULL so deleting a subject never
+# cascade-destroys evidence still needed by a retained counterpart.
+class NullifyModerationEventSubjectFks < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured do
+      remove_foreign_key :moderation_interaction_events, column: :actor_subject_id
+      remove_foreign_key :moderation_interaction_events, column: :target_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejector_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejected_subject_id
+
+      change_column_null :moderation_interaction_events, :actor_subject_id, true
+      change_column_null :moderation_interaction_events, :target_subject_id, true
+      change_column_null :moderation_rejection_events, :rejector_subject_id, true
+      change_column_null :moderation_rejection_events, :rejected_subject_id, true
+
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :actor_subject_id, on_delete: :nullify
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :target_subject_id, on_delete: :nullify
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejector_subject_id, on_delete: :nullify
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejected_subject_id, on_delete: :nullify
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_foreign_key :moderation_interaction_events, column: :actor_subject_id
+      remove_foreign_key :moderation_interaction_events, column: :target_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejector_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejected_subject_id
+
+      change_column_null :moderation_interaction_events, :actor_subject_id, false
+      change_column_null :moderation_interaction_events, :target_subject_id, false
+      change_column_null :moderation_rejection_events, :rejector_subject_id, false
+      change_column_null :moderation_rejection_events, :rejected_subject_id, false
+
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :actor_subject_id, on_delete: :cascade
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :target_subject_id, on_delete: :cascade
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejector_subject_id, on_delete: :cascade
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejected_subject_id, on_delete: :cascade
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -776,8 +776,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   end
 
   create_table "moderation_interaction_events", force: :cascade do |t|
-    t.bigint "actor_subject_id", null: false
-    t.bigint "target_subject_id", null: false
+    t.bigint "actor_subject_id"
+    t.bigint "target_subject_id"
     t.integer "event_type", null: false
     t.bigint "status_id"
     t.string "source_record_type"
@@ -795,8 +795,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   end
 
   create_table "moderation_rejection_events", force: :cascade do |t|
-    t.bigint "rejector_subject_id", null: false
-    t.bigint "rejected_subject_id", null: false
+    t.bigint "rejector_subject_id"
+    t.bigint "rejected_subject_id"
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
     t.datetime "occurred_at", null: false
@@ -1182,10 +1182,10 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.bigint "generator_id"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20210710", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL))"
+    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["account_id", "id"], name: "index_statuses_private_searchable", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL) AND (reblog_of_id IS NULL) AND (searchability = ANY (ARRAY[0, 1, 2])))"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
-    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["quote_id"], name: "index_statuses_on_quote_id"
@@ -1207,6 +1207,15 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tag_account_mutes", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
+    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
@@ -1220,15 +1229,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.float "max_score"
     t.datetime "max_score_at"
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
-  end
-
-  create_table "tag_account_mutes", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "account_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
-    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
   end
 
   create_table "tombstones", force: :cascade do |t|
@@ -1434,11 +1434,11 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :nullify
   add_foreign_key "moderation_subjects", "accounts", on_delete: :nullify
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
@@ -1487,6 +1487,53 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users"
 
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
+      SELECT account_id,
+      sum(rank) AS rank,
+      array_agg(reason) AS reason
+     FROM ( SELECT account_summaries.account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM (((follows
+               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT account_summaries.account_id,
+              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM (((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
+    GROUP BY account_id
+    ORDER BY (sum(rank)) DESC;
+  SQL
+  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
+
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (
            SELECT accounts.domain,
@@ -1510,52 +1557,5 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
        LEFT JOIN domain_counts ON (((domain_counts.domain)::text = (domain_allows.domain)::text)));
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
-
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT t0.account_id,
-      sum(t0.rank) AS rank,
-      array_agg(t0.reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM (((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM (((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
-    GROUP BY t0.account_id
-    ORDER BY (sum(t0.rank)) DESC;
-  SQL
-  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1182,10 +1182,10 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.bigint "generator_id"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20210710", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL))"
-    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["account_id", "id"], name: "index_statuses_private_searchable", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL) AND (reblog_of_id IS NULL) AND (searchability = ANY (ARRAY[0, 1, 2])))"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
+    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["quote_id"], name: "index_statuses_on_quote_id"
@@ -1207,15 +1207,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "tag_account_mutes", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "account_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
-    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
-  end
-
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
@@ -1229,6 +1220,15 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.float "max_score"
     t.datetime "max_score_at"
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
+  end
+
+  create_table "tag_account_mutes", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
+    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
   end
 
   create_table "tombstones", force: :cascade do |t|
@@ -1487,53 +1487,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users"
 
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT account_id,
-      sum(rank) AS rank,
-      array_agg(reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM (((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM (((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
-    GROUP BY account_id
-    ORDER BY (sum(rank)) DESC;
-  SQL
-  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
-
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (
            SELECT accounts.domain,
@@ -1557,5 +1510,52 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
        LEFT JOIN domain_counts ON (((domain_counts.domain)::text = (domain_allows.domain)::text)));
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
+
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
+      SELECT t0.account_id,
+      sum(t0.rank) AS rank,
+      array_agg(t0.reason) AS reason
+     FROM ( SELECT account_summaries.account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM (((follows
+               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT account_summaries.account_id,
+              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM (((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
+    GROUP BY t0.account_id
+    ORDER BY (sum(t0.rank)) DESC;
+  SQL
+  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
 
 end

--- a/spec/lib/moderation/retention_cleanup_spec.rb
+++ b/spec/lib/moderation/retention_cleanup_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::RetentionCleanup do
+  describe '.events_without_retained_participant' do
+    it 'evaluates retained subjects in SQL via NOT EXISTS' do
+      sql = described_class.events_without_retained_participant(
+        ModerationInteractionEvent,
+        :actor_subject_id,
+        :target_subject_id,
+        Time.now.utc
+      ).to_sql
+
+      expect(sql).to include('NOT EXISTS')
+      expect(sql).to include('moderation_subjects')
+      expect(sql).to include('retention_until')
+      expect(sql).to_not match(/NOT IN \s*\(/i)
+    end
+
+    it 'includes events whose remaining participants are expired or NULL' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        retained = Fabricate(:moderation_subject)
+        expired  = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        kept = Fabricate(:moderation_interaction_event, actor_subject: retained, target_subject: expired)
+        orphan = Fabricate(:moderation_interaction_event, actor_subject: expired, target_subject: expired)
+        orphan.update_columns(actor_subject_id: nil)
+
+        scope = described_class.events_without_retained_participant(
+          ModerationInteractionEvent,
+          :actor_subject_id,
+          :target_subject_id,
+          Time.now.utc
+        )
+
+        expect(scope).to include(orphan)
+        expect(scope).to_not include(kept)
+      end
+    end
+  end
+end

--- a/spec/lib/moderation/retention_cleanup_spec.rb
+++ b/spec/lib/moderation/retention_cleanup_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Moderation::RetentionCleanup do
       expect(sql).to include('NOT EXISTS')
       expect(sql).to include('moderation_subjects')
       expect(sql).to include('retention_until')
-      expect(sql).to include('moderation_interaction_events.actor_subject_id')
-      expect(sql).to include('moderation_interaction_events.target_subject_id')
+      expect(sql).to match(/moderation_interaction_events"?\."?actor_subject_id/)
+      expect(sql).to match(/moderation_interaction_events"?\."?target_subject_id/)
       expect(sql).to_not match(/NOT IN \s*\(/i)
     end
 

--- a/spec/lib/moderation/retention_cleanup_spec.rb
+++ b/spec/lib/moderation/retention_cleanup_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Moderation::RetentionCleanup do
       expect(sql).to include('NOT EXISTS')
       expect(sql).to include('moderation_subjects')
       expect(sql).to include('retention_until')
+      expect(sql).to include('moderation_interaction_events.actor_subject_id')
+      expect(sql).to include('moderation_interaction_events.target_subject_id')
       expect(sql).to_not match(/NOT IN \s*\(/i)
     end
 

--- a/spec/lib/moderation/retention_policy_spec.rb
+++ b/spec/lib/moderation/retention_policy_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::RetentionPolicy do
+  describe '.retention_days' do
+    it 'defaults to 365 when unset' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: nil do
+        expect(described_class.retention_days).to eq 365
+      end
+    end
+
+    it 'reads MODERATION_LEDGER_RETENTION_DAYS' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        expect(described_class.retention_days).to eq 30
+      end
+    end
+
+    it 'clamps negative values to 0 (disabled)' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '-5' do
+        expect(described_class.retention_days).to eq 0
+        expect(described_class.enabled?).to be false
+      end
+    end
+  end
+
+  describe '.expire_at' do
+    it 'is nil when retention is disabled' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '0' do
+        expect(described_class.expire_at(Time.now.utc)).to be_nil
+      end
+    end
+
+    it 'is the tombstone time plus the retention duration when enabled' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '10' do
+        from = Time.utc(2026, 1, 1)
+        expect(described_class.expire_at(from)).to eq(from + 10.days)
+      end
+    end
+  end
+end

--- a/spec/models/moderation/retention_spec.rb
+++ b/spec/models/moderation/retention_spec.rb
@@ -53,5 +53,14 @@ RSpec.describe 'ModerationSubject retention', type: :model do
       expect(ModerationSubject.expired).to include(expired)
       expect(ModerationSubject.expired).to_not include(future)
     end
+
+    it 'retained matches live subjects and tombstones that have not reached eligibility' do
+      live    = Fabricate(:moderation_subject)
+      future  = Fabricate(:moderation_subject, deleted_at: 2.days.ago, retention_until: 1.day.from_now)
+      expired = Fabricate(:moderation_subject, deleted_at: 2.days.ago, retention_until: 1.day.ago)
+
+      expect(ModerationSubject.retained).to include(live, future)
+      expect(ModerationSubject.retained).to_not include(expired)
+    end
   end
 end

--- a/spec/models/moderation/retention_spec.rb
+++ b/spec/models/moderation/retention_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'ModerationSubject retention', type: :model do
+  describe '#tombstone!' do
+    it 'sets deleted_at and retention_until from the policy' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        subject = Fabricate(:moderation_subject)
+        now = Time.now.utc
+
+        subject.tombstone!(now: now)
+
+        expect(subject.reload).to be_tombstoned
+        expect(subject.deleted_at).to be_within(1.second).of(now)
+        expect(subject.retention_until).to be_within(1.second).of(now + 30.days)
+      end
+    end
+
+    it 'leaves retention_until nil when retention is disabled' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '0' do
+        subject = Fabricate(:moderation_subject)
+
+        subject.tombstone!
+
+        expect(subject.reload).to be_tombstoned
+        expect(subject.retention_until).to be_nil
+      end
+    end
+  end
+
+  describe '.tombstone_for_account!' do
+    it 'tombstones the live subject bound to the account' do
+      account = Fabricate(:account)
+      subject = ModerationSubject.for_account!(account)
+
+      ModerationSubject.tombstone_for_account!(account)
+
+      expect(subject.reload).to be_tombstoned
+    end
+  end
+
+  describe 'scopes' do
+    it 'orphaned matches detached, non-tombstoned subjects' do
+      subject = Fabricate(:moderation_subject)
+      subject.update!(account_id: nil)
+
+      expect(ModerationSubject.orphaned).to include(subject)
+    end
+
+    it 'expired matches tombstoned subjects past retention_until' do
+      expired = Fabricate(:moderation_subject, deleted_at: 2.days.ago, retention_until: 1.day.ago)
+      future  = Fabricate(:moderation_subject, deleted_at: 2.days.ago, retention_until: 1.day.from_now)
+
+      expect(ModerationSubject.expired).to include(expired)
+      expect(ModerationSubject.expired).to_not include(future)
+    end
+  end
+end

--- a/spec/models/moderation/shared_evidence_retention_spec.rb
+++ b/spec/models/moderation/shared_evidence_retention_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 # Regression for the shared-evidence retention bug: expiring B must not erase
 # A→B contacts or B→A rejections while A is still retained.
+#
+# +retention_until+ is eligibility, not a hard deadline: B stays past that
+# timestamp while A's evidence still names B.
 RSpec.describe 'Moderation shared evidence retention', type: :model do
   it 'keeps A\'s contact and rejection evidence after B tombstones and expires' do
     ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do

--- a/spec/models/moderation/shared_evidence_retention_spec.rb
+++ b/spec/models/moderation/shared_evidence_retention_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+# Regression for the shared-evidence retention bug: expiring B must not erase
+# A→B contacts or B→A rejections while A is still retained.
+RSpec.describe 'Moderation shared evidence retention', type: :model do
+  it 'keeps A\'s contact and rejection evidence after B tombstones and expires' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      alice = Fabricate(:account, username: 'alice_retained')
+      bob   = Fabricate(:account, username: 'bob_expired')
+
+      contact = Moderation::EventRecorder.record_interaction(actor: alice, target: bob, event_type: :follow)
+      rejection = Moderation::EventRecorder.record_rejection(
+        rejector: bob,
+        rejected: alice,
+        event_type: :block,
+        preceding_interaction: contact
+      )
+
+      alice_subject = contact.actor_subject
+      bob_subject   = contact.target_subject
+
+      bob_subject.tombstone!(now: 40.days.ago)
+
+      Scheduler::ModerationLedgerRetentionScheduler.new.perform
+
+      expect(ModerationSubject.exists?(alice_subject.id)).to be true
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+      expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+
+      expect(ModerationInteractionEvent.where(actor_subject_id: alice_subject.id, target_subject_id: bob_subject.id)).to exist
+      expect(ModerationRejectionEvent.where(rejector_subject_id: bob_subject.id, rejected_subject_id: alice_subject.id)).to exist
+
+      expect(alice_subject.reload).to_not be_tombstoned
+      expect(bob_subject.reload).to be_tombstoned
+    end
+  end
+end

--- a/spec/services/moderation/deletion_durability_spec.rb
+++ b/spec/services/moderation/deletion_durability_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+# PR 3: deleting/purging an account through DeleteAccountService must tombstone
+# the moderation subject (and set its retention window) while preserving the
+# recorded events — the account link is only nullified, never cascaded.
+RSpec.describe 'Moderation ledger deletion durability', type: :service do
+  it 'tombstones the subject and preserves events when an account is purged' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      actor  = Fabricate(:account, domain: 'a.example', uri: 'https://a.example/users/x', inbox_url: 'https://a.example/inbox', protocol: :activitypub)
+      target = Fabricate(:account, domain: 'b.example', uri: 'https://b.example/users/y', inbox_url: 'https://b.example/inbox', protocol: :activitypub)
+
+      event = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :follow)
+      subject_id = event.actor_subject_id
+
+      expect { DeleteAccountService.new.call(actor, reserve_username: false, skip_side_effects: true) }
+        .to_not change(ModerationInteractionEvent, :count)
+
+      subject = ModerationSubject.find(subject_id)
+      expect(subject.account_id).to be_nil
+      expect(subject).to be_tombstoned
+      expect(subject.retention_until).to be_present
+      expect(ModerationInteractionEvent.exists?(event.id)).to be true
+    end
+  end
+end

--- a/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
+++ b/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
@@ -16,17 +16,42 @@ RSpec.describe Scheduler::ModerationLedgerRetentionScheduler do
       end
     end
 
-    it 'expires tombstoned subjects past retention and cascades their events' do
+    it 'expires an unshared tombstoned subject and its only-participant events' do
       ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
-        expired = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
-        other   = Fabricate(:moderation_subject)
-        event   = Fabricate(:moderation_interaction_event, actor_subject: expired, target_subject: other)
+        expired_a = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        expired_b = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        event = Fabricate(:moderation_interaction_event, actor_subject: expired_a, target_subject: expired_b)
 
-        expect { subject.perform }.to change(ModerationSubject, :count).by(-1)
+        expect { subject.perform }.to change(ModerationSubject, :count).by(-2)
 
-        expect(ModerationSubject.exists?(expired.id)).to be false
+        expect(ModerationSubject.exists?(expired_a.id)).to be false
+        expect(ModerationSubject.exists?(expired_b.id)).to be false
         expect(ModerationInteractionEvent.exists?(event.id)).to be false
-        expect(ModerationSubject.exists?(other.id)).to be true
+      end
+    end
+
+    it 'keeps shared evidence when only one participant has expired' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        actor  = Fabricate(:account)
+        target = Fabricate(:account)
+
+        contact = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :mention)
+        rejection = Moderation::EventRecorder.record_rejection(rejector: target, rejected: actor, event_type: :block, preceding_interaction: contact)
+
+        target_subject = rejection.rejector_subject
+        actor_subject  = contact.actor_subject
+        target_subject.update!(deleted_at: 40.days.ago, retention_until: 10.days.ago)
+
+        expect { subject.perform }.to_not change(ModerationInteractionEvent, :count)
+        expect { subject.perform }.to_not change(ModerationRejectionEvent, :count)
+
+        expect(ModerationSubject.exists?(actor_subject.id)).to be true
+        expect(ModerationSubject.exists?(target_subject.id)).to be true
+        expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+        expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+
+        expect(ModerationInteractionEvent.where(actor_subject_id: actor_subject.id)).to exist
+        expect(ModerationRejectionEvent.where(rejected_subject_id: actor_subject.id)).to exist
       end
     end
 

--- a/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
+++ b/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
@@ -63,5 +63,40 @@ RSpec.describe Scheduler::ModerationLedgerRetentionScheduler do
         expect(ModerationSubject.exists?(expired.id)).to be true
       end
     end
+
+    # Counterpart FKs are ON DELETE SET NULL. SQL `WHERE column NOT IN (...)`
+    # does not match NULL, so cleanup must treat a nullified side as "not
+    # retained" and delete the event once no retained participant remains.
+    it 'deletes an event after one participant is nullified once no retained participant remains' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        retained = Fabricate(:moderation_subject)
+        expired  = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        event = Fabricate(:moderation_interaction_event, actor_subject: retained, target_subject: expired)
+        rejection = Fabricate(:moderation_rejection_event, rejector_subject: expired, rejected_subject: retained)
+
+        event.update_columns(target_subject_id: nil)
+        rejection.update_columns(rejector_subject_id: nil)
+
+        expect { subject.perform }.to_not change { ModerationInteractionEvent.exists?(event.id) }.from(true)
+        expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+        expect(ModerationSubject.exists?(retained.id)).to be true
+        expect(ModerationSubject.exists?(expired.id)).to be false
+
+        retained.update!(deleted_at: 40.days.ago, retention_until: 10.days.ago)
+
+        expect { subject.perform }.to change { ModerationInteractionEvent.exists?(event.id) }.from(true).to(false)
+        expect(ModerationRejectionEvent.exists?(rejection.id)).to be false
+        expect(ModerationSubject.exists?(retained.id)).to be false
+      end
+    end
+
+    it 'deletes events whose remaining participants are all NULL' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        event = Fabricate(:moderation_interaction_event)
+        event.update_columns(actor_subject_id: nil, target_subject_id: nil)
+
+        expect { subject.perform }.to change { ModerationInteractionEvent.exists?(event.id) }.from(true).to(false)
+      end
+    end
   end
 end

--- a/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
+++ b/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Scheduler::ModerationLedgerRetentionScheduler do
+  subject { described_class.new }
+
+  describe '#perform' do
+    it 'reconciles orphaned subjects by tombstoning them' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        orphan = Fabricate(:moderation_subject)
+        orphan.update!(account_id: nil)
+
+        subject.perform
+
+        expect(orphan.reload).to be_tombstoned
+        expect(orphan.retention_until).to be_present
+      end
+    end
+
+    it 'expires tombstoned subjects past retention and cascades their events' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        expired = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        other   = Fabricate(:moderation_subject)
+        event   = Fabricate(:moderation_interaction_event, actor_subject: expired, target_subject: other)
+
+        expect { subject.perform }.to change(ModerationSubject, :count).by(-1)
+
+        expect(ModerationSubject.exists?(expired.id)).to be false
+        expect(ModerationInteractionEvent.exists?(event.id)).to be false
+        expect(ModerationSubject.exists?(other.id)).to be true
+      end
+    end
+
+    it 'does not modify data in dry-run mode' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30', MODERATION_LEDGER_RETENTION_DRY_RUN: 'true' do
+        expired = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+
+        expect { subject.perform }.to_not change(ModerationSubject, :count)
+        expect(ModerationSubject.exists?(expired.id)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 3 of the moderation-signal foundation (design memo §13 / Phase 2 "Deletion-safe retention"). Rebased onto current `fedibird` after #29 and #30 merged. Phase 1 already guaranteed that deleting an account only nullifies `moderation_subjects.account_id`. This PR adds lifecycle management:

- **Tombstoning on purge:** `DeleteAccountService` marks the subject deleted (and sets its retention window) right before the account row is destroyed. Best-effort — failures are logged and never break account deletion.
- **Configurable retention policy:** `Moderation::RetentionPolicy` reads `MODERATION_LEDGER_RETENTION_DAYS` (default 365; a non-positive value disables expiry).
- **Retention cleanup scheduler:** daily `Scheduler::ModerationLedgerRetentionScheduler` that reconciles orphans and expires events/unheld subjects using SQL `NOT EXISTS` / `IN` subqueries.

## Query approach

Cleanup stays in SQL. No `pluck` of retained or expired subject ids.

- An event is deletable when it has **no retained participant** (`retention_until IS NULL OR retention_until > now`).
- Correlated `NOT EXISTS` against `moderation_subjects`. A NULL participant FK (`ON DELETE SET NULL`) does not satisfy `subjects.id IN (left, right)`, so NULL is “not retained”.
- An expired subject is deleted only when it is **not held by an event that still has a retained counterpart**.

## Operational note

`MODERATION_LEDGER_RETENTION_DAYS` / `retention_until` is the **earliest eligibility** for deleting a tombstoned subject — **not a hard deletion deadline**. Shared evidence may hold a subject past that date. Set `0` to keep everything indefinitely. No pseudonymization in this PR.

## Migration rollback

`20260909110001_nullify_moderation_event_subject_fks` is **irreversible**. After SET NULL, existing NULL participant ids make restoring `NOT NULL` / `ON DELETE CASCADE` fail (or require destroying shared evidence). `down` raises `ActiveRecord::IrreversibleMigration`.

Verified: `RAILS_ENV=test bundle exec rails db:migrate:down VERSION=20260909110001` → `ActiveRecord::IrreversibleMigration`.

`db/schema.rb` contains only the four nullable SET NULL event FKs on top of current `fedibird` (follow-import tables from #30 are unchanged).

## Testing

**Head:** `6e31b29e764f5e4fb184800e75ef579d0716bcc3`  
**Base:** `be215274292d9f47f1d85afcb60661d57befab13`

**#31 focused suite** — 21 examples, 0 failures:

```
bundle exec rspec \
  spec/lib/moderation/retention_policy_spec.rb \
  spec/lib/moderation/retention_cleanup_spec.rb \
  spec/models/moderation/retention_spec.rb \
  spec/models/moderation/shared_evidence_retention_spec.rb \
  spec/services/moderation/deletion_durability_spec.rb \
  spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
```

Includes NULL-participant cleanup and shared-evidence retention.

**Local composed lifecycle** (current `fedibird` + #31 + #32, #32 not in this PR) — 8 examples, 0 failures, including both-participants-expired deletion and NULL counterpart cleanup.

GitHub: MERGEABLE / CLEAN.

READY TO MERGE. Do not merge until the repository owner reviews.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

