### PR TITLE
Moderation Action + Evidence Snapshot (PR 5)

### DIFF
--- a/app/lib/moderation/causality.rb
+++ b/app/lib/moderation/causality.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Causality rules for linking a rejection to the contact it responded to.
+#
+# Same-window overlap of "A contacted B" and "B rejected A" is not enough to
+# treat B as a negative target. A rejection is causally linked only when:
+#
+#   * it occurred at or after the candidate interaction;
+#   * the interaction is A → B and the rejection is B → A;
+#   * the elapsed time is within MAX_WINDOW.
+#
+# Preferred evidence is +preceding_interaction_event_id+ (populated by
+# Moderation::EventRecorder). Unlinked same-window overlap is retained as a
+# weaker correlation and must not be stored in +negative_target_subject_ids+.
+module Moderation
+  module Causality
+    MAX_WINDOW = 14.days
+
+    module_function
+
+    def valid_link?(interaction, rejection)
+      return false if rejection.nil?
+
+      valid_pair?(
+        interaction,
+        rejected_subject_id: rejection.rejected_subject_id,
+        rejector_subject_id: rejection.rejector_subject_id,
+        occurred_at: rejection.occurred_at
+      )
+    end
+
+    def valid_pair?(interaction, rejected_subject_id:, rejector_subject_id:, occurred_at:)
+      return false if interaction.nil? || occurred_at.nil?
+      return false unless interaction.actor_subject_id == rejected_subject_id
+      return false unless interaction.target_subject_id == rejector_subject_id
+      return false if interaction.occurred_at.nil?
+      return false if occurred_at < interaction.occurred_at
+
+      (occurred_at - interaction.occurred_at) <= MAX_WINDOW
+    end
+
+    def find_preceding_interaction(rejected_subject:, rejector_subject:, occurred_at:)
+      return if rejected_subject.nil? || rejector_subject.nil? || occurred_at.nil?
+
+      ModerationInteractionEvent
+        .where(actor_subject_id: rejected_subject.id, target_subject_id: rejector_subject.id)
+        .where('occurred_at <= ?', occurred_at)
+        .where('occurred_at >= ?', occurred_at - MAX_WINDOW)
+        .order(occurred_at: :desc, id: :desc)
+        .first
+    end
+  end
+end

--- a/app/lib/moderation/preceding_contact_link.rb
+++ b/app/lib/moderation/preceding_contact_link.rb
@@ -34,6 +34,10 @@ module Moderation
 
     def valid_pair?(interaction, rejected_subject_id:, rejector_subject_id:, occurred_at:)
       return false if interaction.nil? || occurred_at.nil?
+      # NULL participant ids (ON DELETE SET NULL after counterpart expiry)
+      # must not match each other: nil == nil is not a preceding-contact link.
+      return false if rejected_subject_id.nil? || rejector_subject_id.nil?
+      return false if interaction.actor_subject_id.nil? || interaction.target_subject_id.nil?
       return false unless interaction.actor_subject_id == rejected_subject_id
       return false unless interaction.target_subject_id == rejector_subject_id
       return false if interaction.occurred_at.nil?

--- a/app/lib/moderation/preceding_contact_link.rb
+++ b/app/lib/moderation/preceding_contact_link.rb
@@ -1,24 +1,27 @@
 # frozen_string_literal: true
 
-# Causality rules for linking a rejection to the contact it responded to.
+# Rules for a *preceding-contact link* between a rejection and an earlier
+# contact. This is a strong temporal/linked association, not proof that the
+# rejection was caused by that interaction.
 #
 # Same-window overlap of "A contacted B" and "B rejected A" is not enough to
-# treat B as a negative target. A rejection is causally linked only when:
+# treat B as a linked negative target. A preceding-contact link is recorded
+# only when:
 #
-#   * it occurred at or after the candidate interaction;
+#   * the rejection occurred at or after the candidate interaction;
 #   * the interaction is A → B and the rejection is B → A;
 #   * the elapsed time is within MAX_WINDOW.
 #
 # Preferred evidence is +preceding_interaction_event_id+ (populated by
 # Moderation::EventRecorder). Unlinked same-window overlap is retained as a
-# weaker correlation and must not be stored in +negative_target_subject_ids+.
+# weaker correlation and must not be stored in +linked_negative_target_subject_ids+.
 module Moderation
-  module Causality
+  module PrecedingContactLink
     MAX_WINDOW = 14.days
 
     module_function
 
