### PR TITLE
Moderation ledger integrity follow-up (cross-PR review)

### DIFF
--- a/app/lib/moderation/causality.rb
+++ b/app/lib/moderation/causality.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Causality rules for linking a rejection to the contact it responded to.
+#
+# Same-window overlap of "A contacted B" and "B rejected A" is not enough to
+# treat B as a negative target. A rejection is causally linked only when:
+#
+#   * it occurred at or after the candidate interaction;
+#   * the interaction is A → B and the rejection is B → A;
+#   * the elapsed time is within MAX_WINDOW.
+#
+# Preferred evidence is +preceding_interaction_event_id+ (populated by
+# Moderation::EventRecorder). Unlinked same-window overlap is retained as a
+# weaker correlation and must not be stored in +negative_target_subject_ids+.
+module Moderation
+  module Causality
+    MAX_WINDOW = 14.days
+
+    module_function
+
+    def valid_link?(interaction, rejection)
+      return false if rejection.nil?
+
+      valid_pair?(
+        interaction,
+        rejected_subject_id: rejection.rejected_subject_id,
+        rejector_subject_id: rejection.rejector_subject_id,
+        occurred_at: rejection.occurred_at
+      )
+    end
+
+    def valid_pair?(interaction, rejected_subject_id:, rejector_subject_id:, occurred_at:)
+      return false if interaction.nil? || occurred_at.nil?
+      return false unless interaction.actor_subject_id == rejected_subject_id
+      return false unless interaction.target_subject_id == rejector_subject_id
+      return false if interaction.occurred_at.nil?
+      return false if occurred_at < interaction.occurred_at
+
+      (occurred_at - interaction.occurred_at) <= MAX_WINDOW
+    end
+
+    def find_preceding_interaction(rejected_subject:, rejector_subject:, occurred_at:)
+      return if rejected_subject.nil? || rejector_subject.nil? || occurred_at.nil?
+
+      ModerationInteractionEvent
+        .where(actor_subject_id: rejected_subject.id, target_subject_id: rejector_subject.id)
+        .where('occurred_at <= ?', occurred_at)
+        .where('occurred_at >= ?', occurred_at - MAX_WINDOW)
+        .order(occurred_at: :desc, id: :desc)
+        .first
+    end
+  end
+end

--- a/app/lib/moderation/retention_policy.rb
+++ b/app/lib/moderation/retention_policy.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Configurable retention policy for the moderation ledger. The retention period
+# is intentionally not hardcoded: it is read from the environment so operators
+# can tune it after privacy/legal review.
+#
+# A tombstoned subject (its account was deleted/purged) is kept until
+# +retention_until+, after which the retention cleanup scheduler removes it and,
+# via foreign keys, its recorded events. A non-positive value disables
+# expiry (records are kept indefinitely).
+module Moderation
+  module RetentionPolicy
+    DEFAULT_RETENTION_DAYS = 365
+
+    module_function
+
+    def retention_days
+      value = ENV.fetch('MODERATION_LEDGER_RETENTION_DAYS', DEFAULT_RETENTION_DAYS).to_i
+      value.negative? ? 0 : value
+    rescue ArgumentError, TypeError
+      DEFAULT_RETENTION_DAYS
+    end
+
+    def enabled?
+      retention_days.positive?
+    end
+
+    def duration
+      retention_days.days
+    end
+
+    # When a subject tombstoned at +from+ should expire, or nil when retention
+    # is disabled (kept indefinitely).
+    def expire_at(from = Time.now.utc)
+      return nil unless enabled?
+
+      from + duration
+    end
+  end
+end

--- a/app/lib/moderation/retention_policy.rb
+++ b/app/lib/moderation/retention_policy.rb
@@ -5,9 +5,10 @@
 # can tune it after privacy/legal review.
 #
 # A tombstoned subject (its account was deleted/purged) is kept until
-# +retention_until+, after which the retention cleanup scheduler removes it and,
-# via foreign keys, its recorded events. A non-positive value disables
-# expiry (records are kept indefinitely).
+# +retention_until+. The scheduler then expires it only when no shared
+# event still involves a retained counterpart — so one participant's
+# expiry cannot erase another subject's evidence. A non-positive value
+# disables expiry (records are kept indefinitely).
 module Moderation
   module RetentionPolicy
     DEFAULT_RETENTION_DAYS = 365

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -40,6 +40,7 @@ class Admin::AccountAction
     process_email!
     process_reports!
     process_queue!
+    record_moderation_action!
   end
 
   def report
@@ -141,6 +142,27 @@ class Admin::AccountAction
 
   def text_for_warning
     [warning_preset&.text, text].compact.join("\n\n")
+  end
+
+  # Record the moderator action + an evidence snapshot into the moderation
+  # ledger. Failure-tolerant, so it never breaks the action itself.
+  def record_moderation_action!
+    Moderation::ActionRecorder.record(
+      account: target_account,
+      action_type: moderation_action_type,
+      moderator: current_account,
+      reason_code: type
+    )
+  end
+
+  def moderation_action_type
+    case type
+    when 'suspend'                 then :suspend
+    when 'silence', 'hard_silence' then :limit
+    when 'disable'                 then :freeze
+    when 'none'                    then :warn
+    else :other
+    end
   end
 
   def queue_suspension_worker!

--- a/app/models/follow_import_batch.rb
+++ b/app/models/follow_import_batch.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: follow_import_batches
+#
+#  id                      :bigint(8)        not null, primary key
+#  subject_id              :bigint(8)        not null
+#  import_id               :bigint(8)
+#  imported_at             :datetime         not null
+#  mode                    :integer          default("unknown"), not null
+#  target_count            :integer          default(0), not null
+#  resolved_target_count   :integer          default(0), not null
+#  unresolved_target_count :integer          default(0), not null
+#  account_age_seconds     :bigint(8)
+#  migration_evidence      :integer          default("none"), not null
+#  metadata                :jsonb            not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# A single follow-import event, recorded before the follows are executed.
+#
+# Follow import is an especially valuable observation point because the entire
+# target set is presented to the server up front. The batch stores the summary
+# (counts, mode, account age, migration evidence) and its `targets` capture the
+# individual contacted accounts.
+class FollowImportBatch < ApplicationRecord
+  self.table_name = 'follow_import_batches'
+
+  enum mode: { unknown: 0, merge: 1, overwrite: 2 }, _suffix: :mode
+  enum migration_evidence: { none: 0, weak: 1, strong: 2 }, _prefix: :migration
+
+  belongs_to :subject, class_name: 'ModerationSubject'
+
+  has_many :targets, class_name: 'FollowImportTarget', foreign_key: :batch_id, inverse_of: :batch, dependent: :destroy
+
+  validates :imported_at, presence: true
+  validates :target_count, :resolved_target_count, :unresolved_target_count, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/models/follow_import_batch.rb
+++ b/app/models/follow_import_batch.rb
@@ -36,4 +36,5 @@ class FollowImportBatch < ApplicationRecord
 
   validates :imported_at, presence: true
   validates :target_count, :resolved_target_count, :unresolved_target_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :import_id, uniqueness: { allow_nil: true }
 end

--- a/app/models/follow_import_target.rb
+++ b/app/models/follow_import_target.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: follow_import_targets
+#
+#  id                       :bigint(8)        not null, primary key
+#  batch_id                 :bigint(8)        not null
+#  target_subject_id        :bigint(8)
+#  target_key_hash          :string
+#  position                 :integer
+#  prior_relationship_state :jsonb
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# A single target within a follow-import batch. `target_subject` is set when the
+# imported account address resolves to a known account at import time; otherwise
+# `target_key_hash` holds a pseudonymous stable key for the unresolved address.
+class FollowImportTarget < ApplicationRecord
+  self.table_name = 'follow_import_targets'
+
+  belongs_to :batch, class_name: 'FollowImportBatch', inverse_of: :targets
+  belongs_to :target_subject, class_name: 'ModerationSubject', optional: true
+
+  validates :target_subject_id, presence: true, unless: -> { target_key_hash.present? }
+
+  def resolved?
+    target_subject_id.present?
+  end
+end

--- a/app/models/moderation_action.rb
+++ b/app/models/moderation_action.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_actions
+#
+#  id                   :bigint(8)        not null, primary key
+#  subject_id           :bigint(8)        not null
+#  action_type          :integer          not null
+#  performed_at         :datetime         not null
+#  moderator_account_id :bigint(8)
+#  reason_code          :string
+#  evidence_snapshot_id :bigint(8)
+#  metadata             :jsonb            not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+# A moderator action taken against a subject (warn/limit/freeze/suspend/delete/
+# other), with an optional link to the evidence snapshot captured at the time.
+# Kept independently of Mastodon's own moderation records so the history
+# survives account/report deletion.
+class ModerationAction < ApplicationRecord
+  self.table_name = 'moderation_actions'
+
+  enum action_type: {
+    warn: 0,
+    limit: 1,
+    freeze: 2,
+    suspend: 3,
+    delete: 4,
+    other: 5,
+  }, _suffix: :action
+
+  belongs_to :subject, class_name: 'ModerationSubject'
+  belongs_to :moderator_account, class_name: 'Account', optional: true
+  belongs_to :evidence_snapshot, class_name: 'ModerationEvidenceSnapshot', optional: true
+
+  validates :action_type, presence: true
+  validates :performed_at, presence: true
+end

--- a/app/models/moderation_evidence_snapshot.rb
+++ b/app/models/moderation_evidence_snapshot.rb
@@ -33,4 +33,10 @@ class ModerationEvidenceSnapshot < ApplicationRecord
   def negative_target_subject_ids
     Array(fingerprint['negative_target_subject_ids'])
   end
+
+  # Same-window overlap without a proven contact→rejection order. Must not be
+  # treated as a causal negative-target set.
+  def correlated_negative_target_subject_ids
+    Array(fingerprint['correlated_negative_target_subject_ids'])
+  end
 end

--- a/app/models/moderation_evidence_snapshot.rb
+++ b/app/models/moderation_evidence_snapshot.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_evidence_snapshots
+#
+#  id             :bigint(8)        not null, primary key
+#  subject_id     :bigint(8)        not null
+#  window_start   :datetime
+#  window_end     :datetime
+#  summary        :jsonb            not null
+#  fingerprint    :jsonb            not null
+#  schema_version :integer          default(1), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# A point-in-time evidence snapshot for a moderation subject, generated when a
+# moderator action is taken. It fixes the reasoning behind an action so it can
+# be reviewed later even after the underlying records are gone, and provides a
+# baseline for comparing behaviour after a suspension.
+#
+# +summary+ holds scalar counts; +fingerprint+ holds sets such as the negative
+# target set. +schema_version+ tracks the shape of those payloads.
+class ModerationEvidenceSnapshot < ApplicationRecord
+  self.table_name = 'moderation_evidence_snapshots'
+
+  belongs_to :subject, class_name: 'ModerationSubject'
+
+  has_many :moderation_actions, class_name: 'ModerationAction', foreign_key: :evidence_snapshot_id, inverse_of: :evidence_snapshot, dependent: :nullify
+
+  validates :schema_version, numericality: { only_integer: true, greater_than: 0 }
+
+  def negative_target_subject_ids
+    Array(fingerprint['negative_target_subject_ids'])
+  end
+end

--- a/app/models/moderation_interaction_event.rb
+++ b/app/models/moderation_interaction_event.rb
@@ -5,8 +5,8 @@
 # Table name: moderation_interaction_events
 #
 #  id                 :bigint(8)        not null, primary key
-#  actor_subject_id   :bigint(8)        not null
-#  target_subject_id  :bigint(8)        not null
+#  actor_subject_id   :bigint(8)
+#  target_subject_id  :bigint(8)
 #  event_type         :integer          not null
 #  status_id          :bigint(8)
 #  source_record_type :string
@@ -39,8 +39,8 @@ class ModerationInteractionEvent < ApplicationRecord
     follow_import: 7,
   }, _suffix: :event
 
-  belongs_to :actor_subject, class_name: 'ModerationSubject', inverse_of: :actor_interaction_events
-  belongs_to :target_subject, class_name: 'ModerationSubject', inverse_of: :target_interaction_events
+  belongs_to :actor_subject, class_name: 'ModerationSubject', inverse_of: :actor_interaction_events, optional: true
+  belongs_to :target_subject, class_name: 'ModerationSubject', inverse_of: :target_interaction_events, optional: true
 
   has_many :caused_rejections,
            class_name: 'ModerationRejectionEvent',

--- a/app/models/moderation_interaction_event.rb
+++ b/app/models/moderation_interaction_event.rb
@@ -12,6 +12,7 @@
 #  source_record_type :string
 #  source_record_id   :bigint(8)
 #  import_batch_id    :bigint(8)
+#  source_event_key   :string
 #  occurred_at        :datetime         not null
 #  observed_at        :datetime         not null
 #  metadata           :jsonb            not null

--- a/app/models/moderation_rejection_event.rb
+++ b/app/models/moderation_rejection_event.rb
@@ -5,8 +5,8 @@
 # Table name: moderation_rejection_events
 #
 #  id                             :bigint(8)        not null, primary key
-#  rejector_subject_id            :bigint(8)        not null
-#  rejected_subject_id            :bigint(8)        not null
+#  rejector_subject_id            :bigint(8)
+#  rejected_subject_id            :bigint(8)
 #  event_type                     :integer          not null
 #  preceding_interaction_event_id :bigint(8)
 #  occurred_at                    :datetime         not null
@@ -34,8 +34,8 @@ class ModerationRejectionEvent < ApplicationRecord
     report: 5,
   }, _suffix: :event
 
-  belongs_to :rejector_subject, class_name: 'ModerationSubject', inverse_of: :rejections_made
-  belongs_to :rejected_subject, class_name: 'ModerationSubject', inverse_of: :rejections_received
+  belongs_to :rejector_subject, class_name: 'ModerationSubject', inverse_of: :rejections_made, optional: true
+  belongs_to :rejected_subject, class_name: 'ModerationSubject', inverse_of: :rejections_received, optional: true
   belongs_to :preceding_interaction_event, class_name: 'ModerationInteractionEvent', optional: true, inverse_of: :caused_rejections
 
   validates :event_type, presence: true

--- a/app/models/moderation_rejection_event.rb
+++ b/app/models/moderation_rejection_event.rb
@@ -9,6 +9,7 @@
 #  rejected_subject_id            :bigint(8)        not null
 #  event_type                     :integer          not null
 #  preceding_interaction_event_id :bigint(8)
+#  source_event_key               :string
 #  occurred_at                    :datetime         not null
 #  observed_at                    :datetime         not null
 #  metadata                       :jsonb            not null

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -49,6 +49,16 @@ class ModerationSubject < ApplicationRecord
            foreign_key: :rejected_subject_id,
            inverse_of: :rejected_subject,
            dependent: :destroy
+  has_many :evidence_snapshots,
+           class_name: 'ModerationEvidenceSnapshot',
+           foreign_key: :subject_id,
+           inverse_of: :subject,
+           dependent: :destroy
+  has_many :moderation_actions,
+           class_name: 'ModerationAction',
+           foreign_key: :subject_id,
+           inverse_of: :subject,
+           dependent: :destroy
 
   validates :origin, presence: true
   validates :first_seen_at, :last_seen_at, presence: true

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -33,22 +33,22 @@ class ModerationSubject < ApplicationRecord
            class_name: 'ModerationInteractionEvent',
            foreign_key: :actor_subject_id,
            inverse_of: :actor_subject,
-           dependent: :destroy
+           dependent: :nullify
   has_many :target_interaction_events,
            class_name: 'ModerationInteractionEvent',
            foreign_key: :target_subject_id,
            inverse_of: :target_subject,
-           dependent: :destroy
+           dependent: :nullify
   has_many :rejections_made,
            class_name: 'ModerationRejectionEvent',
            foreign_key: :rejector_subject_id,
            inverse_of: :rejector_subject,
-           dependent: :destroy
+           dependent: :nullify
   has_many :rejections_received,
            class_name: 'ModerationRejectionEvent',
            foreign_key: :rejected_subject_id,
            inverse_of: :rejected_subject,
-           dependent: :destroy
+           dependent: :nullify
 
   validates :origin, presence: true
   validates :first_seen_at, :last_seen_at, presence: true

--- a/app/models/moderation_subject.rb
+++ b/app/models/moderation_subject.rb
@@ -55,6 +55,11 @@ class ModerationSubject < ApplicationRecord
 
   scope :active, -> { where(deleted_at: nil) }
   scope :tombstoned, -> { where.not(deleted_at: nil) }
+  # Detached from their account (FK nullified on account deletion) but not yet
+  # tombstoned — e.g. deleted through a path that bypassed the service hook.
+  scope :orphaned, -> { where(account_id: nil, deleted_at: nil) }
+  # Tombstoned subjects whose retention window has elapsed.
+  scope :expired, ->(now = Time.now.utc) { where.not(retention_until: nil).where('retention_until <= ?', now) }
 
   # Resolve (or create) the subject that represents +account+, keeping the
   # denormalized origin/domain and +last_seen_at+ fresh. Accepts either an
@@ -84,8 +89,16 @@ class ModerationSubject < ApplicationRecord
     save! if changed?
   end
 
+  # Tombstone every live subject bound to +account+ before the account row is
+  # deleted (afterwards the FK nullifies account_id and it can't be found by id).
+  def self.tombstone_for_account!(account, now: Time.now.utc)
+    return if account.nil?
+
+    where(account_id: account.id, deleted_at: nil).find_each { |subject| subject.tombstone!(now: now) }
+  end
+
   def tombstone!(now: Time.now.utc)
-    update!(deleted_at: now)
+    update!(deleted_at: now, retention_until: Moderation::RetentionPolicy.expire_at(now))
   end
 
   def tombstoned?

--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -17,7 +17,7 @@ class BlockService < BaseService
     BlockWorker.perform_async(account.id, target_account.id)
     create_notification(block) if !target_account.local? && target_account.activitypub?
 
-    Moderation::EventRecorder.record_rejection(rejector: account, rejected: target_account, event_type: :block)
+    Moderation::EventRecorder.record_rejection(rejector: account, rejected: target_account, event_type: :block, source_record: block)
 
     block
   end

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -154,7 +154,19 @@ class DeleteAccountService < BaseService
     purge_feeds!
     purge_other_associations!
 
-    @account.destroy unless keep_account_record?
+    unless keep_account_record?
+      tombstone_moderation_subject!
+      @account.destroy
+    end
+  end
+
+  # Mark the moderation subject as deleted (and set its retention window) before
+  # the account row is removed. Best-effort: never let this break account
+  # deletion. The database FK still nullifies account_id on destroy.
+  def tombstone_moderation_subject!
+    ModerationSubject.tombstone_for_account!(@account)
+  rescue StandardError => e
+    Rails.logger.warn("[Moderation] failed to tombstone subject for account #{@account.id}: #{e.class}: #{e.message}")
   end
 
   def purge_statuses!

--- a/app/services/emoji_reaction_service.rb
+++ b/app/services/emoji_reaction_service.rb
@@ -15,15 +15,29 @@ class EmojiReactionService < BaseService
 
     return if custom_emoji.present? && domain.present? && !EmojiReaction.where(status_id: status.id, custom_emoji_id: custom_emoji.id).present?
 
-    emoji_reaction = EmojiReaction.find_or_create_by!(account_id: account.id, status_id: status.id, name: shortcode, custom_emoji: custom_emoji)
+    newly_reacted = false
+    emoji_reaction = EmojiReaction.find_or_create_by!(account_id: account.id, status_id: status.id, name: shortcode, custom_emoji: custom_emoji) do
+      newly_reacted = true
+    end
 
     emoji_reaction.tap do |emoji_reaction|
       create_notification(emoji_reaction)
       bump_potential_friendship(account, status)
+      record_moderation_reaction!(status, emoji_reaction) if newly_reacted
     end
   end
 
-  private 
+  private
+
+  def record_moderation_reaction!(status, emoji_reaction)
+    Moderation::EventRecorder.record_interaction(
+      actor: @account,
+      target: status.account,
+      event_type: :reaction,
+      status: status,
+      source_record: emoji_reaction
+    )
+  end
 
   def create_notification(emoji_reaction)
     status = emoji_reaction.status

--- a/app/services/emoji_reaction_service.rb
+++ b/app/services/emoji_reaction_service.rb
@@ -15,9 +15,22 @@ class EmojiReactionService < BaseService
 
     return if custom_emoji.present? && domain.present? && !EmojiReaction.where(status_id: status.id, custom_emoji_id: custom_emoji.id).present?
 
+    # Look up first so a sequential retry does not re-run validations on
+    # create. Rescue RecordNotUnique for the concurrent create race — the
+    # losing racer must not be treated as a new reaction (the old
+    # find_or_create_by! block set newly_reacted=true before the insert lost).
+    attrs = { account_id: account.id, status_id: status.id, name: shortcode }
+    emoji_reaction = EmojiReaction.find_by(attrs)
     newly_reacted = false
-    emoji_reaction = EmojiReaction.find_or_create_by!(account_id: account.id, status_id: status.id, name: shortcode, custom_emoji: custom_emoji) do
-      newly_reacted = true
+
+    if emoji_reaction.nil?
+      begin
+        emoji_reaction = EmojiReaction.create!(attrs.merge(custom_emoji: custom_emoji))
+        newly_reacted = true
+      rescue ActiveRecord::RecordNotUnique
+        emoji_reaction = EmojiReaction.find_by!(attrs)
+        newly_reacted = false
+      end
     end
 
     emoji_reaction.tap do |emoji_reaction|

--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -29,7 +29,16 @@ class ImportService < BaseService
 
   def import_follows!
     parse_import_data!(['Account address'])
+    record_follow_import_batch!
     import_relationships!('follow', 'unfollow', @account.following.map { |account| { acct: account.acct }}, ROWS_PROCESSING_LIMIT, show_reblogs: { header: 'Show boosts', default: true }, notify: { header: 'Notify on new posts', default: false }, languages: { header: 'Languages', default: nil }, delivery: { header: 'Delivery to home', default: true })
+  end
+
+  # Record the follow-import target set into the moderation ledger before the
+  # follows are executed (the whole set is known here after CSV parsing).
+  def record_follow_import_batch!
+    accts = @data.take(ROWS_PROCESSING_LIMIT).filter_map { |row| row['Account address']&.strip.presence }
+
+    Moderation::FollowImportRecorder.record_batch(account: @account, accts: accts, import: @import, mode: @import.mode)
   end
 
   def import_account_subscribings!

--- a/app/services/moderation/action_recorder.rb
+++ b/app/services/moderation/action_recorder.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Records a moderator action into the ledger and captures an evidence snapshot
+# at the same time. This is the entry point moderation flows call.
+#
+# The class-level helper is failure-tolerant: a recording error is logged and
+# returns nil, so it never breaks the moderation action itself.
+module Moderation
+  class ActionRecorder
+    class << self
+      def record(**options)
+        new.record(**options)
+      rescue StandardError => e
+        Rails.logger.warn("[Moderation::ActionRecorder] failed to record moderation action: #{e.class}: #{e.message}")
+        nil
+      end
+    end
+
+    def record(account:, action_type:, moderator: nil, reason_code: nil, window: Moderation::EvidenceSnapshotService::DEFAULT_WINDOW, performed_at: nil, metadata: {})
+      performed_at ||= Time.now.utc
+      subject = ModerationSubject.for_account!(account, observed_at: performed_at)
+
+      snapshot = Moderation::EvidenceSnapshotService.new.call(subject, window: window, now: performed_at)
+
+      ModerationAction.create!(
+        subject: subject,
+        action_type: action_type,
+        performed_at: performed_at,
+        moderator_account_id: moderator&.id,
+        reason_code: reason_code,
+        evidence_snapshot: snapshot,
+        metadata: metadata || {}
+      )
+    end
+  end
+end

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -11,8 +11,15 @@
 #     are observable.
 #   * Record only behavioural metadata (who / whom / what / when), never raw
 #     post/DM/profile content.
+#   * Source-backed observations are idempotent: a stable +source_event_key+
+#     plus a unique index prevent duplicate rows when a caller retries or
+#     loses a uniqueness race.
 #
 # This phase performs recording only: no scoring, throttling, or enforcement.
+#
+# Known coverage limitation: inbound ActivityPub-only paths (remote
+# mention/reply/follow/favourite/reaction/block) are not yet hooked. Snapshots
+# and future scores for remote actors are therefore incomplete.
 module Moderation
   class EventRecorder
     class << self
@@ -40,41 +47,96 @@ module Moderation
     # Record a contact (actor -> target). +actor+/+target+ may be an Account or
     # an already-resolved ModerationSubject. Raises on failure; prefer the
     # class-level Moderation::EventRecorder.record_interaction at call sites.
-    def record_interaction(actor:, target:, event_type:, status: nil, source_record: nil, import_batch_id: nil, occurred_at: nil, observed_at: nil, metadata: {})
+    def record_interaction(actor:, target:, event_type:, status: nil, source_record: nil, import_batch_id: nil, occurred_at: nil, observed_at: nil, metadata: {}, source_event_key: nil)
       observed_at ||= Time.now.utc
       actor_subject  = ModerationSubject.for_account!(actor, observed_at: observed_at)
       target_subject = ModerationSubject.for_account!(target, observed_at: observed_at)
+      key = source_event_key.presence || self.class.source_event_key_for(source_record, event_type)
 