-    def valid_link?(interaction, rejection)
+    def strong_association?(interaction, rejection)
       return false if rejection.nil?
 
       valid_pair?(

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -40,6 +40,7 @@ class Admin::AccountAction
     process_email!
     process_reports!
     process_queue!
+    record_moderation_action!
   end
 
   def report
@@ -141,6 +142,27 @@ class Admin::AccountAction
 
   def text_for_warning
     [warning_preset&.text, text].compact.join("\n\n")
+  end
+
+  # Record the moderator action + an evidence snapshot into the moderation
+  # ledger. Failure-tolerant, so it never breaks the action itself.
+  def record_moderation_action!
+    Moderation::ActionRecorder.record(
+      account: target_account,
+      action_type: moderation_action_type,
+      moderator: current_account,
+      reason_code: type
+    )
+  end
+
+  def moderation_action_type
+    case type
+    when 'suspend'                 then :suspend
+    when 'silence', 'hard_silence' then :limit
+    when 'disable'                 then :freeze
+    when 'none'                    then :warn
+    else :other
+    end
   end
 
   def queue_suspension_worker!

--- a/app/models/moderation_action.rb
+++ b/app/models/moderation_action.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_actions
+#
+#  id                   :bigint(8)        not null, primary key
+#  subject_id           :bigint(8)        not null
+#  action_type          :integer          not null
+#  performed_at         :datetime         not null
+#  moderator_account_id :bigint(8)
+#  reason_code          :string
+#  evidence_snapshot_id :bigint(8)
+#  metadata             :jsonb            not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# A moderator action taken against a subject (warn/limit/freeze/suspend/delete/
+# other), with an optional link to the evidence snapshot captured at the time.
+# Kept independently of Mastodon's own moderation records so the history
+# survives account/report deletion.
+class ModerationAction < ApplicationRecord
+  self.table_name = 'moderation_actions'
+
+  enum action_type: {
+    warn: 0,
+    limit: 1,
+    freeze: 2,
+    suspend: 3,
+    delete: 4,
+    other: 5,
+  }, _suffix: :action
+
+  belongs_to :subject, class_name: 'ModerationSubject'
+  belongs_to :moderator_account, class_name: 'Account', optional: true
+  belongs_to :evidence_snapshot, class_name: 'ModerationEvidenceSnapshot', optional: true
+
+  validates :action_type, presence: true
+  validates :performed_at, presence: true
+end

--- a/app/models/moderation_evidence_snapshot.rb
+++ b/app/models/moderation_evidence_snapshot.rb
@@ -19,8 +19,10 @@
 # be reviewed later even after the underlying records are gone, and provides a
 # baseline for comparing behaviour after a suspension.
 #
-# +summary+ holds scalar counts; +fingerprint+ holds sets such as the negative
-# target set. +schema_version+ tracks the shape of those payloads.
+# +summary+ holds scalar counts; +fingerprint+ holds sets such as the linked
+# negative-target set (preceding-contact association) and the weaker
+# same-window correlation set. +schema_version+ tracks the shape of those
+# payloads.
 class ModerationEvidenceSnapshot < ApplicationRecord
   self.table_name = 'moderation_evidence_snapshots'
 
@@ -30,13 +32,16 @@ class ModerationEvidenceSnapshot < ApplicationRecord
 
   validates :schema_version, numericality: { only_integer: true, greater_than: 0 }
 
-  def negative_target_subject_ids
-    Array(fingerprint['negative_target_subject_ids'])
+  # Strong temporal/linked association via preceding_interaction_event_id.
+  # Not proof that the rejection was caused by that contact.
+  def linked_negative_target_subject_ids
+    Array(fingerprint['linked_negative_target_subject_ids'].presence || fingerprint['negative_target_subject_ids'])
   end
 
-  # Same-window overlap without a proven contact→rejection order. Must not be
-  # treated as a causal negative-target set.
+  # Same-window overlap without a preceding-contact link. Must not be treated
+  # as a linked negative-target set.
   def correlated_negative_target_subject_ids
     Array(fingerprint['correlated_negative_target_subject_ids'])
   end
 end
+

--- a/app/models/moderation_evidence_snapshot.rb
+++ b/app/models/moderation_evidence_snapshot.rb
@@ -33,4 +33,10 @@ class ModerationEvidenceSnapshot < ApplicationRecord
   def negative_target_subject_ids
     Array(fingerprint['negative_target_subject_ids'])
   end
+
+  # Same-window overlap without a proven contact→rejection order. Must not be
+  # treated as a causal negative-target set.
+  def correlated_negative_target_subject_ids
+    Array(fingerprint['correlated_negative_target_subject_ids'])
+  end
 end

--- a/app/models/moderation_evidence_snapshot.rb
+++ b/app/models/moderation_evidence_snapshot.rb
@@ -35,13 +35,13 @@ class ModerationEvidenceSnapshot < ApplicationRecord
   # Strong temporal/linked association via preceding_interaction_event_id.
   # Not proof that the rejection was caused by that contact.
   def linked_negative_target_subject_ids
-    Array(fingerprint['linked_negative_target_subject_ids'].presence || fingerprint['negative_target_subject_ids'])
+    Array(fingerprint['linked_negative_target_subject_ids'].presence || fingerprint['negative_target_subject_ids']).compact
   end
 
   # Same-window overlap without a preceding-contact link. Must not be treated
   # as a linked negative-target set.
   def correlated_negative_target_subject_ids
-    Array(fingerprint['correlated_negative_target_subject_ids'])
+    Array(fingerprint['correlated_negative_target_subject_ids']).compact
   end
 end
 

--- a/app/models/moderation_evidence_snapshot.rb
+++ b/app/models/moderation_evidence_snapshot.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_evidence_snapshots
+#
+#  id             :bigint(8)        not null, primary key
+#  subject_id     :bigint(8)        not null
+#  window_start   :datetime
+#  window_end     :datetime
+#  summary        :jsonb            not null
+#  fingerprint    :jsonb            not null
+#  schema_version :integer          default(1), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# A point-in-time evidence snapshot for a moderation subject, generated when a
+# moderator action is taken. It fixes the reasoning behind an action so it can
+# be reviewed later even after the underlying records are gone, and provides a
+# baseline for comparing behaviour after a suspension.
+#
+# +summary+ holds scalar counts; +fingerprint+ holds sets such as the negative
+# target set. +schema_version+ tracks the shape of those payloads.
+class ModerationEvidenceSnapshot < ApplicationRecord
+  self.table_name = 'moderation_evidence_snapshots'
+
+  belongs_to :subject, class_name: 'ModerationSubject'
+
+  has_many :moderation_actions, class_name: 'ModerationAction', foreign_key: :evidence_snapshot_id, inverse_of: :evidence_snapshot, dependent: :nullify
+
+  validates :schema_version, numericality: { only_integer: true, greater_than: 0 }
+
+  def negative_target_subject_ids
+    Array(fingerprint['negative_target_subject_ids'])
+  end
+end

--- a/app/models/moderation_interaction_event.rb
+++ b/app/models/moderation_interaction_event.rb
@@ -12,6 +12,7 @@
 #  source_record_type :string
 #  source_record_id   :bigint(8)
 #  import_batch_id    :bigint(8)
+#  source_event_key   :string
 #  occurred_at        :datetime         not null
 #  observed_at        :datetime         not null
 #  metadata           :jsonb            not null

--- a/app/models/moderation_rejection_event.rb
+++ b/app/models/moderation_rejection_event.rb
@@ -9,6 +9,7 @@
 #  rejected_subject_id            :bigint(8)
 #  event_type                     :integer          not null
 #  preceding_interaction_event_id :bigint(8)
+#  source_event_key               :string
 #  occurred_at                    :datetime         not null
 #  observed_at                    :datetime         not null
 #  metadata                       :jsonb            not null

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -49,6 +49,16 @@ class ModerationSubject < ApplicationRecord
            foreign_key: :rejected_subject_id,
            inverse_of: :rejected_subject,
            dependent: :nullify
+  has_many :evidence_snapshots,
+           class_name: 'ModerationEvidenceSnapshot',
+           foreign_key: :subject_id,
+           inverse_of: :subject,
+           dependent: :destroy
+  has_many :moderation_actions,
+           class_name: 'ModerationAction',
+           foreign_key: :subject_id,
+           inverse_of: :subject,
+           dependent: :destroy
 
   validates :origin, presence: true
   validates :first_seen_at, :last_seen_at, presence: true

--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -17,7 +17,7 @@ class BlockService < BaseService
     BlockWorker.perform_async(account.id, target_account.id)
     create_notification(block) if !target_account.local? && target_account.activitypub?
 
-    Moderation::EventRecorder.record_rejection(rejector: account, rejected: target_account, event_type: :block)
+    Moderation::EventRecorder.record_rejection(rejector: account, rejected: target_account, event_type: :block, source_record: block)
 
     block
   end

--- a/app/services/moderation/action_recorder.rb
+++ b/app/services/moderation/action_recorder.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Records a moderator action into the ledger and captures an evidence snapshot
+# at the same time. This is the entry point moderation flows call.
+#
+# The class-level helper is failure-tolerant: a recording error is logged and
+# returns nil, so it never breaks the moderation action itself.
+module Moderation
+  class ActionRecorder
+    class << self
+      def record(**options)
+        new.record(**options)
+      rescue StandardError => e
+        Rails.logger.warn("[Moderation::ActionRecorder] failed to record moderation action: #{e.class}: #{e.message}")
+        nil
+      end
+    end
+
+    def record(account:, action_type:, moderator: nil, reason_code: nil, window: Moderation::EvidenceSnapshotService::DEFAULT_WINDOW, performed_at: nil, metadata: {})
+      performed_at ||= Time.now.utc
+      subject = ModerationSubject.for_account!(account, observed_at: performed_at)
+
+      snapshot = Moderation::EvidenceSnapshotService.new.call(subject, window: window, now: performed_at)
+
+      ModerationAction.create!(
+        subject: subject,
+        action_type: action_type,
+        performed_at: performed_at,
+        moderator_account_id: moderator&.id,
+        reason_code: reason_code,
+        evidence_snapshot: snapshot,
+        metadata: metadata || {}
+      )
+    end
+  end
+end

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -72,7 +72,8 @@ module Moderation
 
     # Record a negative signal (rejector -> rejected). When the caller does
     # not supply a preceding interaction, the nearest earlier contact from
-    # rejected → rejector within the causal window is linked automatically.
+    # rejected → rejector within the association window is linked automatically.
+    # The link is a strong temporal association, not a causal proof.
     def record_rejection(rejector:, rejected:, event_type:, preceding_interaction: nil, occurred_at: nil, observed_at: nil, metadata: {}, source_record: nil, source_event_key: nil)
       observed_at ||= Time.now.utc
       occurred_at ||= observed_at
@@ -110,7 +111,7 @@ module Moderation
     private
 
     def resolve_preceding_interaction(explicit:, rejected_subject:, rejector_subject:, occurred_at:)
-      if Moderation::Causality.valid_pair?(
+      if Moderation::PrecedingContactLink.valid_pair?(
         explicit,
         rejected_subject_id: rejected_subject.id,
         rejector_subject_id: rejector_subject.id,
@@ -119,7 +120,7 @@ module Moderation
         return explicit
       end
 
-      Moderation::Causality.find_preceding_interaction(
+      Moderation::PrecedingContactLink.find_preceding_interaction(
         rejected_subject: rejected_subject,
         rejector_subject: rejector_subject,
         occurred_at: occurred_at

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -11,8 +11,15 @@
 #     are observable.
 #   * Record only behavioural metadata (who / whom / what / when), never raw
 #     post/DM/profile content.
+#   * Source-backed observations are idempotent: a stable +source_event_key+
+#     plus a unique index prevent duplicate rows when a caller retries or
+#     loses a uniqueness race.
 #
 # This phase performs recording only: no scoring, throttling, or enforcement.
+#
+# Known coverage limitation: inbound ActivityPub-only paths (remote
+# mention/reply/follow/favourite/reaction/block) are not yet hooked. Snapshots
+# and future scores for remote actors are therefore incomplete.
 module Moderation
   class EventRecorder
     class << self
@@ -40,41 +47,96 @@ module Moderation
     # Record a contact (actor -> target). +actor+/+target+ may be an Account or
     # an already-resolved ModerationSubject. Raises on failure; prefer the
     # class-level Moderation::EventRecorder.record_interaction at call sites.
-    def record_interaction(actor:, target:, event_type:, status: nil, source_record: nil, import_batch_id: nil, occurred_at: nil, observed_at: nil, metadata: {})
+    def record_interaction(actor:, target:, event_type:, status: nil, source_record: nil, import_batch_id: nil, occurred_at: nil, observed_at: nil, metadata: {}, source_event_key: nil)
       observed_at ||= Time.now.utc
       actor_subject  = ModerationSubject.for_account!(actor, observed_at: observed_at)
       target_subject = ModerationSubject.for_account!(target, observed_at: observed_at)
+      key = source_event_key.presence || self.class.source_event_key_for(source_record, event_type)
 
-      ModerationInteractionEvent.create!(
-        actor_subject: actor_subject,
-        target_subject: target_subject,
-        event_type: event_type,
-        status_id: status&.id,
-        source_record_type: source_record&.class&.base_class&.name,
-        source_record_id: source_record&.id,
-        import_batch_id: import_batch_id,
-        occurred_at: occurred_at || observed_at,
-        observed_at: observed_at,
-        metadata: metadata || {}
+      upsert_by_source_key(ModerationInteractionEvent, key) do
+        ModerationInteractionEvent.create!(
+          actor_subject: actor_subject,
+          target_subject: target_subject,
+          event_type: event_type,
+          status_id: status&.id,
+          source_record_type: source_record&.class&.base_class&.name,
+          source_record_id: source_record&.id,
+          import_batch_id: import_batch_id,
+          source_event_key: key,
+          occurred_at: occurred_at || observed_at,
+          observed_at: observed_at,
+          metadata: metadata || {}
+        )
+      end
+    end
+
+    # Record a negative signal (rejector -> rejected). When the caller does
+    # not supply a preceding interaction, the nearest earlier contact from
+    # rejected → rejector within the causal window is linked automatically.
+    def record_rejection(rejector:, rejected:, event_type:, preceding_interaction: nil, occurred_at: nil, observed_at: nil, metadata: {}, source_record: nil, source_event_key: nil)
+      observed_at ||= Time.now.utc
+      occurred_at ||= observed_at
+      rejector_subject = ModerationSubject.for_account!(rejector, observed_at: observed_at)
+      rejected_subject = ModerationSubject.for_account!(rejected, observed_at: observed_at)
+      key = source_event_key.presence || self.class.source_event_key_for(source_record, event_type)
+
+      preceding = resolve_preceding_interaction(
+        explicit: preceding_interaction,
+        rejected_subject: rejected_subject,
+        rejector_subject: rejector_subject,
+        occurred_at: occurred_at
+      )
+
+      upsert_by_source_key(ModerationRejectionEvent, key) do
+        ModerationRejectionEvent.create!(
+          rejector_subject: rejector_subject,
+          rejected_subject: rejected_subject,
+          event_type: event_type,
+          preceding_interaction_event: preceding,
+          source_event_key: key,
+          occurred_at: occurred_at,
+          observed_at: observed_at,
+          metadata: metadata || {}
+        )
+      end
+    end
+
+    def self.source_event_key_for(source_record, event_type)
+      return if source_record.nil? || source_record.id.nil?
+
+      "#{source_record.class.base_class.name}:#{source_record.id}:#{event_type}"
+    end
+
+    private
+
+    def resolve_preceding_interaction(explicit:, rejected_subject:, rejector_subject:, occurred_at:)
+      if Moderation::Causality.valid_pair?(
+        explicit,
+        rejected_subject_id: rejected_subject.id,
+        rejector_subject_id: rejector_subject.id,
+        occurred_at: occurred_at
+      )
+        return explicit
+      end
+
+      Moderation::Causality.find_preceding_interaction(
+        rejected_subject: rejected_subject,
+        rejector_subject: rejector_subject,
+        occurred_at: occurred_at
       )
     end
 
-    # Record a negative signal (rejector -> rejected). +preceding_interaction+
-    # optionally links the contact this rejection responded to.
-    def record_rejection(rejector:, rejected:, event_type:, preceding_interaction: nil, occurred_at: nil, observed_at: nil, metadata: {})
-      observed_at ||= Time.now.utc
-      rejector_subject = ModerationSubject.for_account!(rejector, observed_at: observed_at)
-      rejected_subject = ModerationSubject.for_account!(rejected, observed_at: observed_at)
+    def upsert_by_source_key(model, key)
+      if key.present?
+        existing = model.find_by(source_event_key: key)
+        return existing if existing
+      end
 
-      ModerationRejectionEvent.create!(
-        rejector_subject: rejector_subject,
-        rejected_subject: rejected_subject,
-        event_type: event_type,
-        preceding_interaction_event: preceding_interaction,
-        occurred_at: occurred_at || observed_at,
-        observed_at: observed_at,
-        metadata: metadata || {}
-      )
+      yield
+    rescue ActiveRecord::RecordNotUnique
+      raise if key.blank?
+
+      model.find_by!(source_event_key: key)
     end
   end
 end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -3,12 +3,15 @@
 # Builds a ModerationEvidenceSnapshot for a subject over a time window from the
 # recorded ledger (interaction + rejection events).
 #
-# The key artifact is the negative target set: accounts this subject contacted
-# that then returned a negative signal *after* that contact, within the causal
-# window, preferably linked via +preceding_interaction_event_id+.
+# The key artifact is the *linked* negative target set: accounts this subject
+# contacted that later returned a negative signal, with a preceding-contact
+# link (via +preceding_interaction_event_id+) inside the association window.
+# That is a strong temporal association, not proof the rejection was caused
+# by that contact.
 #
-# Same-window overlap without a proven A→B then B→A order is stored separately
-# as a weaker correlation and is never written to +negative_target_subject_ids+.
+# Same-window overlap without a preceding-contact link is stored separately
+# as a weaker correlation and is never written to
+# +linked_negative_target_subject_ids+.
 #
 # Recording/summarising only — no scoring or thresholds.
 #
@@ -19,7 +22,7 @@
 # incomplete until those paths are covered. See +fingerprint['coverage']+.
 module Moderation
   class EvidenceSnapshotService
-    SCHEMA_VERSION = 2
+    SCHEMA_VERSION = 3
     DEFAULT_WINDOW = 30.days
 
     # Cap the persisted id sets so a pathological subject can't create an
@@ -46,26 +49,26 @@ module Moderation
 
       contacted_ids      = interactions.distinct.pluck(:target_subject_id)
       rejections_by_type = rejections.group(:event_type).count
-      strong_ids, weak_ids = classify_negative_targets(rejections, contacted_ids)
+      linked_ids, correlated_ids = classify_negative_targets(rejections, contacted_ids)
 
       summary = {
-        'interactions_count'              => interactions.count,
-        'unique_contacts'                 => contacted_ids.size,
-        'negative_responders'             => rejections.distinct.count(:rejector_subject_id),
-        'negative_target_count'           => strong_ids.size,
-        'correlated_negative_target_count' => weak_ids.size,
-        'blocks_received'                 => rejections_by_type['block'].to_i,
-        'follow_rejects_received'         => rejections_by_type['follow_reject'].to_i,
-        'removed_as_follower'             => rejections_by_type['remove_follower'].to_i,
-        'reports_received'                => rejections_by_type['report'].to_i,
-        'mutes_received'                  => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
+        'interactions_count'               => interactions.count,
+        'unique_contacts'                  => contacted_ids.size,
+        'negative_responders'              => rejections.distinct.count(:rejector_subject_id),
+        'linked_negative_target_count'     => linked_ids.size,
+        'correlated_negative_target_count' => correlated_ids.size,
+        'blocks_received'                  => rejections_by_type['block'].to_i,
+        'follow_rejects_received'          => rejections_by_type['follow_reject'].to_i,
+        'removed_as_follower'              => rejections_by_type['remove_follower'].to_i,
+        'reports_received'                 => rejections_by_type['report'].to_i,
+        'mutes_received'                   => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
       }
 
       fingerprint = {
-        'negative_target_subject_ids'              => strong_ids.first(MAX_FINGERPRINT_IDS),
-        'correlated_negative_target_subject_ids'   => weak_ids.first(MAX_FINGERPRINT_IDS),
-        'contacted_target_count'                   => contacted_ids.size,
-        'coverage'                                 => INBOUND_ACTIVITYPUB_COVERAGE,
+        'linked_negative_target_subject_ids'     => linked_ids.first(MAX_FINGERPRINT_IDS),
+        'correlated_negative_target_subject_ids' => correlated_ids.first(MAX_FINGERPRINT_IDS),
+        'contacted_target_count'                 => contacted_ids.size,
+        'coverage'                               => INBOUND_ACTIVITYPUB_COVERAGE,
       }
 
       ModerationEvidenceSnapshot.create!(
@@ -92,29 +95,29 @@ module Moderation
       scope
     end
 
-    # Strong: linked preceding interaction that satisfies causality.
-    # Weak: same-window subject-id overlap without a valid causal link.
+    # Linked: preceding-contact link (strong temporal association).
+    # Correlated: same-window subject-id overlap without that link.
     def classify_negative_targets(rejections, contacted_ids)
       contacted = contacted_ids.to_set
-      strong = Set.new
-      weak = Set.new
+      linked = Set.new
+      correlated = Set.new
 
       rejections.includes(:preceding_interaction_event).find_each do |rejection|
         rejector_id = rejection.rejector_subject_id
         next unless contacted.include?(rejector_id)
 
-        if Moderation::Causality.valid_link?(rejection.preceding_interaction_event, rejection)
-          strong << rejector_id
+        if Moderation::PrecedingContactLink.strong_association?(rejection.preceding_interaction_event, rejection)
+          linked << rejector_id
         else
-          weak << rejector_id
+          correlated << rejector_id
         end
       end
 
-      # A rejector with any strong link is not also reported as a weak
-      # correlation — the fingerprint must not imply both.
-      weak.subtract(strong)
+      # A rejector with any preceding-contact link is not also reported as a
+      # weak correlation — the fingerprint must not imply both.
+      correlated.subtract(linked)
 
-      [strong.to_a, weak.to_a]
+      [linked.to_a, correlated.to_a]
     end
   end
 end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Builds a ModerationEvidenceSnapshot for a subject over a time window from the
+# recorded ledger (interaction + rejection events).
+#
+# The key artifact is the negative target set: the accounts this subject
+# contacted that returned a negative signal (block/mute/reject/remove/report).
+# Recording/summarising only — no scoring or thresholds.
+module Moderation
+  class EvidenceSnapshotService
+    SCHEMA_VERSION = 1
+    DEFAULT_WINDOW = 30.days
+
+    # Cap the persisted id sets so a pathological subject can't create an
+    # unbounded fingerprint.
+    MAX_FINGERPRINT_IDS = 1_000
+
+    REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
+
+    def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)
+      subject = ModerationSubject.for_account!(subject_or_account, observed_at: now)
+
+      window_start = window.nil? ? nil : now - window
+      window_end   = now
+
+      interactions = interactions_scope(subject, window_start, window_end)
+      rejections   = rejections_scope(subject, window_start, window_end)
+
+      contacted_ids       = interactions.distinct.pluck(:target_subject_id)
+      rejections_by_type  = rejections.group(:event_type).count
+      negative_target_ids = rejections.where(rejector_subject_id: contacted_ids).distinct.pluck(:rejector_subject_id)
+
+      summary = {
+        'interactions_count'      => interactions.count,
+        'unique_contacts'         => contacted_ids.size,
+        'negative_responders'     => rejections.distinct.count(:rejector_subject_id),
+        'negative_target_count'   => negative_target_ids.size,
+        'blocks_received'         => rejections_by_type['block'].to_i,
+        'follow_rejects_received' => rejections_by_type['follow_reject'].to_i,
+        'removed_as_follower'     => rejections_by_type['remove_follower'].to_i,
+        'reports_received'        => rejections_by_type['report'].to_i,
+        'mutes_received'          => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
+      }
+
+      fingerprint = {
+        'negative_target_subject_ids' => negative_target_ids.first(MAX_FINGERPRINT_IDS),
+        'contacted_target_count'      => contacted_ids.size,
+      }
+
+      ModerationEvidenceSnapshot.create!(
+        subject: subject,
+        window_start: window_start,
+        window_end: window_end,
+        summary: summary,
+        fingerprint: fingerprint,
+        schema_version: SCHEMA_VERSION
+      )
+    end
+
+    private
+
+    def interactions_scope(subject, window_start, window_end)
+      scope = ModerationInteractionEvent.where(actor_subject_id: subject.id)
+      scope = scope.where(occurred_at: window_start..window_end) if window_start
+      scope
+    end
+
+    def rejections_scope(subject, window_start, window_end)
+      scope = ModerationRejectionEvent.where(rejected_subject_id: subject.id)
+      scope = scope.where(occurred_at: window_start..window_end) if window_start
+      scope
+    end
+  end
+end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -3,12 +3,23 @@
 # Builds a ModerationEvidenceSnapshot for a subject over a time window from the
 # recorded ledger (interaction + rejection events).
 #
-# The key artifact is the negative target set: the accounts this subject
-# contacted that returned a negative signal (block/mute/reject/remove/report).
+# The key artifact is the negative target set: accounts this subject contacted
+# that then returned a negative signal *after* that contact, within the causal
+# window, preferably linked via +preceding_interaction_event_id+.
+#
+# Same-window overlap without a proven A→B then B→A order is stored separately
+# as a weaker correlation and is never written to +negative_target_subject_ids+.
+#
 # Recording/summarising only — no scoring or thresholds.
+#
+# Coverage limitation: inbound ActivityPub-only mentions, replies, follows,
+# favourites, reactions, and blocks are not yet observed. A remote subject can
+# therefore accumulate local blocks/reports while the triggering remote
+# contacts are missing. Snapshots (and future scores) for remote actors are
+# incomplete until those paths are covered. See +fingerprint['coverage']+.
 module Moderation
   class EvidenceSnapshotService
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
     DEFAULT_WINDOW = 30.days
 
     # Cap the persisted id sets so a pathological subject can't create an
@@ -16,6 +27,13 @@ module Moderation
     MAX_FINGERPRINT_IDS = 1_000
 
     REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
+
+    # Explicit until inbound ActivityPub interaction paths are wired. Do not
+    # treat snapshot counts or future scores as complete for remote actors.
+    INBOUND_ACTIVITYPUB_COVERAGE = {
+      'inbound_activitypub' => 'deferred',
+      'complete_for_remote_subjects' => false,
+    }.freeze
 
     def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)
       subject = ModerationSubject.for_account!(subject_or_account, observed_at: now)
@@ -26,25 +44,28 @@ module Moderation
       interactions = interactions_scope(subject, window_start, window_end)
       rejections   = rejections_scope(subject, window_start, window_end)
 
-      contacted_ids       = interactions.distinct.pluck(:target_subject_id)
-      rejections_by_type  = rejections.group(:event_type).count
-      negative_target_ids = rejections.where(rejector_subject_id: contacted_ids).distinct.pluck(:rejector_subject_id)
+      contacted_ids      = interactions.distinct.pluck(:target_subject_id)
+      rejections_by_type = rejections.group(:event_type).count
+      strong_ids, weak_ids = classify_negative_targets(rejections, contacted_ids)
 
       summary = {
-        'interactions_count'      => interactions.count,
-        'unique_contacts'         => contacted_ids.size,
-        'negative_responders'     => rejections.distinct.count(:rejector_subject_id),
-        'negative_target_count'   => negative_target_ids.size,
-        'blocks_received'         => rejections_by_type['block'].to_i,
-        'follow_rejects_received' => rejections_by_type['follow_reject'].to_i,
-        'removed_as_follower'     => rejections_by_type['remove_follower'].to_i,
-        'reports_received'        => rejections_by_type['report'].to_i,
-        'mutes_received'          => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
+        'interactions_count'              => interactions.count,
+        'unique_contacts'                 => contacted_ids.size,
+        'negative_responders'             => rejections.distinct.count(:rejector_subject_id),
+        'negative_target_count'           => strong_ids.size,
+        'correlated_negative_target_count' => weak_ids.size,
+        'blocks_received'                 => rejections_by_type['block'].to_i,
+        'follow_rejects_received'         => rejections_by_type['follow_reject'].to_i,
+        'removed_as_follower'             => rejections_by_type['remove_follower'].to_i,
+        'reports_received'                => rejections_by_type['report'].to_i,
+        'mutes_received'                  => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
       }
 
       fingerprint = {
-        'negative_target_subject_ids' => negative_target_ids.first(MAX_FINGERPRINT_IDS),
-        'contacted_target_count'      => contacted_ids.size,
+        'negative_target_subject_ids'              => strong_ids.first(MAX_FINGERPRINT_IDS),
+        'correlated_negative_target_subject_ids'   => weak_ids.first(MAX_FINGERPRINT_IDS),
+        'contacted_target_count'                   => contacted_ids.size,
+        'coverage'                                 => INBOUND_ACTIVITYPUB_COVERAGE,
       }
 
       ModerationEvidenceSnapshot.create!(
@@ -69,6 +90,31 @@ module Moderation
       scope = ModerationRejectionEvent.where(rejected_subject_id: subject.id)
       scope = scope.where(occurred_at: window_start..window_end) if window_start
       scope
+    end
+
+    # Strong: linked preceding interaction that satisfies causality.
+    # Weak: same-window subject-id overlap without a valid causal link.
+    def classify_negative_targets(rejections, contacted_ids)
+      contacted = contacted_ids.to_set
+      strong = Set.new
+      weak = Set.new
+
+      rejections.includes(:preceding_interaction_event).find_each do |rejection|
+        rejector_id = rejection.rejector_subject_id
+        next unless contacted.include?(rejector_id)
+
+        if Moderation::Causality.valid_link?(rejection.preceding_interaction_event, rejection)
+          strong << rejector_id
+        else
+          weak << rejector_id
+        end
+      end
+
+      # A rejector with any strong link is not also reported as a weak
+      # correlation — the fingerprint must not imply both.
+      weak.subtract(strong)
+
+      [strong.to_a, weak.to_a]
     end
   end
 end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -47,7 +47,9 @@ module Moderation
       interactions = interactions_scope(subject, window_start, window_end)
       rejections   = rejections_scope(subject, window_start, window_end)
 
-      contacted_ids      = interactions.distinct.pluck(:target_subject_id)
+      # Counterpart FKs may be NULL after #31 SET NULL expiry. Never treat a
+      # missing id as a contact/target, and never persist nil into fingerprints.
+      contacted_ids      = interactions.distinct.pluck(:target_subject_id).compact
       rejections_by_type = rejections.group(:event_type).count
       linked_ids, correlated_ids = classify_negative_targets(rejections, contacted_ids)
 
@@ -104,6 +106,7 @@ module Moderation
 
       rejections.includes(:preceding_interaction_event).find_each do |rejection|
         rejector_id = rejection.rejector_subject_id
+        next if rejector_id.nil?
         next unless contacted.include?(rejector_id)
 
         if Moderation::PrecedingContactLink.strong_association?(rejection.preceding_interaction_event, rejection)

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -10,6 +10,7 @@ class MuteService < BaseService
       rejector: account,
       rejected: target_account,
       event_type: :mute,
+      source_record: mute,
       metadata: { hide_notifications: mute.hide_notifications? }
     )
 

--- a/app/services/reject_follow_service.rb
+++ b/app/services/reject_follow_service.rb
@@ -9,7 +9,7 @@ class RejectFollowService < BaseService
     create_notification(follow_request) if !source_account.local? && source_account.activitypub?
 
     # source_account is the requester; target_account is the account rejecting.
-    Moderation::EventRecorder.record_rejection(rejector: target_account, rejected: source_account, event_type: :follow_reject)
+    Moderation::EventRecorder.record_rejection(rejector: target_account, rejected: source_account, event_type: :follow_reject, source_record: follow_request)
 
     follow_request
   end

--- a/app/services/remove_from_followers_service.rb
+++ b/app/services/remove_from_followers_service.rb
@@ -8,7 +8,7 @@ class RemoveFromFollowersService < BaseService
       follower = follow.account
       follow.destroy
 
-      Moderation::EventRecorder.record_rejection(rejector: source_account, rejected: follower, event_type: :remove_follower)
+      Moderation::EventRecorder.record_rejection(rejector: source_account, rejected: follower, event_type: :remove_follower, source_record: follow)
 
       if source_account.local? && !follower.local? && follower.activitypub?
         create_notification(follow)

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -27,6 +27,7 @@ class ReportService < BaseService
       rejector: @source_account,
       rejected: @target_account,
       event_type: :report,
+      source_record: @report,
       metadata: { status_count: @status_ids.size }
     )
   end

--- a/db/migrate/20260909070001_create_moderation_evidence_snapshots.rb
+++ b/db/migrate/20260909070001_create_moderation_evidence_snapshots.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateModerationEvidenceSnapshots < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_evidence_snapshots do |t|
+      t.references :subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      t.datetime :window_start
+      t.datetime :window_end
+      t.jsonb :summary, null: false, default: {}
+      t.jsonb :fingerprint, null: false, default: {}
+      t.integer :schema_version, null: false, default: 1
+
+      t.timestamps
+    end
+
+    add_index :moderation_evidence_snapshots, [:subject_id, :created_at], name: :index_mod_evidence_snapshots_on_subject_and_created
+  end
+end

--- a/db/migrate/20260909070002_create_moderation_actions.rb
+++ b/db/migrate/20260909070002_create_moderation_actions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateModerationActions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_actions do |t|
+      t.references :subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      t.integer :action_type, null: false
+      t.datetime :performed_at, null: false
+
+      # ON DELETE SET NULL so a moderator's account deletion never removes the
+      # audit of actions they performed.
+      t.bigint :moderator_account_id
+      t.string :reason_code
+
+      t.references :evidence_snapshot, foreign_key: { to_table: :moderation_evidence_snapshots, on_delete: :nullify }, index: false
+
+      t.jsonb :metadata, null: false, default: {}
+
+      t.timestamps
+    end
+
+    safety_assured do
+      add_foreign_key :moderation_actions, :accounts, column: :moderator_account_id, on_delete: :nullify
+    end
+
+    add_index :moderation_actions, [:subject_id, :performed_at], name: :index_moderation_actions_on_subject_and_performed
+    add_index :moderation_actions, [:action_type, :performed_at], name: :index_moderation_actions_on_type_and_performed
+    add_index :moderation_actions, :evidence_snapshot_id, where: 'evidence_snapshot_id IS NOT NULL', name: :index_moderation_actions_on_evidence_snapshot
+    add_index :moderation_actions, :moderator_account_id, where: 'moderator_account_id IS NOT NULL', name: :index_moderation_actions_on_moderator
+  end
+end

--- a/db/migrate/20260909100001_add_source_event_key_to_moderation_events.rb
+++ b/db/migrate/20260909100001_add_source_event_key_to_moderation_events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddSourceEventKeyToModerationEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :moderation_interaction_events, :source_event_key, :string
+    add_column :moderation_rejection_events, :source_event_key, :string
+
+    safety_assured do
+      add_index :moderation_interaction_events, :source_event_key,
+                unique: true,
+                where: 'source_event_key IS NOT NULL',
+                name: :index_mod_interaction_events_on_source_event_key
+      add_index :moderation_rejection_events, :source_event_key,
+                unique: true,
+                where: 'source_event_key IS NOT NULL',
+                name: :index_mod_rejection_events_on_source_event_key
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -775,6 +775,34 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.index ["status_id"], name: "index_mentions_on_status_id"
   end
 
+  create_table "moderation_actions", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.integer "action_type", null: false
+    t.datetime "performed_at", null: false
+    t.bigint "moderator_account_id"
+    t.string "reason_code"
+    t.bigint "evidence_snapshot_id"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["action_type", "performed_at"], name: "index_moderation_actions_on_type_and_performed"
+    t.index ["evidence_snapshot_id"], name: "index_moderation_actions_on_evidence_snapshot", where: "(evidence_snapshot_id IS NOT NULL)"
+    t.index ["moderator_account_id"], name: "index_moderation_actions_on_moderator", where: "(moderator_account_id IS NOT NULL)"
+    t.index ["subject_id", "performed_at"], name: "index_moderation_actions_on_subject_and_performed"
+  end
+
+  create_table "moderation_evidence_snapshots", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.datetime "window_start"
+    t.datetime "window_end"
+    t.jsonb "summary", default: {}, null: false
+    t.jsonb "fingerprint", default: {}, null: false
+    t.integer "schema_version", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject_id", "created_at"], name: "index_mod_evidence_snapshots_on_subject_and_created"
+  end
+
   create_table "moderation_interaction_events", force: :cascade do |t|
     t.bigint "actor_subject_id"
     t.bigint "target_subject_id"
@@ -1434,6 +1462,10 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
+  add_foreign_key "moderation_actions", "accounts", column: "moderator_account_id", on_delete: :nullify
+  add_foreign_key "moderation_actions", "moderation_evidence_snapshots", column: "evidence_snapshot_id", on_delete: :nullify
+  add_foreign_key "moderation_actions", "moderation_subjects", column: "subject_id", on_delete: :cascade
+  add_foreign_key "moderation_evidence_snapshots", "moderation_subjects", column: "subject_id", on_delete: :cascade
   add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :nullify
   add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -811,6 +811,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.string "source_record_type"
     t.bigint "source_record_id"
     t.bigint "import_batch_id"
+    t.string "source_event_key"
     t.datetime "occurred_at", null: false
     t.datetime "observed_at", null: false
     t.jsonb "metadata", default: {}, null: false
@@ -819,6 +820,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.index ["actor_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_actor_and_occurred"
     t.index ["actor_subject_id", "target_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_actor_target_occurred"
     t.index ["event_type", "occurred_at"], name: "index_mod_interaction_events_on_type_and_occurred"
+    t.index ["source_event_key"], name: "index_mod_interaction_events_on_source_event_key", unique: true, where: "(source_event_key IS NOT NULL)"
     t.index ["target_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_target_and_occurred"
   end
 
@@ -827,6 +829,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.bigint "rejected_subject_id"
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
+    t.string "source_event_key"
     t.datetime "occurred_at", null: false
     t.datetime "observed_at", null: false
     t.jsonb "metadata", default: {}, null: false
@@ -834,6 +837,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_120001) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_type", "occurred_at"], name: "index_mod_rejection_events_on_type_and_occurred"
     t.index ["preceding_interaction_event_id"], name: "index_mod_rejection_events_on_preceding_event", where: "(preceding_interaction_event_id IS NOT NULL)"
+    t.index ["source_event_key"], name: "index_mod_rejection_events_on_source_event_key", unique: true, where: "(source_event_key IS NOT NULL)"
     t.index ["rejected_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejected_and_occurred"
     t.index ["rejected_subject_id", "rejector_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejected_rejector_occurred"
     t.index ["rejector_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejector_and_occurred"

--- a/spec/fabricators/moderation_action_fabricator.rb
+++ b/spec/fabricators/moderation_action_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:moderation_action) do
+  subject      { Fabricate(:moderation_subject) }
+  action_type  :suspend
+  performed_at { Time.now.utc }
+end

--- a/spec/fabricators/moderation_evidence_snapshot_fabricator.rb
+++ b/spec/fabricators/moderation_evidence_snapshot_fabricator.rb
@@ -1,0 +1,6 @@
+Fabricator(:moderation_evidence_snapshot) do
+  subject        { Fabricate(:moderation_subject) }
+  window_start   { 30.days.ago }
+  window_end     { Time.now.utc }
+  schema_version 1
+end

--- a/spec/lib/moderation/causality_spec.rb
+++ b/spec/lib/moderation/causality_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::Causality do
+  let(:actor_subject)    { Fabricate(:moderation_subject) }
+  let(:target_subject)   { Fabricate(:moderation_subject) }
+  let(:contacted_at)     { Time.utc(2026, 1, 1, 10, 0, 0) }
+  let(:interaction) do
+    Fabricate(
+      :moderation_interaction_event,
+      actor_subject: actor_subject,
+      target_subject: target_subject,
+      occurred_at: contacted_at
+    )
+  end
+
+  def rejection(occurred_at:, preceding: interaction)
+    Fabricate(
+      :moderation_rejection_event,
+      rejector_subject: target_subject,
+      rejected_subject: actor_subject,
+      preceding_interaction_event: preceding,
+      occurred_at: occurred_at
+    )
+  end
+
+  describe '.valid_link?' do
+    it 'is true when the rejection follows the matching contact within the window' do
+      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at + 1.hour))).to be true
+    end
+
+    it 'is false when the rejection occurs before the contact' do
+      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at - 1.hour, preceding: nil))).to be false
+    end
+
+    it 'is false when the elapsed time exceeds MAX_WINDOW' do
+      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at + described_class::MAX_WINDOW + 1.second))).to be false
+    end
+
+    it 'is false when the interaction pair is reversed' do
+      reversed = Fabricate(
+        :moderation_interaction_event,
+        actor_subject: target_subject,
+        target_subject: actor_subject,
+        occurred_at: contacted_at
+      )
+      expect(described_class.valid_link?(reversed, rejection(occurred_at: contacted_at + 1.minute, preceding: reversed))).to be false
+    end
+
+    it 'is false without a preceding interaction' do
+      expect(described_class.valid_link?(nil, rejection(occurred_at: contacted_at + 1.minute, preceding: nil))).to be false
+    end
+  end
+
+  describe '.find_preceding_interaction' do
+    it 'returns the nearest earlier contact from rejected to rejector' do
+      older = Fabricate(
+        :moderation_interaction_event,
+        actor_subject: actor_subject,
+        target_subject: target_subject,
+        occurred_at: contacted_at - 2.hours
+      )
+      newer = interaction
+
+      found = described_class.find_preceding_interaction(
+        rejected_subject: actor_subject,
+        rejector_subject: target_subject,
+        occurred_at: contacted_at + 5.minutes
+      )
+
+      expect(found).to eq newer
+      expect(found).to_not eq older
+    end
+
+    it 'ignores contacts after the rejection' do
+      earlier = interaction
+      Fabricate(
+        :moderation_interaction_event,
+        actor_subject: actor_subject,
+        target_subject: target_subject,
+        occurred_at: contacted_at + 1.hour
+      )
+
+      found = described_class.find_preceding_interaction(
+        rejected_subject: actor_subject,
+        rejector_subject: target_subject,
+        occurred_at: contacted_at
+      )
+
+      expect(found).to eq earlier
+    end
+  end
+end