-      ModerationInteractionEvent.create!(
-        actor_subject: actor_subject,
-        target_subject: target_subject,
-        event_type: event_type,
-        status_id: status&.id,
-        source_record_type: source_record&.class&.base_class&.name,
-        source_record_id: source_record&.id,
-        import_batch_id: import_batch_id,
-        occurred_at: occurred_at || observed_at,
-        observed_at: observed_at,
-        metadata: metadata || {}
+      upsert_by_source_key(ModerationInteractionEvent, key) do
+        ModerationInteractionEvent.create!(
+          actor_subject: actor_subject,
+          target_subject: target_subject,
+          event_type: event_type,
+          status_id: status&.id,
+          source_record_type: source_record&.class&.base_class&.name,
+          source_record_id: source_record&.id,
+          import_batch_id: import_batch_id,
+          source_event_key: key,
+          occurred_at: occurred_at || observed_at,
+          observed_at: observed_at,
+          metadata: metadata || {}
+        )
+      end
+    end
+
+    # Record a negative signal (rejector -> rejected). When the caller does
+    # not supply a preceding interaction, the nearest earlier contact from
+    # rejected → rejector within the causal window is linked automatically.
+    def record_rejection(rejector:, rejected:, event_type:, preceding_interaction: nil, occurred_at: nil, observed_at: nil, metadata: {}, source_record: nil, source_event_key: nil)
+      observed_at ||= Time.now.utc
+      occurred_at ||= observed_at
+      rejector_subject = ModerationSubject.for_account!(rejector, observed_at: observed_at)
+      rejected_subject = ModerationSubject.for_account!(rejected, observed_at: observed_at)
+      key = source_event_key.presence || self.class.source_event_key_for(source_record, event_type)
+
+      preceding = resolve_preceding_interaction(
+        explicit: preceding_interaction,
+        rejected_subject: rejected_subject,
+        rejector_subject: rejector_subject,
+        occurred_at: occurred_at
+      )
+
+      upsert_by_source_key(ModerationRejectionEvent, key) do
+        ModerationRejectionEvent.create!(
+          rejector_subject: rejector_subject,
+          rejected_subject: rejected_subject,
+          event_type: event_type,
+          preceding_interaction_event: preceding,
+          source_event_key: key,
+          occurred_at: occurred_at,
+          observed_at: observed_at,
+          metadata: metadata || {}
+        )
+      end
+    end
+
+    def self.source_event_key_for(source_record, event_type)
+      return if source_record.nil? || source_record.id.nil?
+
+      "#{source_record.class.base_class.name}:#{source_record.id}:#{event_type}"
+    end
+
+    private
+
+    def resolve_preceding_interaction(explicit:, rejected_subject:, rejector_subject:, occurred_at:)
+      if Moderation::Causality.valid_pair?(
+        explicit,
+        rejected_subject_id: rejected_subject.id,
+        rejector_subject_id: rejector_subject.id,
+        occurred_at: occurred_at
+      )
+        return explicit
+      end
+
+      Moderation::Causality.find_preceding_interaction(
+        rejected_subject: rejected_subject,
+        rejector_subject: rejector_subject,
+        occurred_at: occurred_at
       )
     end
 
-    # Record a negative signal (rejector -> rejected). +preceding_interaction+
-    # optionally links the contact this rejection responded to.
-    def record_rejection(rejector:, rejected:, event_type:, preceding_interaction: nil, occurred_at: nil, observed_at: nil, metadata: {})
-      observed_at ||= Time.now.utc
-      rejector_subject = ModerationSubject.for_account!(rejector, observed_at: observed_at)
-      rejected_subject = ModerationSubject.for_account!(rejected, observed_at: observed_at)
+    def upsert_by_source_key(model, key)
+      if key.present?
+        existing = model.find_by(source_event_key: key)
+        return existing if existing
+      end
 
-      ModerationRejectionEvent.create!(
-        rejector_subject: rejector_subject,
-        rejected_subject: rejected_subject,
-        event_type: event_type,
-        preceding_interaction_event: preceding_interaction,
-        occurred_at: occurred_at || observed_at,
-        observed_at: observed_at,
-        metadata: metadata || {}
-      )
+      yield
+    rescue ActiveRecord::RecordNotUnique
+      raise if key.blank?
+
+      model.find_by!(source_event_key: key)
     end
   end
 end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Builds a ModerationEvidenceSnapshot for a subject over a time window from the
+# recorded ledger (interaction + rejection events).
+#
+# The key artifact is the negative target set: the accounts this subject
+# contacted that returned a negative signal (block/mute/reject/remove/report).
+# Recording/summarising only — no scoring or thresholds.
+module Moderation
+  class EvidenceSnapshotService
+    SCHEMA_VERSION = 1
+    DEFAULT_WINDOW = 30.days
+
+    # Cap the persisted id sets so a pathological subject can't create an
+    # unbounded fingerprint.
+    MAX_FINGERPRINT_IDS = 1_000
+
+    REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
+
+    def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)
+      subject = ModerationSubject.for_account!(subject_or_account, observed_at: now)
+
+      window_start = window.nil? ? nil : now - window
+      window_end   = now
+
+      interactions = interactions_scope(subject, window_start, window_end)
+      rejections   = rejections_scope(subject, window_start, window_end)
+
+      contacted_ids       = interactions.distinct.pluck(:target_subject_id)
+      rejections_by_type  = rejections.group(:event_type).count
+      negative_target_ids = rejections.where(rejector_subject_id: contacted_ids).distinct.pluck(:rejector_subject_id)
+
+      summary = {
+        'interactions_count'      => interactions.count,
+        'unique_contacts'         => contacted_ids.size,
+        'negative_responders'     => rejections.distinct.count(:rejector_subject_id),
+        'negative_target_count'   => negative_target_ids.size,
+        'blocks_received'         => rejections_by_type['block'].to_i,
+        'follow_rejects_received' => rejections_by_type['follow_reject'].to_i,
+        'removed_as_follower'     => rejections_by_type['remove_follower'].to_i,
+        'reports_received'        => rejections_by_type['report'].to_i,
+        'mutes_received'          => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
+      }
+
+      fingerprint = {
+        'negative_target_subject_ids' => negative_target_ids.first(MAX_FINGERPRINT_IDS),
+        'contacted_target_count'      => contacted_ids.size,
+      }
+
+      ModerationEvidenceSnapshot.create!(
+        subject: subject,
+        window_start: window_start,
+        window_end: window_end,
+        summary: summary,
+        fingerprint: fingerprint,
+        schema_version: SCHEMA_VERSION
+      )
+    end
+
+    private
+
+    def interactions_scope(subject, window_start, window_end)
+      scope = ModerationInteractionEvent.where(actor_subject_id: subject.id)
+      scope = scope.where(occurred_at: window_start..window_end) if window_start
+      scope
+    end
+
+    def rejections_scope(subject, window_start, window_end)
+      scope = ModerationRejectionEvent.where(rejected_subject_id: subject.id)
+      scope = scope.where(occurred_at: window_start..window_end) if window_start
+      scope
+    end
+  end
+end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -3,12 +3,23 @@
 # Builds a ModerationEvidenceSnapshot for a subject over a time window from the
 # recorded ledger (interaction + rejection events).
 #
-# The key artifact is the negative target set: the accounts this subject
-# contacted that returned a negative signal (block/mute/reject/remove/report).
+# The key artifact is the negative target set: accounts this subject contacted
+# that then returned a negative signal *after* that contact, within the causal
+# window, preferably linked via +preceding_interaction_event_id+.
+#
+# Same-window overlap without a proven A→B then B→A order is stored separately
+# as a weaker correlation and is never written to +negative_target_subject_ids+.
+#
 # Recording/summarising only — no scoring or thresholds.
+#
+# Coverage limitation: inbound ActivityPub-only mentions, replies, follows,
+# favourites, reactions, and blocks are not yet observed. A remote subject can
+# therefore accumulate local blocks/reports while the triggering remote
+# contacts are missing. Snapshots (and future scores) for remote actors are
+# incomplete until those paths are covered. See +fingerprint['coverage']+.
 module Moderation
   class EvidenceSnapshotService
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
     DEFAULT_WINDOW = 30.days
 
     # Cap the persisted id sets so a pathological subject can't create an
@@ -16,6 +27,13 @@ module Moderation
     MAX_FINGERPRINT_IDS = 1_000
 
     REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
+
+    # Explicit until inbound ActivityPub interaction paths are wired. Do not
+    # treat snapshot counts or future scores as complete for remote actors.
+    INBOUND_ACTIVITYPUB_COVERAGE = {
+      'inbound_activitypub' => 'deferred',
+      'complete_for_remote_subjects' => false,
+    }.freeze
 
     def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)
       subject = ModerationSubject.for_account!(subject_or_account, observed_at: now)
@@ -26,25 +44,28 @@ module Moderation
       interactions = interactions_scope(subject, window_start, window_end)
       rejections   = rejections_scope(subject, window_start, window_end)
 
-      contacted_ids       = interactions.distinct.pluck(:target_subject_id)
-      rejections_by_type  = rejections.group(:event_type).count
-      negative_target_ids = rejections.where(rejector_subject_id: contacted_ids).distinct.pluck(:rejector_subject_id)
+      contacted_ids      = interactions.distinct.pluck(:target_subject_id)
+      rejections_by_type = rejections.group(:event_type).count
+      strong_ids, weak_ids = classify_negative_targets(rejections, contacted_ids)
 
       summary = {
-        'interactions_count'      => interactions.count,
-        'unique_contacts'         => contacted_ids.size,
-        'negative_responders'     => rejections.distinct.count(:rejector_subject_id),
-        'negative_target_count'   => negative_target_ids.size,
-        'blocks_received'         => rejections_by_type['block'].to_i,
-        'follow_rejects_received' => rejections_by_type['follow_reject'].to_i,
-        'removed_as_follower'     => rejections_by_type['remove_follower'].to_i,
-        'reports_received'        => rejections_by_type['report'].to_i,
-        'mutes_received'          => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
+        'interactions_count'              => interactions.count,
+        'unique_contacts'                 => contacted_ids.size,
+        'negative_responders'             => rejections.distinct.count(:rejector_subject_id),
+        'negative_target_count'           => strong_ids.size,
+        'correlated_negative_target_count' => weak_ids.size,
+        'blocks_received'                 => rejections_by_type['block'].to_i,
+        'follow_rejects_received'         => rejections_by_type['follow_reject'].to_i,
+        'removed_as_follower'             => rejections_by_type['remove_follower'].to_i,
+        'reports_received'                => rejections_by_type['report'].to_i,
+        'mutes_received'                  => rejections_by_type['mute'].to_i + rejections_by_type['mute_notifications'].to_i,
       }
 
       fingerprint = {
-        'negative_target_subject_ids' => negative_target_ids.first(MAX_FINGERPRINT_IDS),
-        'contacted_target_count'      => contacted_ids.size,
+        'negative_target_subject_ids'              => strong_ids.first(MAX_FINGERPRINT_IDS),
+        'correlated_negative_target_subject_ids'   => weak_ids.first(MAX_FINGERPRINT_IDS),
+        'contacted_target_count'                   => contacted_ids.size,
+        'coverage'                                 => INBOUND_ACTIVITYPUB_COVERAGE,
       }
 
       ModerationEvidenceSnapshot.create!(
@@ -69,6 +90,31 @@ module Moderation
       scope = ModerationRejectionEvent.where(rejected_subject_id: subject.id)
       scope = scope.where(occurred_at: window_start..window_end) if window_start
       scope
+    end
+
+    # Strong: linked preceding interaction that satisfies causality.
+    # Weak: same-window subject-id overlap without a valid causal link.
+    def classify_negative_targets(rejections, contacted_ids)
+      contacted = contacted_ids.to_set
+      strong = Set.new
+      weak = Set.new
+
+      rejections.includes(:preceding_interaction_event).find_each do |rejection|
+        rejector_id = rejection.rejector_subject_id
+        next unless contacted.include?(rejector_id)
+
+        if Moderation::Causality.valid_link?(rejection.preceding_interaction_event, rejection)
+          strong << rejector_id
+        else
+          weak << rejector_id
+        end
+      end
+
+      # A rejector with any strong link is not also reported as a weak
+      # correlation — the fingerprint must not imply both.
+      weak.subtract(strong)
+
+      [strong.to_a, weak.to_a]
     end
   end
 end

--- a/app/services/moderation/follow_import_recorder.rb
+++ b/app/services/moderation/follow_import_recorder.rb
@@ -22,6 +22,13 @@ module Moderation
 
     def record_batch(account:, accts:, import: nil, mode: nil, imported_at: nil)
       imported_at ||= Time.now.utc
+
+      # Sidekiq retries the same Import row; import_id is the idempotency key.
+      if import&.id
+        existing = FollowImportBatch.find_by(import_id: import.id)
+        return existing if existing
+      end
+
       subject = ModerationSubject.for_account!(account, observed_at: imported_at)
 
       resolved_count   = 0
@@ -70,6 +77,10 @@ module Moderation
       end
 
       batch
+    rescue ActiveRecord::RecordNotUnique
+      raise if import&.id.blank?
+
+      FollowImportBatch.find_by!(import_id: import.id)
     end
 
     private

--- a/app/services/moderation/follow_import_recorder.rb
+++ b/app/services/moderation/follow_import_recorder.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Records a follow-import batch and its target set into the moderation ledger.
+#
+# Follow import is a high-value observation point: the whole target set is
+# presented to the server before any follow is executed, so it is recorded up
+# front. Resolvable addresses are linked to a ModerationSubject; unresolved ones
+# keep a pseudonymous target_key_hash so they can still be correlated later.
+#
+# Recording only — no scoring or enforcement. The class-level entry point is
+# failure-tolerant so a recording error never breaks the import.
+module Moderation
+  class FollowImportRecorder
+    class << self
+      def record_batch(**options)
+        new.record_batch(**options)
+      rescue StandardError => e
+        Rails.logger.warn("[Moderation::FollowImportRecorder] failed to record follow import batch: #{e.class}: #{e.message}")
+        nil
+      end
+    end
+
+    def record_batch(account:, accts:, import: nil, mode: nil, imported_at: nil)
+      imported_at ||= Time.now.utc
+      subject = ModerationSubject.for_account!(account, observed_at: imported_at)
+
+      resolved_count   = 0
+      unresolved_count = 0
+      target_rows      = []
+
+      accts.each_with_index do |raw_acct, index|
+        acct = raw_acct.to_s.strip
+        next if acct.blank?
+
+        target_account = resolve_account(acct)
+
+        if target_account
+          resolved_count += 1
+          target_subject = ModerationSubject.for_account!(target_account, observed_at: imported_at)
+          target_rows << {
+            target_subject_id: target_subject.id,
+            position: index,
+            prior_relationship_state: { following: account.following?(target_account) },
+          }
+        else
+          unresolved_count += 1
+          target_rows << {
+            target_key_hash: hash_acct(acct),
+            position: index,
+          }
+        end
+      end
+
+      batch = nil
+
+      ApplicationRecord.transaction do
+        batch = FollowImportBatch.create!(
+          subject: subject,
+          import_id: import&.id,
+          imported_at: imported_at,
+          mode: normalize_mode(mode),
+          target_count: target_rows.size,
+          resolved_target_count: resolved_count,
+          unresolved_target_count: unresolved_count,
+          account_age_seconds: account_age_seconds(account, imported_at),
+          migration_evidence: migration_evidence(account)
+        )
+
+        target_rows.each { |attrs| batch.targets.create!(attrs) }
+      end
+
+      batch
+    end
+
+    private
+
+    # Resolve an account address to a known account without hitting the network.
+    def resolve_account(acct)
+      username, domain = acct.split('@', 2)
+      return if username.blank?
+
+      domain = nil if domain.blank? || TagManager.instance.local_domain?(domain)
+
+      if domain.nil?
+        Account.find_local(username)
+      else
+        Account.find_remote(username, domain)
+      end
+    rescue StandardError
+      nil
+    end
+
+    def hash_acct(acct)
+      username, domain = acct.split('@', 2)
+      domain = Rails.configuration.x.local_domain if domain.blank?
+      Digest::SHA256.hexdigest("#{username.to_s.downcase}@#{domain.to_s.downcase}")
+    end
+
+    def normalize_mode(mode)
+      case mode&.to_sym
+      when :merge then :merge
+      when :overwrite then :overwrite
+      else :unknown
+      end
+    end
+
+    def account_age_seconds(account, at)
+      return if account.created_at.nil?
+
+      (at - account.created_at).to_i
+    end
+
+    def migration_evidence(account)
+      account.aliases.exists? ? :weak : :none
+    rescue StandardError
+      :none
+    end
+  end
+end

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -10,6 +10,7 @@ class MuteService < BaseService
       rejector: account,
       rejected: target_account,
       event_type: :mute,
+      source_record: mute,
       metadata: { hide_notifications: mute.hide_notifications? }
     )
 

--- a/app/services/process_status_reference_service.rb
+++ b/app/services/process_status_reference_service.rb
@@ -47,6 +47,8 @@ class ProcessStatusReferenceService
       StatusReference.create(status_id: status_id, target_status_id: target_status.id)
     end
 
+    record_moderation_references!(references)
+
     references.group_by{|reference| reference.target_status.account}.each do |account, grouped_references|
       create_notification(grouped_references.sort_by(&:id).first) if account.local?
     end
@@ -54,6 +56,29 @@ class ProcessStatusReferenceService
 
   def create_notification(reference)
     NotifyService.new.call(reference.target_status.account, :status_reference, reference)
+  end
+
+  # Record references as interaction signals. The quoted status is skipped here
+  # because it is recorded as a `quote` interaction by PostStatusService, so it
+  # would otherwise be double-counted.
+  def record_moderation_references!(references)
+    quote_target_id = @status.quote_id
+
+    references.each do |reference|
+      next unless reference.persisted?
+      next if quote_target_id.present? && reference.target_status_id == quote_target_id
+
+      target_status = reference.target_status
+      next if target_status.nil?
+
+      Moderation::EventRecorder.record_interaction(
+        actor: @status.account,
+        target: target_status.account,
+        event_type: :reference,
+        status: @status,
+        source_record: reference
+      )
+    end
   end
 
   def parse_local_urls(text)

--- a/app/services/reject_follow_service.rb
+++ b/app/services/reject_follow_service.rb
@@ -9,7 +9,7 @@ class RejectFollowService < BaseService
     create_notification(follow_request) if !source_account.local? && source_account.activitypub?
 
     # source_account is the requester; target_account is the account rejecting.
-    Moderation::EventRecorder.record_rejection(rejector: target_account, rejected: source_account, event_type: :follow_reject)
+    Moderation::EventRecorder.record_rejection(rejector: target_account, rejected: source_account, event_type: :follow_reject, source_record: follow_request)
 
     follow_request
   end

--- a/app/services/remove_from_followers_service.rb
+++ b/app/services/remove_from_followers_service.rb
@@ -8,7 +8,7 @@ class RemoveFromFollowersService < BaseService
       follower = follow.account
       follow.destroy
 
-      Moderation::EventRecorder.record_rejection(rejector: source_account, rejected: follower, event_type: :remove_follower)
+      Moderation::EventRecorder.record_rejection(rejector: source_account, rejected: follower, event_type: :remove_follower, source_record: follow)
 
       if source_account.local? && !follower.local? && follower.activitypub?
         create_notification(follow)

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -27,6 +27,7 @@ class ReportService < BaseService
       rejector: @source_account,
       rejected: @target_account,
       event_type: :report,
+      source_record: @report,
       metadata: { status_count: @status_ids.size }
     )
   end

--- a/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
+++ b/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
@@ -6,8 +6,13 @@
 #      nullified by the FK on account deletion) that were never tombstoned — for
 #      example when deletion happened through a path that bypassed the service
 #      hook. They are tombstoned so the retention window starts.
-#   2. Expire: tombstoned subjects past their retention_until are deleted; the
-#      database foreign keys cascade to their recorded events.
+#   2. Expire at the *event* level: a shared interaction/rejection is kept as
+#      long as any involved subject is still retained. An expired subject is
+#      deleted only when no remaining event references it (held otherwise so
+#      a retained counterpart's evidence stays internally consistent).
+#
+# Counterpart subject FKs are ON DELETE SET NULL as a safety net; this
+# scheduler should not need that path when it holds referenced subjects.
 #
 # Set MODERATION_LEDGER_RETENTION_DRY_RUN=true to log what would happen without
 # modifying any data.
@@ -39,13 +44,34 @@ class Scheduler::ModerationLedgerRetentionScheduler
   def expire_tombstoned!(now)
     return 0 unless Moderation::RetentionPolicy.enabled?
 
-    scope = ModerationSubject.expired(now)
-    count = scope.count
-    return count if count.zero? || dry_run?
+    expired_ids = ModerationSubject.expired(now).pluck(:id)
+    return 0 if expired_ids.empty?
+    return expired_ids.size if dry_run?
 
-    # delete_all relies on ON DELETE CASCADE to remove the subject's events.
-    scope.in_batches.delete_all
-    count
+    delete_events_without_retained_participant!(expired_ids)
+    deletable_ids = expired_ids - subject_ids_still_referenced(expired_ids)
+    return 0 if deletable_ids.empty?
+
+    ModerationSubject.where(id: deletable_ids).in_batches.delete_all
+    deletable_ids.size
+  end
+
+  # Drop events whose every participant is expired (or already null). Events
+  # that still name a retained subject are left intact.
+  def delete_events_without_retained_participant!(expired_ids)
+    retained_ids = ModerationSubject.where.not(id: expired_ids).pluck(:id)
+
+    ModerationInteractionEvent.where.not(actor_subject_id: retained_ids).where.not(target_subject_id: retained_ids).in_batches.delete_all
+    ModerationRejectionEvent.where.not(rejector_subject_id: retained_ids).where.not(rejected_subject_id: retained_ids).in_batches.delete_all
+  end
+
+  def subject_ids_still_referenced(expired_ids)
+    (
+      ModerationInteractionEvent.where(actor_subject_id: expired_ids).distinct.pluck(:actor_subject_id) +
+      ModerationInteractionEvent.where(target_subject_id: expired_ids).distinct.pluck(:target_subject_id) +
+      ModerationRejectionEvent.where(rejector_subject_id: expired_ids).distinct.pluck(:rejector_subject_id) +
+      ModerationRejectionEvent.where(rejected_subject_id: expired_ids).distinct.pluck(:rejected_subject_id)
+    ).compact.uniq
   end
 
   def dry_run?

--- a/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
+++ b/app/workers/scheduler/moderation_ledger_retention_scheduler.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Retention cleanup for the moderation ledger.
+#
+#   1. Reconcile orphans: subjects detached from their account (account_id
+#      nullified by the FK on account deletion) that were never tombstoned — for
+#      example when deletion happened through a path that bypassed the service
+#      hook. They are tombstoned so the retention window starts.
+#   2. Expire: tombstoned subjects past their retention_until are deleted; the
+#      database foreign keys cascade to their recorded events.
+#
+# Set MODERATION_LEDGER_RETENTION_DRY_RUN=true to log what would happen without
+# modifying any data.
+class Scheduler::ModerationLedgerRetentionScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0
+
+  def perform
+    now = Time.now.utc
+
+    reconciled = reconcile_orphans!(now)
+    expired    = expire_tombstoned!(now)
+
+    Rails.logger.info("[Scheduler::ModerationLedgerRetentionScheduler] reconciled=#{reconciled} expired=#{expired} dry_run=#{dry_run?} retention_days=#{Moderation::RetentionPolicy.retention_days}")
+  end
+
+  private
+
+  def reconcile_orphans!(now)
+    scope = ModerationSubject.orphaned
+    count = scope.count
+    return count if count.zero? || dry_run?
+
+    scope.in_batches.update_all(deleted_at: now, retention_until: Moderation::RetentionPolicy.expire_at(now))
+    count
+  end
+
+  def expire_tombstoned!(now)
+    return 0 unless Moderation::RetentionPolicy.enabled?
+
+    scope = ModerationSubject.expired(now)
+    count = scope.count
+    return count if count.zero? || dry_run?
+
+    # delete_all relies on ON DELETE CASCADE to remove the subject's events.
+    scope.in_batches.delete_all
+    count
+  end
+
+  def dry_run?
+    ENV['MODERATION_LEDGER_RETENTION_DRY_RUN'] == 'true'
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -67,3 +67,7 @@
       interval: 1 minute
       class: Scheduler::AccountsStatusesCleanupScheduler
       queue: scheduler
+    moderation_ledger_retention_scheduler:
+      cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
+      class: Scheduler::ModerationLedgerRetentionScheduler
+      queue: scheduler

--- a/db/migrate/20260909020001_create_follow_import_batches.rb
+++ b/db/migrate/20260909020001_create_follow_import_batches.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CreateFollowImportBatches < ActiveRecord::Migration[6.1]
+  def change
+    create_table :follow_import_batches do |t|
+      t.references :subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      # fedibird destroys the Import row after processing, so this is a plain
+      # (non-FK) short-term correlation id, not a foreign key.
+      t.bigint :import_id
+
+      t.datetime :imported_at, null: false
+      t.integer :mode, null: false, default: 0
+      t.integer :target_count, null: false, default: 0
+      t.integer :resolved_target_count, null: false, default: 0
+      t.integer :unresolved_target_count, null: false, default: 0
+      t.bigint :account_age_seconds
+      t.integer :migration_evidence, null: false, default: 0
+      t.jsonb :metadata, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :follow_import_batches, [:subject_id, :imported_at], name: :index_follow_import_batches_on_subject_and_imported_at
+  end
+end

--- a/db/migrate/20260909020002_create_follow_import_targets.rb
+++ b/db/migrate/20260909020002_create_follow_import_targets.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateFollowImportTargets < ActiveRecord::Migration[6.1]
+  def change
+    create_table :follow_import_targets do |t|
+      t.references :batch, null: false, foreign_key: { to_table: :follow_import_batches, on_delete: :cascade }, index: false
+
+      # Nullable: an imported target may not resolve to a known account at
+      # import time. ON DELETE SET NULL keeps the target row if the subject is
+      # later removed.
+      t.references :target_subject, foreign_key: { to_table: :moderation_subjects, on_delete: :nullify }, index: false
+
+      t.string :target_key_hash
+      t.integer :position
+      t.jsonb :prior_relationship_state
+
+      t.timestamps
+    end
+
+    add_index :follow_import_targets, [:batch_id, :target_subject_id], name: :index_follow_import_targets_on_batch_and_target
+    add_index :follow_import_targets, :target_subject_id, where: 'target_subject_id IS NOT NULL', name: :index_follow_import_targets_on_target_subject
+    add_index :follow_import_targets, :target_key_hash, where: 'target_key_hash IS NOT NULL', name: :index_follow_import_targets_on_target_key_hash
+  end
+end

--- a/db/migrate/20260909070001_create_moderation_evidence_snapshots.rb
+++ b/db/migrate/20260909070001_create_moderation_evidence_snapshots.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateModerationEvidenceSnapshots < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_evidence_snapshots do |t|
+      t.references :subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      t.datetime :window_start
+      t.datetime :window_end
+      t.jsonb :summary, null: false, default: {}
+      t.jsonb :fingerprint, null: false, default: {}
+      t.integer :schema_version, null: false, default: 1
+
+      t.timestamps
+    end
+
+    add_index :moderation_evidence_snapshots, [:subject_id, :created_at], name: :index_mod_evidence_snapshots_on_subject_and_created
+  end
+end

--- a/db/migrate/20260909070002_create_moderation_actions.rb
+++ b/db/migrate/20260909070002_create_moderation_actions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateModerationActions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :moderation_actions do |t|
+      t.references :subject, null: false, foreign_key: { to_table: :moderation_subjects, on_delete: :cascade }, index: false
+
+      t.integer :action_type, null: false
+      t.datetime :performed_at, null: false
+
+      # ON DELETE SET NULL so a moderator's account deletion never removes the
+      # audit of actions they performed.
+      t.bigint :moderator_account_id
+      t.string :reason_code
+
+      t.references :evidence_snapshot, foreign_key: { to_table: :moderation_evidence_snapshots, on_delete: :nullify }, index: false
+
+      t.jsonb :metadata, null: false, default: {}
+
+      t.timestamps
+    end
+
+    safety_assured do
+      add_foreign_key :moderation_actions, :accounts, column: :moderator_account_id, on_delete: :nullify
+    end
+
+    add_index :moderation_actions, [:subject_id, :performed_at], name: :index_moderation_actions_on_subject_and_performed
+    add_index :moderation_actions, [:action_type, :performed_at], name: :index_moderation_actions_on_type_and_performed
+    add_index :moderation_actions, :evidence_snapshot_id, where: 'evidence_snapshot_id IS NOT NULL', name: :index_moderation_actions_on_evidence_snapshot
+    add_index :moderation_actions, :moderator_account_id, where: 'moderator_account_id IS NOT NULL', name: :index_moderation_actions_on_moderator
+  end
+end

--- a/db/migrate/20260909100001_add_source_event_key_to_moderation_events.rb
+++ b/db/migrate/20260909100001_add_source_event_key_to_moderation_events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddSourceEventKeyToModerationEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :moderation_interaction_events, :source_event_key, :string
+    add_column :moderation_rejection_events, :source_event_key, :string
+
+    safety_assured do
+      add_index :moderation_interaction_events, :source_event_key,
+                unique: true,
+                where: 'source_event_key IS NOT NULL',
+                name: :index_mod_interaction_events_on_source_event_key
+      add_index :moderation_rejection_events, :source_event_key,
+                unique: true,
+                where: 'source_event_key IS NOT NULL',
+                name: :index_mod_rejection_events_on_source_event_key
+    end
+  end
+end

--- a/db/migrate/20260909110001_nullify_moderation_event_subject_fks.rb
+++ b/db/migrate/20260909110001_nullify_moderation_event_subject_fks.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Shared ledger events must survive expiry of one participant. Counterpart
+# subject FKs become nullable and SET NULL so deleting a subject never
+# cascade-destroys evidence still needed by a retained counterpart.
+class NullifyModerationEventSubjectFks < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured do
+      remove_foreign_key :moderation_interaction_events, column: :actor_subject_id
+      remove_foreign_key :moderation_interaction_events, column: :target_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejector_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejected_subject_id
+
+      change_column_null :moderation_interaction_events, :actor_subject_id, true
+      change_column_null :moderation_interaction_events, :target_subject_id, true
+      change_column_null :moderation_rejection_events, :rejector_subject_id, true
+      change_column_null :moderation_rejection_events, :rejected_subject_id, true
+
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :actor_subject_id, on_delete: :nullify
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :target_subject_id, on_delete: :nullify
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejector_subject_id, on_delete: :nullify
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejected_subject_id, on_delete: :nullify
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_foreign_key :moderation_interaction_events, column: :actor_subject_id
+      remove_foreign_key :moderation_interaction_events, column: :target_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejector_subject_id
+      remove_foreign_key :moderation_rejection_events, column: :rejected_subject_id
+
+      change_column_null :moderation_interaction_events, :actor_subject_id, false
+      change_column_null :moderation_interaction_events, :target_subject_id, false
+      change_column_null :moderation_rejection_events, :rejector_subject_id, false
+      change_column_null :moderation_rejection_events, :rejected_subject_id, false
+
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :actor_subject_id, on_delete: :cascade
+      add_foreign_key :moderation_interaction_events, :moderation_subjects, column: :target_subject_id, on_delete: :cascade
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejector_subject_id, on_delete: :cascade
+      add_foreign_key :moderation_rejection_events, :moderation_subjects, column: :rejected_subject_id, on_delete: :cascade
+    end
+  end
+end