--- a/spec/lib/moderation/preceding_contact_link_spec.rb
+++ b/spec/lib/moderation/preceding_contact_link_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Moderation::Causality do
+RSpec.describe Moderation::PrecedingContactLink do
   let(:actor_subject)    { Fabricate(:moderation_subject) }
   let(:target_subject)   { Fabricate(:moderation_subject) }
   let(:contacted_at)     { Time.utc(2026, 1, 1, 10, 0, 0) }
@@ -23,17 +23,17 @@ RSpec.describe Moderation::Causality do
     )
   end
 
-  describe '.valid_link?' do
+  describe '.strong_association?' do
     it 'is true when the rejection follows the matching contact within the window' do
-      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at + 1.hour))).to be true
+      expect(described_class.strong_association?(interaction, rejection(occurred_at: contacted_at + 1.hour))).to be true
     end
 
     it 'is false when the rejection occurs before the contact' do
-      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at - 1.hour, preceding: nil))).to be false
+      expect(described_class.strong_association?(interaction, rejection(occurred_at: contacted_at - 1.hour, preceding: nil))).to be false
     end
 
     it 'is false when the elapsed time exceeds MAX_WINDOW' do
-      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at + described_class::MAX_WINDOW + 1.second))).to be false
+      expect(described_class.strong_association?(interaction, rejection(occurred_at: contacted_at + described_class::MAX_WINDOW + 1.second))).to be false
     end
 
     it 'is false when the interaction pair is reversed' do