--- a/db/migrate/20260909120001_add_unique_import_id_to_follow_import_batches.rb
+++ b/db/migrate/20260909120001_add_unique_import_id_to_follow_import_batches.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUniqueImportIdToFollowImportBatches < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_index :follow_import_batches, :import_id,
+                unique: true,
+                where: 'import_id IS NOT NULL',
+                name: :index_follow_import_batches_on_import_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_08_230003) do
+ActiveRecord::Schema.define(version: 2026_09_09_070002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -745,6 +745,34 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
     t.index ["status_id"], name: "index_mentions_on_status_id"
   end
 
+  create_table "moderation_actions", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.integer "action_type", null: false
+    t.datetime "performed_at", null: false
+    t.bigint "moderator_account_id"
+    t.string "reason_code"
+    t.bigint "evidence_snapshot_id"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["action_type", "performed_at"], name: "index_moderation_actions_on_type_and_performed"
+    t.index ["evidence_snapshot_id"], name: "index_moderation_actions_on_evidence_snapshot", where: "(evidence_snapshot_id IS NOT NULL)"
+    t.index ["moderator_account_id"], name: "index_moderation_actions_on_moderator", where: "(moderator_account_id IS NOT NULL)"
+    t.index ["subject_id", "performed_at"], name: "index_moderation_actions_on_subject_and_performed"
+  end
+
+  create_table "moderation_evidence_snapshots", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.datetime "window_start"
+    t.datetime "window_end"
+    t.jsonb "summary", default: {}, null: false
+    t.jsonb "fingerprint", default: {}, null: false
+    t.integer "schema_version", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject_id", "created_at"], name: "index_mod_evidence_snapshots_on_subject_and_created"
+  end
+
   create_table "moderation_interaction_events", force: :cascade do |t|
     t.bigint "actor_subject_id", null: false
     t.bigint "target_subject_id", null: false
@@ -1401,6 +1429,10 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
+  add_foreign_key "moderation_actions", "accounts", column: "moderator_account_id", on_delete: :nullify
+  add_foreign_key "moderation_actions", "moderation_evidence_snapshots", column: "evidence_snapshot_id", on_delete: :nullify
+  add_foreign_key "moderation_actions", "moderation_subjects", column: "subject_id", on_delete: :cascade
+  add_foreign_key "moderation_evidence_snapshots", "moderation_subjects", column: "subject_id", on_delete: :cascade
   add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
   add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_08_230003) do
+ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -547,6 +547,35 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
     t.string "url"
     t.index ["account_id"], name: "index_featured_tags_on_account_id"
     t.index ["tag_id"], name: "index_featured_tags_on_tag_id"
+  end
+
+  create_table "follow_import_batches", force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.bigint "import_id"
+    t.datetime "imported_at", null: false
+    t.integer "mode", default: 0, null: false
+    t.integer "target_count", default: 0, null: false
+    t.integer "resolved_target_count", default: 0, null: false
+    t.integer "unresolved_target_count", default: 0, null: false
+    t.bigint "account_age_seconds"
+    t.integer "migration_evidence", default: 0, null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject_id", "imported_at"], name: "index_follow_import_batches_on_subject_and_imported_at"
+  end
+
+  create_table "follow_import_targets", force: :cascade do |t|
+    t.bigint "batch_id", null: false
+    t.bigint "target_subject_id"
+    t.string "target_key_hash"
+    t.integer "position"
+    t.jsonb "prior_relationship_state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["batch_id", "target_subject_id"], name: "index_follow_import_targets_on_batch_and_target"
+    t.index ["target_key_hash"], name: "index_follow_import_targets_on_target_key_hash", where: "(target_key_hash IS NOT NULL)"
+    t.index ["target_subject_id"], name: "index_follow_import_targets_on_target_subject", where: "(target_subject_id IS NOT NULL)"
   end
 
   create_table "follow_recommendation_suppressions", force: :cascade do |t|
@@ -1377,6 +1406,9 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
   add_foreign_key "featured_tags", "accounts", on_delete: :cascade
   add_foreign_key "featured_tags", "tags", on_delete: :cascade
+  add_foreign_key "follow_import_batches", "moderation_subjects", column: "subject_id", on_delete: :cascade
+  add_foreign_key "follow_import_targets", "follow_import_batches", column: "batch_id", on_delete: :cascade
+  add_foreign_key "follow_import_targets", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "follow_recommendation_suppressions", "accounts", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", column: "target_account_id", name: "fk_9291ec025d", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", name: "fk_76d644b0e7", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_09_020002) do
+ActiveRecord::Schema.define(version: 2026_09_09_120001) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -562,6 +563,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["import_id"], name: "index_follow_import_batches_on_import_id", unique: true, where: "(import_id IS NOT NULL)"
     t.index ["subject_id", "imported_at"], name: "index_follow_import_batches_on_subject_and_imported_at"
   end
 
@@ -775,8 +777,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   end
 
   create_table "moderation_interaction_events", force: :cascade do |t|
-    t.bigint "actor_subject_id", null: false
-    t.bigint "target_subject_id", null: false
+    t.bigint "actor_subject_id"
+    t.bigint "target_subject_id"
     t.integer "event_type", null: false
     t.bigint "status_id"
     t.string "source_record_type"
@@ -794,8 +796,8 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   end
 
   create_table "moderation_rejection_events", force: :cascade do |t|
-    t.bigint "rejector_subject_id", null: false
-    t.bigint "rejected_subject_id", null: false
+    t.bigint "rejector_subject_id"
+    t.bigint "rejected_subject_id"
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
     t.datetime "occurred_at", null: false
@@ -1181,10 +1183,10 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.bigint "generator_id"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20210710", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL))"
+    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["account_id", "id"], name: "index_statuses_private_searchable", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL) AND (reblog_of_id IS NULL) AND (searchability = ANY (ARRAY[0, 1, 2])))"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
-    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["quote_id"], name: "index_statuses_on_quote_id"
@@ -1206,6 +1208,15 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tag_account_mutes", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
+    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
@@ -1219,15 +1230,6 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
     t.float "max_score"
     t.datetime "max_score_at"
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
-  end
-
-  create_table "tag_account_mutes", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "account_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
-    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
   end
 
   create_table "tombstones", force: :cascade do |t|