@@ -43,11 +43,11 @@ RSpec.describe Moderation::Causality do
         target_subject: actor_subject,
         occurred_at: contacted_at
       )
-      expect(described_class.valid_link?(reversed, rejection(occurred_at: contacted_at + 1.minute, preceding: reversed))).to be false
+      expect(described_class.strong_association?(reversed, rejection(occurred_at: contacted_at + 1.minute, preceding: reversed))).to be false
     end
 
     it 'is false without a preceding interaction' do
-      expect(described_class.valid_link?(nil, rejection(occurred_at: contacted_at + 1.minute, preceding: nil))).to be false
+      expect(described_class.strong_association?(nil, rejection(occurred_at: contacted_at + 1.minute, preceding: nil))).to be false
     end
   end
 

--- a/spec/lib/moderation/preceding_contact_link_spec.rb
+++ b/spec/lib/moderation/preceding_contact_link_spec.rb
@@ -49,6 +49,34 @@ RSpec.describe Moderation::PrecedingContactLink do
     it 'is false without a preceding interaction' do
       expect(described_class.strong_association?(nil, rejection(occurred_at: contacted_at + 1.minute, preceding: nil))).to be false
     end
+
+    it 'is false when any participant id is nil' do
+      nullified = Fabricate(
+        :moderation_interaction_event,
+        actor_subject: actor_subject,
+        target_subject: target_subject,
+        occurred_at: contacted_at
+      )
+      nullified.update_columns(actor_subject_id: nil, target_subject_id: nil)
+      orphan_rejection = Fabricate(
+        :moderation_rejection_event,
+        rejector_subject: target_subject,
+        rejected_subject: actor_subject,
+        preceding_interaction_event: nullified,
+        occurred_at: contacted_at + 1.minute
+      )
+      orphan_rejection.update_columns(rejector_subject_id: nil, rejected_subject_id: nil)
+
+      expect(described_class.strong_association?(nullified, orphan_rejection)).to be false
+      expect(
+        described_class.valid_pair?(
+          nullified,
+          rejected_subject_id: nil,
+          rejector_subject_id: nil,
+          occurred_at: contacted_at + 1.minute
+        )
+      ).to be false
+    end
   end
 
   describe '.find_preceding_interaction' do

--- a/spec/models/moderation/admin_action_hook_spec.rb
+++ b/spec/models/moderation/admin_action_hook_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+# Phase 4 / PR 5: a moderator action taken through Admin::AccountAction records
+# a ModerationAction plus an evidence snapshot into the ledger.
+RSpec.describe 'Moderation admin action hook', type: :model do
+  let(:moderator) { Fabricate(:account, user: Fabricate(:user, admin: true)) }
+  let(:target)    { Fabricate(:account, user: Fabricate(:user)) }
+
+  def perform(type)
+    action = Admin::AccountAction.new
+    action.assign_attributes(type: type, current_account: moderator, target_account: target)
+    action.save!
+  end
+
+  it 'records a freeze action with an evidence snapshot when disabling' do
+    expect { perform('disable') }.to change(ModerationAction, :count).by(1).and change(ModerationEvidenceSnapshot, :count).by(1)
+
+    action = ModerationAction.last
+    expect(action.action_type).to eq 'freeze'
+    expect(action.subject.account_id).to eq target.id
+    expect(action.moderator_account_id).to eq moderator.id
+    expect(action.reason_code).to eq 'disable'
+    expect(action.evidence_snapshot).to be_present
+  end
+
+  it 'maps silence to a limit action' do
+    expect { perform('silence') }.to change(ModerationAction, :count).by(1)
+    expect(ModerationAction.last.action_type).to eq 'limit'
+  end
+end