@@ -1433,11 +1435,11 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :nullify
   add_foreign_key "moderation_subjects", "accounts", on_delete: :nullify
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
@@ -1486,6 +1488,53 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users"
 
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
+      SELECT account_id,
+      sum(rank) AS rank,
+      array_agg(reason) AS reason
+     FROM ( SELECT account_summaries.account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM (((follows
+               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT account_summaries.account_id,
+              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM (((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
+    GROUP BY account_id
+    ORDER BY (sum(rank)) DESC;
+  SQL
+  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
+
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (
            SELECT accounts.domain,
@@ -1509,52 +1558,5 @@ ActiveRecord::Schema.define(version: 2026_09_09_020002) do
        LEFT JOIN domain_counts ON (((domain_counts.domain)::text = (domain_allows.domain)::text)));
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
-
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT t0.account_id,
-      sum(t0.rank) AS rank,
-      array_agg(t0.reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM (((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM (((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
-    GROUP BY t0.account_id
-    ORDER BY (sum(t0.rank)) DESC;
-  SQL
-  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_09_070002) do
+ActiveRecord::Schema.define(version: 2026_09_09_100001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -781,6 +781,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_070002) do
     t.string "source_record_type"
     t.bigint "source_record_id"
     t.bigint "import_batch_id"
+    t.string "source_event_key"
     t.datetime "occurred_at", null: false
     t.datetime "observed_at", null: false
     t.jsonb "metadata", default: {}, null: false
@@ -789,6 +790,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_070002) do
     t.index ["actor_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_actor_and_occurred"
     t.index ["actor_subject_id", "target_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_actor_target_occurred"
     t.index ["event_type", "occurred_at"], name: "index_mod_interaction_events_on_type_and_occurred"
+    t.index ["source_event_key"], name: "index_mod_interaction_events_on_source_event_key", unique: true, where: "(source_event_key IS NOT NULL)"
     t.index ["target_subject_id", "occurred_at"], name: "index_mod_interaction_events_on_target_and_occurred"
   end
 
@@ -797,6 +799,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_070002) do
     t.bigint "rejected_subject_id", null: false
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
+    t.string "source_event_key"
     t.datetime "occurred_at", null: false
     t.datetime "observed_at", null: false
     t.jsonb "metadata", default: {}, null: false
@@ -804,6 +807,7 @@ ActiveRecord::Schema.define(version: 2026_09_09_070002) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_type", "occurred_at"], name: "index_mod_rejection_events_on_type_and_occurred"
     t.index ["preceding_interaction_event_id"], name: "index_mod_rejection_events_on_preceding_event", where: "(preceding_interaction_event_id IS NOT NULL)"
+    t.index ["source_event_key"], name: "index_mod_rejection_events_on_source_event_key", unique: true, where: "(source_event_key IS NOT NULL)"
     t.index ["rejected_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejected_and_occurred"
     t.index ["rejected_subject_id", "rejector_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejected_rejector_occurred"
     t.index ["rejector_subject_id", "occurred_at"], name: "index_mod_rejection_events_on_rejector_and_occurred"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_08_230003) do
+ActiveRecord::Schema.define(version: 2026_09_09_110001) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -746,8 +747,8 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   end
 
   create_table "moderation_interaction_events", force: :cascade do |t|
-    t.bigint "actor_subject_id", null: false
-    t.bigint "target_subject_id", null: false
+    t.bigint "actor_subject_id"
+    t.bigint "target_subject_id"
     t.integer "event_type", null: false
     t.bigint "status_id"
     t.string "source_record_type"
@@ -765,8 +766,8 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   end
 
   create_table "moderation_rejection_events", force: :cascade do |t|
-    t.bigint "rejector_subject_id", null: false
-    t.bigint "rejected_subject_id", null: false
+    t.bigint "rejector_subject_id"
+    t.bigint "rejected_subject_id"
     t.integer "event_type", null: false
     t.bigint "preceding_interaction_event_id"
     t.datetime "occurred_at", null: false
@@ -1152,10 +1153,10 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
     t.bigint "generator_id"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20210710", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL))"
+    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["account_id", "id"], name: "index_statuses_private_searchable", order: { id: :desc }, where: "((deleted_at IS NULL) AND (expired_at IS NULL) AND (reblog_of_id IS NULL) AND (searchability = ANY (ARRAY[0, 1, 2])))"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
-    t.index ["account_id", "id"], name: "index_statuses_personal_timeline", order: :desc, where: "((visibility = 200) AND (deleted_at IS NULL) AND (reblog_of_id IS NULL))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["quote_id"], name: "index_statuses_on_quote_id"
@@ -1177,6 +1178,15 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tag_account_mutes", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
+    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
@@ -1190,15 +1200,6 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
     t.float "max_score"
     t.datetime "max_score_at"
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
-  end
-
-  create_table "tag_account_mutes", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "account_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_tag_account_mutes_on_account_id"
-    t.index ["tag_id"], name: "index_tag_account_mutes_on_tag_id"
   end
 
   create_table "tombstones", force: :cascade do |t|
@@ -1401,11 +1402,11 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "actor_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_interaction_events", "moderation_subjects", column: "target_subject_id", on_delete: :nullify
   add_foreign_key "moderation_rejection_events", "moderation_interaction_events", column: "preceding_interaction_event_id", on_delete: :nullify
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :cascade
-  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :cascade
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejected_subject_id", on_delete: :nullify
+  add_foreign_key "moderation_rejection_events", "moderation_subjects", column: "rejector_subject_id", on_delete: :nullify
   add_foreign_key "moderation_subjects", "accounts", on_delete: :nullify
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
@@ -1454,6 +1455,53 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
   add_foreign_key "webauthn_credentials", "users"
 
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
+      SELECT account_id,
+      sum(rank) AS rank,
+      array_agg(reason) AS reason
+     FROM ( SELECT account_summaries.account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM (((follows
+               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT account_summaries.account_id,
+              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM (((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
+               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
+            GROUP BY account_summaries.account_id
+           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
+    GROUP BY account_id
+    ORDER BY (sum(rank)) DESC;
+  SQL
+  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
+
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (
            SELECT accounts.domain,
@@ -1477,52 +1525,5 @@ ActiveRecord::Schema.define(version: 2026_09_08_230003) do
        LEFT JOIN domain_counts ON (((domain_counts.domain)::text = (domain_allows.domain)::text)));
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
-
-  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
-      SELECT accounts.id AS account_id,
-      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
-      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
-     FROM (accounts
-       CROSS JOIN LATERAL ( SELECT statuses.account_id,
-              statuses.language,
-              statuses.sensitive
-             FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
-            ORDER BY statuses.id DESC
-           LIMIT 20) t0)
-    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
-    GROUP BY accounts.id;
-  SQL
-  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
-
-  create_view "follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT t0.account_id,
-      sum(t0.rank) AS rank,
-      array_agg(t0.reason) AS reason
-     FROM ( SELECT account_summaries.account_id,
-              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
-              'most_followed'::text AS reason
-             FROM (((follows
-               JOIN account_summaries ON ((account_summaries.account_id = follows.target_account_id)))
-               JOIN users ON ((users.account_id = follows.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = follows.target_account_id)))
-            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (count(follows.id) >= 5)
-          UNION ALL
-           SELECT account_summaries.account_id,
-              (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) / (1.0 + sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)))) AS rank,
-              'most_interactions'::text AS reason
-             FROM (((status_stats
-               JOIN statuses ON ((statuses.id = status_stats.status_id)))
-               JOIN account_summaries ON ((account_summaries.account_id = statuses.account_id)))
-               LEFT JOIN follow_recommendation_suppressions ON ((follow_recommendation_suppressions.account_id = statuses.account_id)))
-            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (account_summaries.sensitive = false) AND (follow_recommendation_suppressions.id IS NULL))
-            GROUP BY account_summaries.account_id
-           HAVING (sum(((status_stats.reblogs_count + status_stats.favourites_count) + status_stats.emoji_reactions_count)) >= (5)::numeric)) t0
-    GROUP BY t0.account_id
-    ORDER BY (sum(t0.rank)) DESC;
-  SQL
-  add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
 
 end

--- a/spec/fabricators/moderation_action_fabricator.rb
+++ b/spec/fabricators/moderation_action_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:moderation_action) do
+  subject      { Fabricate(:moderation_subject) }
+  action_type  :suspend
+  performed_at { Time.now.utc }
+end

--- a/spec/fabricators/moderation_evidence_snapshot_fabricator.rb
+++ b/spec/fabricators/moderation_evidence_snapshot_fabricator.rb
@@ -1,0 +1,6 @@
+Fabricator(:moderation_evidence_snapshot) do
+  subject        { Fabricate(:moderation_subject) }
+  window_start   { 30.days.ago }
+  window_end     { Time.now.utc }
+  schema_version 1
+end

--- a/spec/lib/moderation/causality_spec.rb
+++ b/spec/lib/moderation/causality_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::Causality do
+  let(:actor_subject)    { Fabricate(:moderation_subject) }
+  let(:target_subject)   { Fabricate(:moderation_subject) }
+  let(:contacted_at)     { Time.utc(2026, 1, 1, 10, 0, 0) }
+  let(:interaction) do
+    Fabricate(
+      :moderation_interaction_event,
+      actor_subject: actor_subject,
+      target_subject: target_subject,
+      occurred_at: contacted_at
+    )
+  end
+
+  def rejection(occurred_at:, preceding: interaction)
+    Fabricate(
+      :moderation_rejection_event,
+      rejector_subject: target_subject,
+      rejected_subject: actor_subject,
+      preceding_interaction_event: preceding,
+      occurred_at: occurred_at
+    )
+  end
+
+  describe '.valid_link?' do
+    it 'is true when the rejection follows the matching contact within the window' do
+      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at + 1.hour))).to be true
+    end
+
+    it 'is false when the rejection occurs before the contact' do
+      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at - 1.hour, preceding: nil))).to be false
+    end
+
+    it 'is false when the elapsed time exceeds MAX_WINDOW' do
+      expect(described_class.valid_link?(interaction, rejection(occurred_at: contacted_at + described_class::MAX_WINDOW + 1.second))).to be false
+    end
+
+    it 'is false when the interaction pair is reversed' do
+      reversed = Fabricate(
+        :moderation_interaction_event,
+        actor_subject: target_subject,
+        target_subject: actor_subject,
+        occurred_at: contacted_at
+      )
+      expect(described_class.valid_link?(reversed, rejection(occurred_at: contacted_at + 1.minute, preceding: reversed))).to be false
+    end
+
+    it 'is false without a preceding interaction' do
+      expect(described_class.valid_link?(nil, rejection(occurred_at: contacted_at + 1.minute, preceding: nil))).to be false
+    end
+  end
+
+  describe '.find_preceding_interaction' do
+    it 'returns the nearest earlier contact from rejected to rejector' do
+      older = Fabricate(
+        :moderation_interaction_event,
+        actor_subject: actor_subject,
+        target_subject: target_subject,
+        occurred_at: contacted_at - 2.hours
+      )
+      newer = interaction
+
+      found = described_class.find_preceding_interaction(
+        rejected_subject: actor_subject,
+        rejector_subject: target_subject,
+        occurred_at: contacted_at + 5.minutes
+      )
+
+      expect(found).to eq newer
+      expect(found).to_not eq older
+    end
+
+    it 'ignores contacts after the rejection' do
+      earlier = interaction
+      Fabricate(
+        :moderation_interaction_event,
+        actor_subject: actor_subject,
+        target_subject: target_subject,
+        occurred_at: contacted_at + 1.hour
+      )
+
+      found = described_class.find_preceding_interaction(
+        rejected_subject: actor_subject,
+        rejector_subject: target_subject,
+        occurred_at: contacted_at
+      )
+
+      expect(found).to eq earlier
+    end
+  end
+end

--- a/spec/lib/moderation/retention_policy_spec.rb
+++ b/spec/lib/moderation/retention_policy_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::RetentionPolicy do
+  describe '.retention_days' do
+    it 'defaults to 365 when unset' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: nil do
+        expect(described_class.retention_days).to eq 365
+      end
+    end
+
+    it 'reads MODERATION_LEDGER_RETENTION_DAYS' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        expect(described_class.retention_days).to eq 30
+      end
+    end
+
+    it 'clamps negative values to 0 (disabled)' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '-5' do
+        expect(described_class.retention_days).to eq 0
+        expect(described_class.enabled?).to be false
+      end
+    end
+  end
+
+  describe '.expire_at' do
+    it 'is nil when retention is disabled' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '0' do
+        expect(described_class.expire_at(Time.now.utc)).to be_nil
+      end
+    end
+
+    it 'is the tombstone time plus the retention duration when enabled' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '10' do
+        from = Time.utc(2026, 1, 1)
+        expect(described_class.expire_at(from)).to eq(from + 10.days)
+      end
+    end
+  end
+end

--- a/spec/models/moderation/admin_action_hook_spec.rb
+++ b/spec/models/moderation/admin_action_hook_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+# Phase 4 / PR 5: a moderator action taken through Admin::AccountAction records
+# a ModerationAction plus an evidence snapshot into the ledger.
+RSpec.describe 'Moderation admin action hook', type: :model do
+  let(:moderator) { Fabricate(:account, user: Fabricate(:user, admin: true)) }
+  let(:target)    { Fabricate(:account, user: Fabricate(:user)) }
+
+  def perform(type)
+    action = Admin::AccountAction.new
+    action.assign_attributes(type: type, current_account: moderator, target_account: target)
+    action.save!
+  end
+
+  it 'records a freeze action with an evidence snapshot when disabling' do
+    expect { perform('disable') }.to change(ModerationAction, :count).by(1).and change(ModerationEvidenceSnapshot, :count).by(1)
+
+    action = ModerationAction.last
+    expect(action.action_type).to eq 'freeze'
+    expect(action.subject.account_id).to eq target.id
+    expect(action.moderator_account_id).to eq moderator.id
+    expect(action.reason_code).to eq 'disable'
+    expect(action.evidence_snapshot).to be_present
+  end
+
+  it 'maps silence to a limit action' do
+    expect { perform('silence') }.to change(ModerationAction, :count).by(1)
+    expect(ModerationAction.last.action_type).to eq 'limit'
+  end
+end

--- a/spec/models/moderation/retention_spec.rb
+++ b/spec/models/moderation/retention_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'ModerationSubject retention', type: :model do
+  describe '#tombstone!' do
+    it 'sets deleted_at and retention_until from the policy' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        subject = Fabricate(:moderation_subject)
+        now = Time.now.utc
+
+        subject.tombstone!(now: now)
+
+        expect(subject.reload).to be_tombstoned
+        expect(subject.deleted_at).to be_within(1.second).of(now)
+        expect(subject.retention_until).to be_within(1.second).of(now + 30.days)
+      end
+    end
+
+    it 'leaves retention_until nil when retention is disabled' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '0' do
+        subject = Fabricate(:moderation_subject)
+
+        subject.tombstone!
+
+        expect(subject.reload).to be_tombstoned
+        expect(subject.retention_until).to be_nil
+      end
+    end
+  end
+
+  describe '.tombstone_for_account!' do
+    it 'tombstones the live subject bound to the account' do
+      account = Fabricate(:account)
+      subject = ModerationSubject.for_account!(account)
+
+      ModerationSubject.tombstone_for_account!(account)
+
+      expect(subject.reload).to be_tombstoned
+    end
+  end
+
+  describe 'scopes' do
+    it 'orphaned matches detached, non-tombstoned subjects' do
+      subject = Fabricate(:moderation_subject)
+      subject.update!(account_id: nil)
+
+      expect(ModerationSubject.orphaned).to include(subject)
+    end
+
+    it 'expired matches tombstoned subjects past retention_until' do
+      expired = Fabricate(:moderation_subject, deleted_at: 2.days.ago, retention_until: 1.day.ago)
+      future  = Fabricate(:moderation_subject, deleted_at: 2.days.ago, retention_until: 1.day.from_now)
+
+      expect(ModerationSubject.expired).to include(expired)
+      expect(ModerationSubject.expired).to_not include(future)
+    end
+  end
+end

--- a/spec/models/moderation/shared_evidence_retention_spec.rb
+++ b/spec/models/moderation/shared_evidence_retention_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+# Regression for the shared-evidence retention bug: expiring B must not erase
+# A→B contacts or B→A rejections while A is still retained.
+RSpec.describe 'Moderation shared evidence retention', type: :model do
+  it 'keeps A\'s contact and rejection evidence after B tombstones and expires' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      alice = Fabricate(:account, username: 'alice_retained')
+      bob   = Fabricate(:account, username: 'bob_expired')
+
+      contact = Moderation::EventRecorder.record_interaction(actor: alice, target: bob, event_type: :follow)
+      rejection = Moderation::EventRecorder.record_rejection(
+        rejector: bob,
+        rejected: alice,
+        event_type: :block,
+        preceding_interaction: contact
+      )
+
+      alice_subject = contact.actor_subject
+      bob_subject   = contact.target_subject
+
+      bob_subject.tombstone!(now: 40.days.ago)
+
+      Scheduler::ModerationLedgerRetentionScheduler.new.perform
+
+      expect(ModerationSubject.exists?(alice_subject.id)).to be true
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+      expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+
+      expect(ModerationInteractionEvent.where(actor_subject_id: alice_subject.id, target_subject_id: bob_subject.id)).to exist
+      expect(ModerationRejectionEvent.where(rejector_subject_id: bob_subject.id, rejected_subject_id: alice_subject.id)).to exist
+
+      expect(alice_subject.reload).to_not be_tombstoned
+      expect(bob_subject.reload).to be_tombstoned
+    end
+  end
+end

--- a/spec/models/moderation_action_spec.rb
+++ b/spec/models/moderation_action_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ModerationAction, type: :model do
+  it 'is valid with the required attributes' do
+    expect(Fabricate.build(:moderation_action)).to be_valid
+  end
+
+  it 'requires an action_type and performed_at' do
+    action = Fabricate.build(:moderation_action, action_type: nil, performed_at: nil)
+    expect(action).to_not be_valid
+    expect(action.errors.attribute_names).to include(:action_type, :performed_at)
+  end
+
+  it 'exposes the action types' do
+    expect(described_class.action_types.keys).to match_array(%w(warn limit freeze suspend delete other))
+  end
+
+  it 'optionally links a moderator and an evidence snapshot' do
+    moderator = Fabricate(:account)
+    snapshot  = Fabricate(:moderation_evidence_snapshot)
+    action    = Fabricate(:moderation_action, moderator_account: moderator, evidence_snapshot: snapshot)
+
+    expect(action.moderator_account).to eq moderator
+    expect(action.evidence_snapshot).to eq snapshot
+  end
+end

--- a/spec/models/moderation_evidence_snapshot_spec.rb
+++ b/spec/models/moderation_evidence_snapshot_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ModerationEvidenceSnapshot, type: :model do
+  it 'is valid with the required attributes' do
+    expect(Fabricate.build(:moderation_evidence_snapshot)).to be_valid
+  end
+
+  it 'requires a positive integer schema_version' do
+    expect(Fabricate.build(:moderation_evidence_snapshot, schema_version: 0)).to_not be_valid
+  end
+
+  it 'reads the negative target set from the fingerprint' do
+    snapshot = Fabricate(:moderation_evidence_snapshot, fingerprint: { 'negative_target_subject_ids' => [1, 2, 3] })
+    expect(snapshot.negative_target_subject_ids).to eq [1, 2, 3]
+  end
+end

--- a/spec/models/moderation_evidence_snapshot_spec.rb
+++ b/spec/models/moderation_evidence_snapshot_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe ModerationEvidenceSnapshot, type: :model do
     snapshot = Fabricate(:moderation_evidence_snapshot, fingerprint: { 'negative_target_subject_ids' => [1, 2, 3] })
     expect(snapshot.negative_target_subject_ids).to eq [1, 2, 3]
   end
+
+  it 'reads the weak same-window correlation set separately from causal targets' do
+    snapshot = Fabricate(
+      :moderation_evidence_snapshot,
+      fingerprint: {
+        'negative_target_subject_ids' => [1],
+        'correlated_negative_target_subject_ids' => [2, 3],
+      }
+    )
+    expect(snapshot.negative_target_subject_ids).to eq [1]
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [2, 3]
+  end
 end

--- a/spec/services/moderation/action_recorder_spec.rb
+++ b/spec/services/moderation/action_recorder_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::ActionRecorder, type: :service do
+  let(:account)   { Fabricate(:account) }
+  let(:moderator) { Fabricate(:account) }
+
+  describe '.record' do
+    it 'records an action and generates an evidence snapshot' do
+      expect { described_class.record(account: account, action_type: :suspend, moderator: moderator, reason_code: 'suspend') }
+        .to change(ModerationAction, :count).by(1)
+        .and change(ModerationEvidenceSnapshot, :count).by(1)
+
+      action = ModerationAction.last
+      expect(action.action_type).to eq 'suspend'
+      expect(action.subject.account_id).to eq account.id
+      expect(action.moderator_account_id).to eq moderator.id
+      expect(action.reason_code).to eq 'suspend'
+      expect(action.evidence_snapshot).to be_present
+    end
+
+    it 'is failure-tolerant and returns nil on error' do
+      allow(Rails.logger).to receive(:warn)
+
+      result = nil
+      expect { result = described_class.record(account: nil, action_type: :suspend) }.to_not change(ModerationAction, :count)
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/services/moderation/deletion_durability_spec.rb
+++ b/spec/services/moderation/deletion_durability_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+# PR 3: deleting/purging an account through DeleteAccountService must tombstone
+# the moderation subject (and set its retention window) while preserving the
+# recorded events — the account link is only nullified, never cascaded.
+RSpec.describe 'Moderation ledger deletion durability', type: :service do
+  it 'tombstones the subject and preserves events when an account is purged' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      actor  = Fabricate(:account, domain: 'a.example', uri: 'https://a.example/users/x', inbox_url: 'https://a.example/inbox', protocol: :activitypub)
+      target = Fabricate(:account, domain: 'b.example', uri: 'https://b.example/users/y', inbox_url: 'https://b.example/inbox', protocol: :activitypub)
+
+      event = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :follow)
+      subject_id = event.actor_subject_id
+
+      expect { DeleteAccountService.new.call(actor, reserve_username: false, skip_side_effects: true) }
+        .to_not change(ModerationInteractionEvent, :count)
+
+      subject = ModerationSubject.find(subject_id)
+      expect(subject.account_id).to be_nil
+      expect(subject).to be_tombstoned
+      expect(subject.retention_until).to be_present
+      expect(ModerationInteractionEvent.exists?(event.id)).to be true
+    end
+  end
+end

--- a/spec/services/moderation/event_recorder_spec.rb
+++ b/spec/services/moderation/event_recorder_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe Moderation::EventRecorder, type: :service do
       expect(event.preceding_interaction_event).to eq contact
     end
 
+    it 'auto-links the nearest earlier contact when no preceding interaction is given' do
+      older = described_class.record_interaction(actor: actor, target: target, event_type: :mention, occurred_at: 3.hours.ago)
+      newer = described_class.record_interaction(actor: actor, target: target, event_type: :follow, occurred_at: 1.hour.ago)
+
+      event = described_class.record_rejection(rejector: target, rejected: actor, event_type: :block)
+
+      expect(event.preceding_interaction_event).to eq newer
+      expect(event.preceding_interaction_event).to_not eq older
+    end
+
+    it 'does not link a later contact as the cause of an earlier rejection' do
+      event = described_class.record_rejection(rejector: target, rejected: actor, event_type: :block, occurred_at: 2.hours.ago)
+      described_class.record_interaction(actor: actor, target: target, event_type: :mention, occurred_at: 1.hour.ago)
+
+      expect(event.reload.preceding_interaction_event).to be_nil
+    end
+
     it 'does not raise and returns nil on failure' do
       allow(Rails.logger).to receive(:warn)
 
@@ -73,6 +90,68 @@ RSpec.describe Moderation::EventRecorder, type: :service do
       end.to_not change(ModerationRejectionEvent, :count)
 
       expect(result).to be_nil
+    end
+  end
+
+  describe 'source-event idempotency' do
+    it 'does not insert a second interaction for the same source record' do
+      status = Fabricate(:status, account: actor)
+      favourite = Fabricate(:favourite, account: actor, status: status)
+
+      first = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+      second = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+
+      expect(ModerationInteractionEvent.count).to eq 1
+      expect(second.id).to eq first.id
+      expect(first.source_event_key).to eq "Favourite:#{favourite.id}:favourite"
+    end
+
+    it 'returns the existing row when a uniqueness race loses the insert' do
+      status = Fabricate(:status, account: actor)
+      favourite = Fabricate(:favourite, account: actor, status: status)
+      first = described_class.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+      key = first.source_event_key
+      lookups = 0
+
+      allow(ModerationInteractionEvent).to receive(:find_by).and_wrap_original do |method, *args|
+        attrs = args.first
+        if attrs.is_a?(Hash) && attrs[:source_event_key] == key
+          lookups += 1
+          lookups == 1 ? nil : method.call(*args)
+        else
+          method.call(*args)
+        end
+      end
+      allow(ModerationInteractionEvent).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'idx')
+
+      raced = described_class.new.record_interaction(
+        actor: actor,
+        target: target,
+        event_type: :favourite,
+        status: status,
+        source_record: favourite
+      )
+
+      expect(raced.id).to eq first.id
+      expect(lookups).to be >= 1
     end
   end
 end

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
   let(:c)     { Fabricate(:account, username: 'ccc') }
   let(:d)     { Fabricate(:account, username: 'ddd') }
 
-  it 'summarises interactions/rejections and captures the negative target set' do
+  def subject_for(account)
+    ModerationSubject.find_by(account_id: account.id)
+  end
+
+  it 'summarises interactions/rejections and captures the causal negative target set' do
     Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention)
     Moderation::EventRecorder.record_interaction(actor: actor, target: b, event_type: :follow)
     Moderation::EventRecorder.record_interaction(actor: actor, target: c, event_type: :mention)
 
-    # a and b were contacted and rejected the actor -> negative targets.
+    # a and b were contacted and then rejected the actor -> strong negative targets.
     Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block)
     Moderation::EventRecorder.record_rejection(rejector: b, rejected: actor, event_type: :report)
     # d rejected the actor but was never contacted -> responder, not a target.
@@ -26,14 +30,57 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.summary['reports_received']).to eq 1
     expect(snapshot.summary['negative_responders']).to eq 3
     expect(snapshot.summary['negative_target_count']).to eq 2
+    expect(snapshot.summary['correlated_negative_target_count']).to eq 0
 
-    a_subject = ModerationSubject.find_by(account_id: a.id)
-    b_subject = ModerationSubject.find_by(account_id: b.id)
-    expect(snapshot.negative_target_subject_ids).to match_array([a_subject.id, b_subject.id])
+    expect(snapshot.negative_target_subject_ids).to match_array([subject_for(a).id, subject_for(b).id])
+    expect(snapshot.correlated_negative_target_subject_ids).to be_empty
 
     expect(snapshot.schema_version).to eq described_class::SCHEMA_VERSION
     expect(snapshot.window_end).to be_present
     expect(snapshot.window_start).to be_present
+    expect(snapshot.fingerprint['coverage']).to eq described_class::INBOUND_ACTIVITYPUB_COVERAGE
+    expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+  end
+
+  it 'does not put unordered same-window overlap into negative_target_subject_ids' do
+    # B rejects A first, then A contacts B — same snapshot window, no causality.
+    Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block, occurred_at: 2.hours.ago)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention, occurred_at: 1.hour.ago)
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.summary['interactions_count']).to eq 1
+    expect(snapshot.summary['blocks_received']).to eq 1
+    expect(snapshot.summary['negative_target_count']).to eq 0
+    expect(snapshot.negative_target_subject_ids).to be_empty
+    expect(snapshot.summary['correlated_negative_target_count']).to eq 1
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [subject_for(a).id]
+  end
+
+  it 'treats an unlinked same-window pair as a weak correlation, not a causal target' do
+    actor_subject = ModerationSubject.for_account!(actor)
+    a_subject     = ModerationSubject.for_account!(a)
+
+    Fabricate(
+      :moderation_interaction_event,
+      actor_subject: actor_subject,
+      target_subject: a_subject,
+      event_type: :mention,
+      occurred_at: 3.hours.ago
+    )
+    Fabricate(
+      :moderation_rejection_event,
+      rejector_subject: a_subject,
+      rejected_subject: actor_subject,
+      event_type: :block,
+      preceding_interaction_event: nil,
+      occurred_at: 1.hour.ago
+    )
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.negative_target_subject_ids).to be_empty
+    expect(snapshot.correlated_negative_target_subject_ids).to eq [a_subject.id]
   end
 
   it 'respects the window boundary' do

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
+  let(:actor) { Fabricate(:account, username: 'actor') }
+  let(:a)     { Fabricate(:account, username: 'aaa') }
+  let(:b)     { Fabricate(:account, username: 'bbb') }
+  let(:c)     { Fabricate(:account, username: 'ccc') }
+  let(:d)     { Fabricate(:account, username: 'ddd') }
+
+  it 'summarises interactions/rejections and captures the negative target set' do
+    Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: b, event_type: :follow)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: c, event_type: :mention)
+
+    # a and b were contacted and rejected the actor -> negative targets.
+    Moderation::EventRecorder.record_rejection(rejector: a, rejected: actor, event_type: :block)
+    Moderation::EventRecorder.record_rejection(rejector: b, rejected: actor, event_type: :report)
+    # d rejected the actor but was never contacted -> responder, not a target.
+    Moderation::EventRecorder.record_rejection(rejector: d, rejected: actor, event_type: :block)
+
+    snapshot = described_class.new.call(actor)
+
+    expect(snapshot.summary['interactions_count']).to eq 3
+    expect(snapshot.summary['unique_contacts']).to eq 3
+    expect(snapshot.summary['blocks_received']).to eq 2
+    expect(snapshot.summary['reports_received']).to eq 1
+    expect(snapshot.summary['negative_responders']).to eq 3
+    expect(snapshot.summary['negative_target_count']).to eq 2
+
+    a_subject = ModerationSubject.find_by(account_id: a.id)
+    b_subject = ModerationSubject.find_by(account_id: b.id)
+    expect(snapshot.negative_target_subject_ids).to match_array([a_subject.id, b_subject.id])
+
+    expect(snapshot.schema_version).to eq described_class::SCHEMA_VERSION
+    expect(snapshot.window_end).to be_present
+    expect(snapshot.window_start).to be_present
+  end
+
+  it 'respects the window boundary' do
+    Moderation::EventRecorder.record_interaction(actor: actor, target: a, event_type: :mention, occurred_at: 100.days.ago)
+
+    snapshot = described_class.new.call(actor, window: 30.days)
+    expect(snapshot.summary['interactions_count']).to eq 0
+  end
+end