--- a/spec/models/moderation_action_spec.rb
+++ b/spec/models/moderation_action_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ModerationAction, type: :model do
+  it 'is valid with the required attributes' do
+    expect(Fabricate.build(:moderation_action)).to be_valid
+  end
+
+  it 'requires an action_type and performed_at' do
+    action = Fabricate.build(:moderation_action, action_type: nil, performed_at: nil)
+    expect(action).to_not be_valid
+    expect(action.errors.attribute_names).to include(:action_type, :performed_at)
+  end
+
+  it 'exposes the action types' do
+    expect(described_class.action_types.keys).to match_array(%w(warn limit freeze suspend delete other))
+  end
+
+  it 'optionally links a moderator and an evidence snapshot' do
+    moderator = Fabricate(:account)
+    snapshot  = Fabricate(:moderation_evidence_snapshot)
+    action    = Fabricate(:moderation_action, moderator_account: moderator, evidence_snapshot: snapshot)
+
+    expect(action.moderator_account).to eq moderator
+    expect(action.evidence_snapshot).to eq snapshot
+  end
+end

--- a/spec/models/moderation_evidence_snapshot_spec.rb
+++ b/spec/models/moderation_evidence_snapshot_spec.rb
@@ -25,4 +25,16 @@ RSpec.describe ModerationEvidenceSnapshot, type: :model do
     expect(snapshot.linked_negative_target_subject_ids).to eq [1]
     expect(snapshot.correlated_negative_target_subject_ids).to eq [2, 3]
   end
+
+  it 'omits nil ids from fingerprint readers' do
+    snapshot = Fabricate(
+      :moderation_evidence_snapshot,
+      fingerprint: {
+        'linked_negative_target_subject_ids' => [1, nil],
+        'correlated_negative_target_subject_ids' => [nil, 2],
+      }
+    )
+    expect(snapshot.linked_negative_target_subject_ids).to eq [1]
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [2]
+  end
 end

--- a/spec/models/moderation_evidence_snapshot_spec.rb
+++ b/spec/models/moderation_evidence_snapshot_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ModerationEvidenceSnapshot, type: :model do
+  it 'is valid with the required attributes' do
+    expect(Fabricate.build(:moderation_evidence_snapshot)).to be_valid
+  end
+
+  it 'requires a positive integer schema_version' do
+    expect(Fabricate.build(:moderation_evidence_snapshot, schema_version: 0)).to_not be_valid
+  end
+
+  it 'reads the negative target set from the fingerprint' do
+    snapshot = Fabricate(:moderation_evidence_snapshot, fingerprint: { 'negative_target_subject_ids' => [1, 2, 3] })
+    expect(snapshot.negative_target_subject_ids).to eq [1, 2, 3]
+  end
+end

--- a/spec/models/moderation_evidence_snapshot_spec.rb
+++ b/spec/models/moderation_evidence_snapshot_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe ModerationEvidenceSnapshot, type: :model do
     snapshot = Fabricate(:moderation_evidence_snapshot, fingerprint: { 'negative_target_subject_ids' => [1, 2, 3] })
     expect(snapshot.negative_target_subject_ids).to eq [1, 2, 3]
   end
+
+  it 'reads the weak same-window correlation set separately from causal targets' do
+    snapshot = Fabricate(
+      :moderation_evidence_snapshot,
+      fingerprint: {
+        'negative_target_subject_ids' => [1],
+        'correlated_negative_target_subject_ids' => [2, 3],
+      }
+    )
+    expect(snapshot.negative_target_subject_ids).to eq [1]
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [2, 3]
+  end
 end

--- a/spec/models/moderation_evidence_snapshot_spec.rb
+++ b/spec/models/moderation_evidence_snapshot_spec.rb
@@ -9,20 +9,20 @@ RSpec.describe ModerationEvidenceSnapshot, type: :model do
     expect(Fabricate.build(:moderation_evidence_snapshot, schema_version: 0)).to_not be_valid
   end
 
-  it 'reads the negative target set from the fingerprint' do
-    snapshot = Fabricate(:moderation_evidence_snapshot, fingerprint: { 'negative_target_subject_ids' => [1, 2, 3] })
-    expect(snapshot.negative_target_subject_ids).to eq [1, 2, 3]
+  it 'reads the linked negative target set from the fingerprint' do
+    snapshot = Fabricate(:moderation_evidence_snapshot, fingerprint: { 'linked_negative_target_subject_ids' => [1, 2, 3] })
+    expect(snapshot.linked_negative_target_subject_ids).to eq [1, 2, 3]
   end
 
-  it 'reads the weak same-window correlation set separately from causal targets' do
+  it 'reads the weak same-window correlation set separately from linked targets' do
     snapshot = Fabricate(
       :moderation_evidence_snapshot,
       fingerprint: {
-        'negative_target_subject_ids' => [1],
+        'linked_negative_target_subject_ids' => [1],
         'correlated_negative_target_subject_ids' => [2, 3],
       }
     )
-    expect(snapshot.negative_target_subject_ids).to eq [1]
+    expect(snapshot.linked_negative_target_subject_ids).to eq [1]
     expect(snapshot.correlated_negative_target_subject_ids).to eq [2, 3]
   end
 end

--- a/spec/services/moderation/action_recorder_spec.rb
+++ b/spec/services/moderation/action_recorder_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::ActionRecorder, type: :service do
+  let(:account)   { Fabricate(:account) }
+  let(:moderator) { Fabricate(:account) }
+
+  describe '.record' do
+    it 'records an action and generates an evidence snapshot' do
+      expect { described_class.record(account: account, action_type: :suspend, moderator: moderator, reason_code: 'suspend') }
+        .to change(ModerationAction, :count).by(1)
+        .and change(ModerationEvidenceSnapshot, :count).by(1)
+
+      action = ModerationAction.last
+      expect(action.action_type).to eq 'suspend'
+      expect(action.subject.account_id).to eq account.id
+      expect(action.moderator_account_id).to eq moderator.id
+      expect(action.reason_code).to eq 'suspend'
+      expect(action.evidence_snapshot).to be_present
+    end
+
+    it 'is failure-tolerant and returns nil on error' do
+      allow(Rails.logger).to receive(:warn)
+
+      result = nil
+      expect { result = described_class.record(account: nil, action_type: :suspend) }.to_not change(ModerationAction, :count)
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/services/moderation/event_recorder_spec.rb
+++ b/spec/services/moderation/event_recorder_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe Moderation::EventRecorder, type: :service do
       expect(event.preceding_interaction_event).to eq contact
     end
 
+    it 'auto-links the nearest earlier contact when no preceding interaction is given' do
+      older = described_class.record_interaction(actor: actor, target: target, event_type: :mention, occurred_at: 3.hours.ago)
+      newer = described_class.record_interaction(actor: actor, target: target, event_type: :follow, occurred_at: 1.hour.ago)
+
+      event = described_class.record_rejection(rejector: target, rejected: actor, event_type: :block)
+
+      expect(event.preceding_interaction_event).to eq newer
+      expect(event.preceding_interaction_event).to_not eq older
+    end
+
+    it 'does not link a later contact as the cause of an earlier rejection' do
+      event = described_class.record_rejection(rejector: target, rejected: actor, event_type: :block, occurred_at: 2.hours.ago)
+      described_class.record_interaction(actor: actor, target: target, event_type: :mention, occurred_at: 1.hour.ago)
+
+      expect(event.reload.preceding_interaction_event).to be_nil
+    end
+
     it 'does not raise and returns nil on failure' do
       allow(Rails.logger).to receive(:warn)
 
@@ -73,6 +90,68 @@ RSpec.describe Moderation::EventRecorder, type: :service do
       end.to_not change(ModerationRejectionEvent, :count)
 
       expect(result).to be_nil
+    end
+  end
+
+  describe 'source-event idempotency' do
+    it 'does not insert a second interaction for the same source record' do
+      status = Fabricate(:status, account: actor)
+      favourite = Fabricate(:favourite, account: actor, status: status)
+
+      first = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+      second = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+
+      expect(ModerationInteractionEvent.count).to eq 1
+      expect(second.id).to eq first.id
+      expect(first.source_event_key).to eq "Favourite:#{favourite.id}:favourite"
+    end
+
+    it 'returns the existing row when a uniqueness race loses the insert' do
+      status = Fabricate(:status, account: actor)
+      favourite = Fabricate(:favourite, account: actor, status: status)
+      first = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+      key = first.source_event_key
+      lookups = 0
+
+      allow(ModerationInteractionEvent).to receive(:find_by).and_wrap_original do |method, *args|
+        attrs = args.first
+        if attrs.is_a?(Hash) && attrs[:source_event_key] == key
+          lookups += 1
+          lookups == 1 ? nil : method.call(*args)
+        else
+          method.call(*args)
+        end
+      end
+      allow(ModerationInteractionEvent).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'idx')
+
+      raced = described_class.new.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+
+      expect(raced.id).to eq first.id
+      expect(lookups).to be >= 1
     end
   end
 end

--- a/spec/services/moderation/event_recorder_spec.rb
+++ b/spec/services/moderation/event_recorder_spec.rb
@@ -118,6 +118,31 @@ RSpec.describe Moderation::EventRecorder, type: :service do
       expect(first.source_event_key).to eq "Favourite:#{favourite.id}:favourite"
     end
 
+    it 'rejects a second insert with the same source_event_key at the database' do
+      status = Fabricate(:status, account: actor)
+      favourite = Fabricate(:favourite, account: actor, status: status)
+      first = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+
+      expect do
+        ModerationInteractionEvent.create!(
+          actor_subject: first.actor_subject,
+          target_subject: first.target_subject,
+          event_type: :favourite,
+          source_event_key: first.source_event_key,
+          occurred_at: Time.now.utc,
+          observed_at: Time.now.utc
+        )
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+
+      expect(ModerationInteractionEvent.where(source_event_key: first.source_event_key).count).to eq 1
+    end
+
     it 'returns the existing row when a uniqueness race loses the insert' do
       status = Fabricate(:status, account: actor)
       favourite = Fabricate(:favourite, account: actor, status: status)

--- a/spec/services/moderation/event_recorder_spec.rb
+++ b/spec/services/moderation/event_recorder_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Moderation::EventRecorder, type: :service do
       expect(event.preceding_interaction_event).to_not eq older
     end
 
-    it 'does not link a later contact as the cause of an earlier rejection' do
+    it 'does not treat a later contact as a preceding-contact link for an earlier rejection' do
       event = described_class.record_rejection(rejector: target, rejected: actor, event_type: :block, occurred_at: 2.hours.ago)
       described_class.record_interaction(actor: actor, target: target, event_type: :mention, occurred_at: 1.hour.ago)
 

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -84,6 +84,54 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.correlated_negative_target_subject_ids).to eq [a_subject.id]
   end
 
+  it 'omits nullified counterpart ids from fingerprints and contact counts' do
+    actor_subject = ModerationSubject.for_account!(actor)
+    a_subject     = ModerationSubject.for_account!(a)
+    b_subject     = ModerationSubject.for_account!(b)
+
+    kept = Fabricate(
+      :moderation_interaction_event,
+      actor_subject: actor_subject,
+      target_subject: a_subject,
+      event_type: :mention,
+      occurred_at: 2.hours.ago
+    )
+    orphan_contact = Fabricate(
+      :moderation_interaction_event,
+      actor_subject: actor_subject,
+      target_subject: b_subject,
+      event_type: :follow,
+      occurred_at: 2.hours.ago
+    )
+    orphan_contact.update_columns(target_subject_id: nil)
+
+    Fabricate(
+      :moderation_rejection_event,
+      rejector_subject: a_subject,
+      rejected_subject: actor_subject,
+      preceding_interaction_event: kept,
+      event_type: :block,
+      occurred_at: 1.hour.ago
+    )
+    orphan_rejection = Fabricate(
+      :moderation_rejection_event,
+      rejector_subject: b_subject,
+      rejected_subject: actor_subject,
+      event_type: :block,
+      occurred_at: 1.hour.ago
+    )
+    orphan_rejection.update_columns(rejector_subject_id: nil)
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.summary['interactions_count']).to eq 2
+    expect(snapshot.summary['unique_contacts']).to eq 1
+    expect(snapshot.linked_negative_target_subject_ids).to eq [a_subject.id]
+    expect(snapshot.linked_negative_target_subject_ids).to_not include(nil)
+    expect(snapshot.correlated_negative_target_subject_ids).to be_empty
+    expect(snapshot.fingerprint['linked_negative_target_subject_ids']).to_not include(nil)
+  end
+
   it 'respects the window boundary' do
     Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention, occurred_at: 100.days.ago)
 

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
   let(:c)     { Fabricate(:account, username: 'ccc') }
   let(:d)     { Fabricate(:account, username: 'ddd') }
 
-  it 'summarises interactions/rejections and captures the negative target set' do
+  def subject_for(account)
+    ModerationSubject.find_by(account_id: account.id)
+  end
+
+  it 'summarises interactions/rejections and captures the causal negative target set' do
     Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention)
     Moderation::EventRecorder.record_interaction(actor: actor, target: b, event_type: :follow)
     Moderation::EventRecorder.record_interaction(actor: actor, target: c, event_type: :mention)
 
-    # a and b were contacted and rejected the actor -> negative targets.
+    # a and b were contacted and then rejected the actor -> strong negative targets.
     Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block)
     Moderation::EventRecorder.record_rejection(rejector: b, rejected: actor, event_type: :report)
     # d rejected the actor but was never contacted -> responder, not a target.
@@ -26,14 +30,57 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.summary['reports_received']).to eq 1
     expect(snapshot.summary['negative_responders']).to eq 3
     expect(snapshot.summary['negative_target_count']).to eq 2
+    expect(snapshot.summary['correlated_negative_target_count']).to eq 0
 
-    a_subject = ModerationSubject.find_by(account_id: a.id)
-    b_subject = ModerationSubject.find_by(account_id: b.id)
-    expect(snapshot.negative_target_subject_ids).to match_array([a_subject.id, b_subject.id])
+    expect(snapshot.negative_target_subject_ids).to match_array([subject_for(a).id, subject_for(b).id])
+    expect(snapshot.correlated_negative_target_subject_ids).to be_empty
 
     expect(snapshot.schema_version).to eq described_class::SCHEMA_VERSION
     expect(snapshot.window_end).to be_present
     expect(snapshot.window_start).to be_present
+    expect(snapshot.fingerprint['coverage']).to eq described_class::INBOUND_ACTIVITYPUB_COVERAGE
+    expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+  end
+
+  it 'does not put unordered same-window overlap into negative_target_subject_ids' do
+    # B rejects A first, then A contacts B — same snapshot window, no causality.
+    Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block, occurred_at: 2.hours.ago)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention, occurred_at: 1.hour.ago)
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.summary['interactions_count']).to eq 1
+    expect(snapshot.summary['blocks_received']).to eq 1
+    expect(snapshot.summary['negative_target_count']).to eq 0
+    expect(snapshot.negative_target_subject_ids).to be_empty
+    expect(snapshot.summary['correlated_negative_target_count']).to eq 1
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [subject_for(a).id]
+  end
+
+  it 'treats an unlinked same-window pair as a weak correlation, not a causal target' do
+    actor_subject = ModerationSubject.for_account!(actor)
+    a_subject     = ModerationSubject.for_account!(a)
+
+    Fabricate(
+      :moderation_interaction_event,
+      actor_subject: actor_subject,
+      target_subject: a_subject,
+      event_type: :mention,
+      occurred_at: 3.hours.ago
+    )
+    Fabricate(
+      :moderation_rejection_event,
+      rejector_subject: a_subject,
+      rejected_subject: actor_subject,
+      event_type: :block,
+      preceding_interaction_event: nil,
+      occurred_at: 1.hour.ago
+    )
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.negative_target_subject_ids).to be_empty
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [a_subject.id]
   end
 
   it 'respects the window boundary' do

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
+  let(:actor) { Fabricate(:account, username: 'actor') }
+  let(:a)     { Fabricate(:account, username: 'aaa') }
+  let(:b)     { Fabricate(:account, username: 'bbb') }
+  let(:c)     { Fabricate(:account, username: 'ccc') }
+  let(:d)     { Fabricate(:account, username: 'ddd') }
+
+  it 'summarises interactions/rejections and captures the negative target set' do
+    Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: b, event_type: :follow)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: c, event_type: :mention)
+
+    # a and b were contacted and rejected the actor -> negative targets.
+    Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block)
+    Moderation::EventRecorder.record_rejection(rejector: b, rejected: actor, event_type: :report)
+    # d rejected the actor but was never contacted -> responder, not a target.
+    Moderation::EventRecorder.record_rejection(rejector: d, rejected: actor, event_type: :block)
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.summary['interactions_count']).to eq 3
+    expect(snapshot.summary['unique_contacts']).to eq 3
+    expect(snapshot.summary['blocks_received']).to eq 2
+    expect(snapshot.summary['reports_received']).to eq 1
+    expect(snapshot.summary['negative_responders']).to eq 3
+    expect(snapshot.summary['negative_target_count']).to eq 2
+
+    a_subject = ModerationSubject.find_by(account_id: a.id)
+    b_subject = ModerationSubject.find_by(account_id: b.id)
+    expect(snapshot.negative_target_subject_ids).to match_array([a_subject.id, b_subject.id])
+
+    expect(snapshot.schema_version).to eq described_class::SCHEMA_VERSION
+    expect(snapshot.window_end).to be_present
+    expect(snapshot.window_start).to be_present
+  end
+
+  it 'respects the window boundary' do
+    Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention, occurred_at: 100.days.ago)
+
+    snapshot = described_class.new.call(actor, window: 30.days)
+    expect(snapshot.summary['interactions_count']).to eq 0
+  end
+end

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     ModerationSubject.find_by(account_id: account.id)
   end
 
-  it 'summarises interactions/rejections and captures the causal negative target set' do
+  it 'summarises interactions/rejections and captures the linked negative target set' do
     Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention)
     Moderation::EventRecorder.record_interaction(actor: actor, target: b, event_type: :follow)
     Moderation::EventRecorder.record_interaction(actor: actor, target: c, event_type: :mention)
 
-    # a and b were contacted and then rejected the actor -> strong negative targets.
+    # a and b were contacted and then rejected the actor -> linked negative targets.
     Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block)
     Moderation::EventRecorder.record_rejection(rejector: b, rejected: actor, event_type: :report)
     # d rejected the actor but was never contacted -> responder, not a target.
@@ -29,10 +29,10 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.summary['blocks_received']).to eq 2
     expect(snapshot.summary['reports_received']).to eq 1
     expect(snapshot.summary['negative_responders']).to eq 3
-    expect(snapshot.summary['negative_target_count']).to eq 2
+    expect(snapshot.summary['linked_negative_target_count']).to eq 2
     expect(snapshot.summary['correlated_negative_target_count']).to eq 0
 
-    expect(snapshot.negative_target_subject_ids).to match_array([subject_for(a).id, subject_for(b).id])
+    expect(snapshot.linked_negative_target_subject_ids).to match_array([subject_for(a).id, subject_for(b).id])
     expect(snapshot.correlated_negative_target_subject_ids).to be_empty
 
     expect(snapshot.schema_version).to eq described_class::SCHEMA_VERSION
@@ -40,10 +40,11 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.window_start).to be_present
     expect(snapshot.fingerprint['coverage']).to eq described_class::INBOUND_ACTIVITYPUB_COVERAGE
     expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'deferred'
   end
 
-  it 'does not put unordered same-window overlap into negative_target_subject_ids' do
-    # B rejects A first, then A contacts B — same snapshot window, no causality.
+  it 'does not put unordered same-window overlap into linked_negative_target_subject_ids' do
+    # B rejects A first, then A contacts B — same snapshot window, no preceding-contact link.
     Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block, occurred_at: 2.hours.ago)
     Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention, occurred_at: 1.hour.ago)
 
@@ -51,13 +52,13 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
 
     expect(snapshot.summary['interactions_count']).to eq 1
     expect(snapshot.summary['blocks_received']).to eq 1