--- a/spec/services/moderation/follow_import_hook_spec.rb
+++ b/spec/services/moderation/follow_import_hook_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+# Integration: a real following import records a FollowImportBatch (and its
+# targets) before the follows are executed.
+RSpec.describe 'Follow import moderation hook', type: :service do
+  include RoutingHelper
+
+  let!(:account) { Fabricate(:account, locked: false) }
+  let!(:bob)     { Fabricate(:account, username: 'bob', locked: false) }
+  let!(:eve)     { Fabricate(:account, username: 'eve', domain: 'example.com', locked: false, protocol: :activitypub, inbox_url: 'https://example.com/inbox') }
+  let(:csv)      { attachment_fixture('mute-imports.txt') }
+  let(:import)   { Import.create(account: account, type: 'following', data: csv) }
+
+  before { stub_request(:post, 'https://example.com/inbox').to_return(status: 200) }
+
+  it 'records a follow import batch with resolved targets' do
+    expect { ImportService.new.call(import) }.to change(FollowImportBatch, :count).by(1)
+
+    batch = FollowImportBatch.last
+    expect(batch.subject.account_id).to eq account.id
+    expect(batch.target_count).to eq 2
+    expect(batch.resolved_target_count).to eq 2
+    expect(batch.targets.count).to eq 2
+    expect(batch.targets.filter_map { |t| t.target_subject&.account_id }).to match_array([bob.id, eve.id])
+  end
+end

--- a/spec/services/moderation/follow_import_hook_spec.rb
+++ b/spec/services/moderation/follow_import_hook_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe 'Follow import moderation hook', type: :service do
     expect(batch.targets.count).to eq 2
     expect(batch.targets.filter_map { |t| t.target_subject&.account_id }).to match_array([bob.id, eve.id])
   end
+
+  it 'does not create a second logical batch when the same import job is retried' do
+    expect { ImportService.new.call(import) }.to change(FollowImportBatch, :count).by(1)
+    expect { ImportService.new.call(import) }.to_not change(FollowImportBatch, :count)
+    expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+  end
 end

--- a/spec/services/moderation/follow_import_recorder_spec.rb
+++ b/spec/services/moderation/follow_import_recorder_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Moderation::FollowImportRecorder, type: :service do
+  let(:account) { Fabricate(:account, username: 'importer') }
+  let!(:bob)    { Fabricate(:account, username: 'bob') }
+  let!(:eve)    { Fabricate(:account, username: 'eve', domain: 'example.com') }
+
+  describe '.record_batch' do
+    it 'records a batch with resolved and unresolved targets' do
+      accts = ['bob', 'eve@example.com', 'ghost@unknown.example']
+
+      batch = nil
+      expect { batch = described_class.record_batch(account: account, accts: accts, mode: :merge) }
+        .to change(FollowImportBatch, :count).by(1)
+        .and change(FollowImportTarget, :count).by(3)
+
+      expect(batch.subject.account_id).to eq account.id
+      expect(batch.mode).to eq 'merge'
+      expect(batch.target_count).to eq 3
+      expect(batch.resolved_target_count).to eq 2
+      expect(batch.unresolved_target_count).to eq 1
+      expect(batch.account_age_seconds).to be_present
+
+      resolved = batch.targets.where.not(target_subject_id: nil)
+      expect(resolved.map { |t| t.target_subject.account_id }).to match_array([bob.id, eve.id])
+
+      unresolved = batch.targets.find_by(target_subject_id: nil)
+      expect(unresolved.target_key_hash).to eq Digest::SHA256.hexdigest('ghost@unknown.example')
+      expect(unresolved.position).to eq 2
+    end
+
+    it 'records prior following relationship state for resolved targets' do
+      account.follow!(bob)
+
+      batch = described_class.record_batch(account: account, accts: ['bob'], mode: :overwrite)
+
+      expect(batch.mode).to eq 'overwrite'
+      expect(batch.targets.first.prior_relationship_state).to eq('following' => true)
+    end
+
+    it 'defaults mode to unknown' do
+      batch = described_class.record_batch(account: account, accts: ['bob'])
+      expect(batch.mode).to eq 'unknown'
+    end
+
+    it 'marks migration evidence weak when the account has aliases' do
+      # Insert directly to avoid AccountAlias#set_uri resolving over the network.
+      AccountAlias.insert!({ account_id: account.id, acct: 'old@example.com', uri: 'https://example.com/users/old', created_at: Time.now.utc, updated_at: Time.now.utc })
+
+      batch = described_class.record_batch(account: account, accts: [])
+      expect(batch.migration_evidence).to eq 'weak'
+    end
+
+    it 'is failure-tolerant and returns nil on error' do
+      allow(Rails.logger).to receive(:warn)
+      expect(described_class.record_batch(account: nil, accts: ['bob'])).to be_nil
+    end
+  end
+end

--- a/spec/services/moderation/follow_import_recorder_spec.rb
+++ b/spec/services/moderation/follow_import_recorder_spec.rb
@@ -55,5 +55,36 @@ RSpec.describe Moderation::FollowImportRecorder, type: :service do
       allow(Rails.logger).to receive(:warn)
       expect(described_class.record_batch(account: nil, accts: ['bob'])).to be_nil
     end