-    expect(snapshot.summary['negative_target_count']).to eq 0
-    expect(snapshot.negative_target_subject_ids).to be_empty
+    expect(snapshot.summary['linked_negative_target_count']).to eq 0
+    expect(snapshot.linked_negative_target_subject_ids).to be_empty
     expect(snapshot.summary['correlated_negative_target_count']).to eq 1
     expect(snapshot.correlated_negative_target_subject_ids).to eq [subject_for(a).id]
   end
 
-  it 'treats an unlinked same-window pair as a weak correlation, not a causal target' do
+  it 'treats an unlinked same-window pair as a weak correlation, not a linked target' do
     actor_subject = ModerationSubject.for_account!(actor)
     a_subject     = ModerationSubject.for_account!(a)
 
@@ -79,7 +80,7 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
 
     snapshot = described_class.new.call(actor)
 
-    expect(snapshot.negative_target_subject_ids).to be_empty
+    expect(snapshot.linked_negative_target_subject_ids).to be_empty
     expect(snapshot.correlated_negative_target_subject_ids).to eq [a_subject.id]
   end
 

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
       expect(event.event_type).to eq 'block'
       expect(event.rejector_subject.account_id).to eq alice.id
       expect(event.rejected_subject.account_id).to eq bob.id
+      expect(event.source_event_key).to start_with('Block:')
+    end
+
+    it 'links the preceding follow when the blocked account had contacted the blocker' do
+      FollowService.new.call(bob, alice)
+      BlockService.new.call(alice, bob)
+
+      event = last_rejection
+      expect(event.preceding_interaction_event).to be_present
+      expect(event.preceding_interaction_event.event_type).to eq 'follow'
+      expect(event.preceding_interaction_event.actor_subject.account_id).to eq bob.id
     end
   end
 

--- a/spec/services/moderation/ledger_lifecycle_spec.rb
+++ b/spec/services/moderation/ledger_lifecycle_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+# Composed lifecycle on the merged foundation (#26/#28/#29/#30/#31) plus #32.
+# Individual PR specs being green does not validate this path.
+RSpec.describe 'Moderation ledger composed lifecycle', type: :service do
+  def remote_account(username, domain)
+    Fabricate(
+      :account,
+      username: username,
+      domain: domain,
+      uri: "https://#{domain}/users/#{username}",
+      inbox_url: "https://#{domain}/inbox",
+      protocol: :activitypub
+    )
+  end
+
+  it 'preserves linked/correlated, idempotent evidence across import, action, deletion, and retention' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      alice     = Fabricate(:account, username: 'alice_lifecycle')
+      bob       = remote_account('bob_lifecycle', 'bob.example')
+      carol     = Fabricate(:account, username: 'carol_lifecycle')
+      moderator = Fabricate(:account, user: Fabricate(:user, admin: true))
+
+      import = instance_double(Import, id: 9_001)
+      2.times do
+        Moderation::FollowImportRecorder.record_batch(
+          account: alice,
+          accts: [bob.acct],
+          import: import,
+          mode: :merge
+        )
+      end
+      expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+
+      status = Fabricate(:status, account: alice)
+      favourite = Fabricate(:favourite, account: alice, status: status)
+      2.times do
+        Moderation::EventRecorder.record_interaction(
+          actor: alice,
+          target: bob,
+          event_type: :favourite,
+          status: status,
+          source_record: favourite
+        )
+      end
+      expect(ModerationInteractionEvent.where(source_event_key: "Favourite:#{favourite.id}:favourite").count).to eq 1
+
+      contact = Moderation::EventRecorder.record_interaction(actor: alice, target: bob, event_type: :follow)
+      rejection = Moderation::EventRecorder.record_rejection(rejector: bob, rejected: alice, event_type: :block)
+      expect(rejection.preceding_interaction_event).to eq contact
+
+      Moderation::EventRecorder.record_rejection(rejector: carol, rejected: alice, event_type: :block, occurred_at: 3.hours.ago)
+      Moderation::EventRecorder.record_interaction(actor: alice, target: carol, event_type: :mention, occurred_at: 1.hour.ago)
+
+      action = Admin::AccountAction.new
+      action.assign_attributes(type: 'silence', current_account: moderator, target_account: alice)
+      action.save!
+
+      snapshot = ModerationAction.last.evidence_snapshot
+      bob_subject = contact.target_subject
+      carol_subject = ModerationSubject.find_by(account_id: carol.id)
+      alice_subject = contact.actor_subject
+
+      expect(snapshot.linked_negative_target_subject_ids).to include(bob_subject.id)
+      expect(snapshot.linked_negative_target_subject_ids).to_not include(carol_subject.id)
+      expect(snapshot.correlated_negative_target_subject_ids).to include(carol_subject.id)
+      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'deferred'
+      expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+
+      expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+
+      expect { DeleteAccountService.new.call(bob, reserve_username: false, skip_side_effects: true) }
+        .to_not change(ModerationInteractionEvent, :count)
+
+      bob_subject.reload.tombstone!(now: 40.days.ago)
+      Scheduler::ModerationLedgerRetentionScheduler.new.perform
+
+      expect(ModerationSubject.exists?(alice_subject.id)).to be true
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+      expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+      expect(ModerationInteractionEvent.where(actor_subject_id: alice_subject.id)).to exist
+      expect(ModerationRejectionEvent.where(rejected_subject_id: alice_subject.id)).to exist
+      expect(ModerationEvidenceSnapshot.exists?(snapshot.id)).to be true
+    end
+  end
+
+  it 'keeps evidence after a counterpart subject id is nullified while the other participant is retained' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      alice = Fabricate(:account, username: 'alice_null_counterpart')
+      bob   = Fabricate(:account, username: 'bob_null_counterpart')
+
+      contact = Moderation::EventRecorder.record_interaction(actor: alice, target: bob, event_type: :follow)
+      rejection = Moderation::EventRecorder.record_rejection(rejector: bob, rejected: alice, event_type: :block)
+      alice_subject = contact.actor_subject
+      bob_subject   = contact.target_subject
+
+      contact.update_columns(target_subject_id: nil)
+      rejection.update_columns(rejector_subject_id: nil)
+      bob_subject.update!(deleted_at: 40.days.ago, retention_until: 10.days.ago)
+
+      Scheduler::ModerationLedgerRetentionScheduler.new.perform
+
+      expect(ModerationSubject.exists?(alice_subject.id)).to be true
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+      expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+      expect(ModerationSubject.exists?(bob_subject.id)).to be false
+
+      snapshot = Moderation::EvidenceSnapshotService.new.call(alice)
+      expect(snapshot.linked_negative_target_subject_ids).to be_empty
+      expect(snapshot.fingerprint['linked_negative_target_subject_ids']).to_not include(nil)
+      expect(snapshot.summary['unique_contacts']).to eq 0
+    end
+  end
+
+  it 'deletes events once every remaining participant is expired or null' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      expired_a = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+      expired_b = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+      both_expired = Fabricate(:moderation_interaction_event, actor_subject: expired_a, target_subject: expired_b)
+      all_null = Fabricate(:moderation_interaction_event, actor_subject: expired_a, target_subject: expired_b)
+      all_null.update_columns(actor_subject_id: nil, target_subject_id: nil)
+
+      Scheduler::ModerationLedgerRetentionScheduler.new.perform
+
+      expect(ModerationInteractionEvent.exists?(both_expired.id)).to be false
+      expect(ModerationInteractionEvent.exists?(all_null.id)).to be false
+      expect(ModerationSubject.exists?(expired_a.id)).to be false
+      expect(ModerationSubject.exists?(expired_b.id)).to be false
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 5 of the moderation-signal foundation (design memo §5.4/§5.5/§15, Phase 4 "Evidence Snapshot"). When a moderator acts on an account, this records the action and captures a point-in-time **evidence snapshot** so the reasoning behind the action can be reviewed later — even after the underlying records are gone — and to provide a baseline for comparing behaviour after a suspension. Still recording only; no scoring or enforcement.

### Schema

- **`moderation_evidence_snapshots`** — `subject_id` (→ `moderation_subjects` `ON DELETE CASCADE`), `window_start`/`window_end`, `summary` (jsonb scalar counts), `fingerprint` (jsonb sets), `schema_version`.
- **`moderation_actions`** — `subject_id` (`ON DELETE CASCADE`), `action_type` (`warn`/`limit`/`freeze`/`suspend`/`delete`/`other`), `performed_at`, `moderator_account_id` and `evidence_snapshot_id` (both `ON DELETE SET NULL` so the audit survives moderator-account / snapshot removal), `reason_code`, `metadata`.

### Behaviour

- **`Moderation::EvidenceSnapshotService`** summarises a subject over a window from the ledger: interaction/unique-contact counts, blocks/reports/rejects/removes/mutes received, negative responders, and the **negative target set** — the accounts the subject *contacted* that then returned a negative signal (the key artifact for later cross-account recurrence analysis). The set is stored in `fingerprint['negative_target_subject_ids']` (capped) with `schema_version`.
- **`Moderation::ActionRecorder`** records a `ModerationAction` and generates its snapshot; the class-level entry point is failure-tolerant (logs and returns `nil`, never breaking the action).
- **`Admin::AccountAction#save!`** records the action, mapping Mastodon's `suspend`/`silence`/`hard_silence`/`disable`/`none` to `suspend`/`limit`/`freeze`/`warn`, and captures a snapshot.
- `ModerationSubject` gains cascade associations so the retention cleanup (PR 3) removes snapshots/actions too.

### Scope / deferrals

- Independent of #29/#30/#31: no migration or code conflicts (this branches off `fedibird` with Phase 1 only). Import-batch metrics in the snapshot and the `delete` action hook are deferred so this PR doesn't depend on the Follow Import Ledger (#30) or the `DeleteAccountService` change (#31).
- The **admin view prototype** from the memo's PR-5 bullet is deferred to the dedicated Moderator UI phase (memo Phase 6); this PR delivers the action + snapshot data layer.

## Testing

New specs (13 examples, 0 failures):

[moderation_action_snapshot_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderation_action_snapshot_rspec.log)

Coverage: snapshot summary + negative-target-set computation and window boundary; action recording + snapshot generation + failure tolerance; model enums/validations; and the `Admin::AccountAction` hook (disable → `freeze`, silence → `limit`) recording an action + snapshot.

Regression: `admin/account_action_spec.rb` has the **same 2 pre-existing failures** with and without this change (verified against the base `fedibird` model — they are `types_for_account` ordering expectations, unrelated to the `save!` hook). Phase 1 ledger specs still pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