+
+    it 'does not create a second batch when the same import is retried' do
+      import = instance_double(Import, id: 880_001)
+
+      first = described_class.record_batch(account: account, accts: ['bob', 'eve@example.com'], import: import, mode: :merge)
+      second = described_class.record_batch(account: account, accts: ['bob', 'eve@example.com'], import: import, mode: :merge)
+
+      expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+      expect(second.id).to eq first.id
+      expect(FollowImportTarget.where(batch_id: first.id).count).to eq 2
+    end
+
+    it 'returns the existing batch when a uniqueness race loses the insert' do
+      import = instance_double(Import, id: 880_002)
+      first = described_class.record_batch(account: account, accts: ['bob'], import: import)
+      lookups = 0
+
+      allow(FollowImportBatch).to receive(:find_by).and_wrap_original do |method, *args|
+        attrs = args.first
+        if attrs.is_a?(Hash) && attrs[:import_id] == import.id
+          lookups += 1
+          lookups == 1 ? nil : method.call(*args)
+        else
+          method.call(*args)
+        end
+      end
+      allow(FollowImportBatch).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'index_follow_import_batches_on_import_id')
+
+      raced = described_class.new.record_batch(account: account, accts: ['bob'], import: import)
+      expect(raced.id).to eq first.id
+    end
   end
 end

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
       expect(event.event_type).to eq 'block'
       expect(event.rejector_subject.account_id).to eq alice.id
       expect(event.rejected_subject.account_id).to eq bob.id
+      expect(event.source_event_key).to start_with('Block:')
+    end
+
+    it 'links the preceding follow when the blocked account had contacted the blocker' do
+      FollowService.new.call(bob, alice)
+      BlockService.new.call(alice, bob)
+
+      event = last_rejection
+      expect(event.preceding_interaction_event).to be_present
+      expect(event.preceding_interaction_event.event_type).to eq 'follow'
+      expect(event.preceding_interaction_event.actor_subject.account_id).to eq bob.id
     end
   end
 

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -159,6 +159,16 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
 
       expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
     end
+
+    it 'does not record a duplicate event when create loses a uniqueness race' do
+      status = Fabricate(:status, account: bob)
+      existing = EmojiReaction.create!(account: alice, status: status, name: '👍')
+
+      allow(EmojiReaction).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique, 'index_emoji_reactions_on_account_id_and_status_id')
+
+      expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
+      expect(EmojiReaction.find_by(account: alice, status: status, name: '👍')).to eq existing
+    end
   end
 
   describe ProcessStatusReferenceService do

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -139,4 +139,46 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
       expect(event.rejected_subject.account_id).to eq bob.id
     end
   end
+
+  describe EmojiReactionService do
+    it 'records a reaction interaction toward the status author' do
+      status = Fabricate(:status, account: bob)
+
+      expect { EmojiReactionService.new.call(alice, status, '👍') }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reaction'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+      expect(event.status_id).to eq status.id
+    end
+
+    it 'does not record a duplicate reaction when the same emoji already exists' do
+      status = Fabricate(:status, account: bob)
+      EmojiReactionService.new.call(alice, status, '👍')
+
+      expect { EmojiReactionService.new.call(alice, status, '👍') }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
+
+  describe ProcessStatusReferenceService do
+    it 'records a reference interaction toward the referenced author' do
+      referenced = Fabricate(:status, account: bob)
+      status = Fabricate(:status, account: alice)
+
+      expect { ProcessStatusReferenceService.new.call(status, status_reference_ids: [referenced.id]) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reference'
+      expect(event.actor_subject.account_id).to eq alice.id
+      expect(event.target_subject.account_id).to eq bob.id
+    end
+
+    it 'does not record a reference for the quoted status (recorded as a quote instead)' do
+      quoted = Fabricate(:status, account: bob)
+      status = Fabricate(:status, account: alice, quote_id: quoted.id)
+
+      expect { ProcessStatusReferenceService.new.call(status, status_reference_ids: [quoted.id]) }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
 end

--- a/spec/services/moderation/ledger_lifecycle_spec.rb
+++ b/spec/services/moderation/ledger_lifecycle_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+# Composed lifecycle across PRs #26/#28/#29/#30/#31/#32. Individual PR specs
+# being green does not validate this path.
+RSpec.describe 'Moderation ledger composed lifecycle', type: :service do
+  def remote_account(username, domain)
+    Fabricate(
+      :account,
+      username: username,
+      domain: domain,
+      uri: "https://#{domain}/users/#{username}",
+      inbox_url: "https://#{domain}/inbox",
+      protocol: :activitypub
+    )
+  end
+
+  it 'preserves causal, idempotent evidence across import, action, deletion, and retention' do
+    ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+      alice     = Fabricate(:account, username: 'alice_lifecycle')
+      bob       = remote_account('bob_lifecycle', 'bob.example')
+      carol     = Fabricate(:account, username: 'carol_lifecycle')
+      moderator = Fabricate(:account, user: Fabricate(:user, admin: true))
+
+      import = instance_double(Import, id: 9_001)
+      2.times do
+        Moderation::FollowImportRecorder.record_batch(
+          account: alice,
+          accts: [bob.acct],
+          import: import,
+          mode: :merge
+        )
+      end
+      expect(FollowImportBatch.where(import_id: import.id).count).to eq 1
+
+      status = Fabricate(:status, account: alice)
+      favourite = Fabricate(:favourite, account: alice, status: status)
+      2.times do
+        Moderation::EventRecorder.record_interaction(
+          actor: alice,
+          target: bob,
+          event_type: :favourite,
+          status: status,
+          source_record: favourite
+        )
+      end
+      expect(ModerationInteractionEvent.where(source_event_key: "Favourite:#{favourite.id}:favourite").count).to eq 1
+
+      contact = Moderation::EventRecorder.record_interaction(actor: alice, target: bob, event_type: :follow)
+      rejection = Moderation::EventRecorder.record_rejection(rejector: bob, rejected: alice, event_type: :block)
+      expect(rejection.preceding_interaction_event).to eq contact
+
+      Moderation::EventRecorder.record_rejection(rejector: carol, rejected: alice, event_type: :block, occurred_at: 3.hours.ago)
+      Moderation::EventRecorder.record_interaction(actor: alice, target: carol, event_type: :mention, occurred_at: 1.hour.ago)
+
+      action = Admin::AccountAction.new
+      action.assign_attributes(type: 'silence', current_account: moderator, target_account: alice)
+      action.save!
+
+      snapshot = ModerationAction.last.evidence_snapshot
+      bob_subject = contact.target_subject
+      carol_subject = ModerationSubject.find_by(account_id: carol.id)
+      alice_subject = contact.actor_subject
+
+      expect(snapshot.negative_target_subject_ids).to include(bob_subject.id)
+      expect(snapshot.negative_target_subject_ids).to_not include(carol_subject.id)
+      expect(snapshot.correlated_negative_target_subject_ids).to include(carol_subject.id)
+      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'deferred'
+      expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+
+      expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+
+      expect { DeleteAccountService.new.call(bob, reserve_username: false, skip_side_effects: true) }
+        .to_not change(ModerationInteractionEvent, :count)
+
+      bob_subject.reload.tombstone!(now: 40.days.ago)
+      Scheduler::ModerationLedgerRetentionScheduler.new.perform
+
+      expect(ModerationSubject.exists?(alice_subject.id)).to be true
+      expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+      expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+      expect(ModerationInteractionEvent.where(actor_subject_id: alice_subject.id)).to exist
+      expect(ModerationRejectionEvent.where(rejected_subject_id: alice_subject.id)).to exist
+      expect(ModerationEvidenceSnapshot.exists?(snapshot.id)).to be true
+    end
+  end
+end

--- a/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
+++ b/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
@@ -16,17 +16,42 @@ RSpec.describe Scheduler::ModerationLedgerRetentionScheduler do
       end
     end
 
-    it 'expires tombstoned subjects past retention and cascades their events' do
+    it 'expires an unshared tombstoned subject and its only-participant events' do
       ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
-        expired = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
-        other   = Fabricate(:moderation_subject)
-        event   = Fabricate(:moderation_interaction_event, actor_subject: expired, target_subject: other)
+        expired_a = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        expired_b = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        event = Fabricate(:moderation_interaction_event, actor_subject: expired_a, target_subject: expired_b)
 
-        expect { subject.perform }.to change(ModerationSubject, :count).by(-1)
+        expect { subject.perform }.to change(ModerationSubject, :count).by(-2)
 
-        expect(ModerationSubject.exists?(expired.id)).to be false
+        expect(ModerationSubject.exists?(expired_a.id)).to be false
+        expect(ModerationSubject.exists?(expired_b.id)).to be false
         expect(ModerationInteractionEvent.exists?(event.id)).to be false
-        expect(ModerationSubject.exists?(other.id)).to be true
+      end
+    end
+
+    it 'keeps shared evidence when only one participant has expired' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        actor  = Fabricate(:account)
+        target = Fabricate(:account)
+
+        contact = Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :mention)
+        rejection = Moderation::EventRecorder.record_rejection(rejector: target, rejected: actor, event_type: :block, preceding_interaction: contact)
+
+        target_subject = rejection.rejector_subject
+        actor_subject  = contact.actor_subject
+        target_subject.update!(deleted_at: 40.days.ago, retention_until: 10.days.ago)
+
+        expect { subject.perform }.to_not change(ModerationInteractionEvent, :count)
+        expect { subject.perform }.to_not change(ModerationRejectionEvent, :count)
+
+        expect(ModerationSubject.exists?(actor_subject.id)).to be true
+        expect(ModerationSubject.exists?(target_subject.id)).to be true
+        expect(ModerationInteractionEvent.exists?(contact.id)).to be true
+        expect(ModerationRejectionEvent.exists?(rejection.id)).to be true
+
+        expect(ModerationInteractionEvent.where(actor_subject_id: actor_subject.id)).to exist
+        expect(ModerationRejectionEvent.where(rejected_subject_id: actor_subject.id)).to exist
       end
     end
 

--- a/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
+++ b/spec/workers/scheduler/moderation_ledger_retention_scheduler_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Scheduler::ModerationLedgerRetentionScheduler do
+  subject { described_class.new }
+
+  describe '#perform' do
+    it 'reconciles orphaned subjects by tombstoning them' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        orphan = Fabricate(:moderation_subject)
+        orphan.update!(account_id: nil)
+
+        subject.perform
+
+        expect(orphan.reload).to be_tombstoned
+        expect(orphan.retention_until).to be_present
+      end
+    end
+
+    it 'expires tombstoned subjects past retention and cascades their events' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30' do
+        expired = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+        other   = Fabricate(:moderation_subject)
+        event   = Fabricate(:moderation_interaction_event, actor_subject: expired, target_subject: other)
+
+        expect { subject.perform }.to change(ModerationSubject, :count).by(-1)
+
+        expect(ModerationSubject.exists?(expired.id)).to be false
+        expect(ModerationInteractionEvent.exists?(event.id)).to be false
+        expect(ModerationSubject.exists?(other.id)).to be true
+      end
+    end
+
+    it 'does not modify data in dry-run mode' do
+      ClimateControl.modify MODERATION_LEDGER_RETENTION_DAYS: '30', MODERATION_LEDGER_RETENTION_DRY_RUN: 'true' do
+        expired = Fabricate(:moderation_subject, deleted_at: 40.days.ago, retention_until: 10.days.ago)
+
+        expect { subject.perform }.to_not change(ModerationSubject, :count)
+        expect(ModerationSubject.exists?(expired.id)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the cross-PR design review on #26 / #28 / #29 / #30 / #31 / #32. This branch composes those PRs and adds a lifecycle spec. Fixes also landed on the individual PRs where they belong.

### Investigation

| Finding | Reproduces? | Where fixed |
| --- | --- | --- |
| 1. Retention CASCADE deletes shared evidence | **Yes.** Both participant FKs were `ON DELETE CASCADE`; #31's scheduler `delete_all`'d expired subjects and its spec asserted the shared event disappeared. | #31 — event-level retention + `SET NULL` FKs |
| 2. Negative-target fingerprint is unordered window overlap | **Yes.** Snapshot intersected contacted ids with rejector ids; hooks never set `preceding_interaction_event_id`. | #32 — causal window + auto-link + weak correlation set |
| 3. Reaction `find_or_create_by!` block race | **Yes.** The creation block can run before a uniqueness race loses, so `newly_reacted` is true for the loser. Broader ledger had no source-event identity. | #29 (caller race) + #32 (`source_event_key` upsert) |
| 4. Follow-import retry duplicates batches | **Yes.** No unique index on `import_id`; recorder always `create!`. | #30 — unique `import_id` + reuse on retry |
| 5. Inbound ActivityPub coverage | **Yes, as a documented limitation.** Remote Create/Like/Follow/Block do not go through the hooked services. Reports via `ActivityPub::Activity::Flag` → `ReportService` *are* recorded. | #32 — explicit `fingerprint['coverage']`; no path wiring (still deferred) |
| 6. No composed lifecycle spec | **Yes.** PRs were independent. | This branch — `spec/services/moderation/ledger_lifecycle_spec.rb` |

### Semantics chosen

- **Retention:** keep an event while any participant is still retained; hold the expired counterpart subject so ids stay consistent. Counterpart FKs are `ON DELETE SET NULL` as a safety net.
- **Causality:** `negative_target_subject_ids` requires a linked preceding contact (A→B then B→A, rejection at/after contact, within 14 days). Same-window overlap without that link goes to `correlated_negative_target_subject_ids`.
- **Idempotency:** source-backed events upsert on `source_event_key`; follow-import batches upsert on `import_id`.
- **Coverage:** snapshots record `inbound_activitypub: deferred` / `complete_for_remote_subjects: false`. Do not treat remote scores as complete until inbound AP paths are hooked.

### Testing

Composed specs (29 examples in the focused run, 0 failures), including the full lifecycle:

`follow import (retried) → contact → rejection → admin action + causal snapshot → status deletion → counterpart purge/expiry → retained subject's evidence still queryable`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ba73cc3-fb3f-4cc3-911a-5e5bfa7753ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ba73cc3-fb3f-4cc3-911a-5e5bfa7753ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

