### PR TITLE
Inbound ActivityPub coverage: hooks + per-event coverage metadata (PR 6)

### DIFF
--- a/app/lib/activitypub/activity/block.rb
+++ b/app/lib/activitypub/activity/block.rb
@@ -18,7 +18,11 @@ class ActivityPub::Activity::Block < ActivityPub::Activity
 
     unless delete_arrived_first?(@json['id'])
       BlockWorker.perform_async(@account.id, target_account.id)
-      @account.block!(target_account, uri: @json['id'])
+      block = @account.block!(target_account, uri: @json['id'])
+
+      # Inbound block of a local account: the remote actor rejected the local
+      # account. Idempotent via source_event_key (the Block record).
+      Moderation::EventRecorder.record_rejection(rejector: @account, rejected: target_account, event_type: :block, source_record: block)
     end
   end
 end

--- a/app/lib/activitypub/activity/block.rb
+++ b/app/lib/activitypub/activity/block.rb
@@ -7,7 +7,9 @@ class ActivityPub::Activity::Block < ActivityPub::Activity
     return if target_account.nil? || !target_account.local?
 
     if @account.blocking?(target_account)
-      @account.block_relationships.find_by(target_account: target_account).update(uri: @json['id']) if @json['id'].present?
+      existing_block = @account.block_relationships.find_by(target_account: target_account)
+      existing_block.update(uri: @json['id']) if existing_block && @json['id'].present?
+      record_inbound_block(target_account, existing_block)
       return
     end
 
@@ -20,9 +22,18 @@ class ActivityPub::Activity::Block < ActivityPub::Activity
       BlockWorker.perform_async(@account.id, target_account.id)
       block = @account.block!(target_account, uri: @json['id'])
 
-      # Inbound block of a local account: the remote actor rejected the local
-      # account. Idempotent via source_event_key (the Block record).
-      Moderation::EventRecorder.record_rejection(rejector: @account, rejected: target_account, event_type: :block, source_record: block)
+      record_inbound_block(target_account, block)
     end
+  end
+
+  private
+
+  # Inbound block of a local account: the remote actor rejected the local
+  # account. Idempotent via source_event_key (the Block record), so re-delivery
+  # both dedupes and repairs a ledger event a transient recorder failure missed.
+  def record_inbound_block(target_account, block)
+    return if block.nil?
+
+    Moderation::EventRecorder.record_rejection(rejector: @account, rejected: target_account, event_type: :block, source_record: block)
   end
 end

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -30,6 +30,11 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     follow_request = FollowRequest.create!(account: @account, target_account: target_account, uri: @json['id'])
 
+    # Inbound follow of a local account: record the remote actor's contact.
+    # Idempotent via source_event_key (the FollowRequest), so re-delivery does
+    # not double-record.
+    Moderation::EventRecorder.record_interaction(actor: @account, target: target_account, event_type: :follow, source_record: follow_request)
+
     if target_account.locked? || @account.silenced? || @account.bot? && target_account.user.setting_confirm_follow_from_bot
       NotifyService.new.call(target_account, :follow_request, follow_request)
     else

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -12,6 +12,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
     existing_follow_request = ::FollowRequest.find_by(account: @account, target_account: target_account)
     unless existing_follow_request.nil?
       existing_follow_request.update!(uri: @json['id'])
+      record_inbound_follow(target_account)
       return
     end
 
@@ -25,15 +26,11 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
     unless existing_follow.nil?
       existing_follow.update!(uri: @json['id'])
       AuthorizeFollowService.new.call(@account, target_account, skip_follow_request: true, follow_request_uri: @json['id'])
+      record_inbound_follow(target_account)
       return
     end
 
     follow_request = FollowRequest.create!(account: @account, target_account: target_account, uri: @json['id'])
-
-    # Inbound follow of a local account: record the remote actor's contact.
-    # Idempotent via source_event_key (the FollowRequest), so re-delivery does
-    # not double-record.
-    Moderation::EventRecorder.record_interaction(actor: @account, target: target_account, event_type: :follow, source_record: follow_request)
 
     if target_account.locked? || @account.silenced? || @account.bot? && target_account.user.setting_confirm_follow_from_bot
       NotifyService.new.call(target_account, :follow_request, follow_request)
@@ -41,10 +38,27 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
       AuthorizeFollowService.new.call(@account, target_account)
       NotifyService.new.call(target_account, :follow, ::Follow.find_by(account: @account, target_account: target_account))
     end
+
+    # Record the inbound follow contact against the surviving durable record
+    # (the Follow if it was auto-accepted, else the FollowRequest) so first
+    # delivery and any re-delivery share a stable source_event_key. This dedupes
+    # ordinary re-delivery and lets re-delivery repair a ledger event that a
+    # transient recorder failure missed on an earlier delivery.
+    record_inbound_follow(target_account)
   end
 
   def reject_follow_request!(target_account)
     json = Oj.dump(serialize_payload(FollowRequest.new(account: @account, target_account: target_account, uri: @json['id']), ActivityPub::RejectFollowSerializer))
     ActivityPub::DeliveryWorker.perform_async(json, target_account.id, @account.inbox_url)
+  end
+
+  private
+
+  def record_inbound_follow(target_account)
+    source_record = ::Follow.find_by(account: @account, target_account: target_account) ||
+                    ::FollowRequest.find_by(account: @account, target_account: target_account)
+    return if source_record.nil?
+
+    Moderation::EventRecorder.record_interaction(actor: @account, target: target_account, event_type: :follow, source_record: source_record)
   end
 end

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -59,6 +59,24 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
                     ::FollowRequest.find_by(account: @account, target_account: target_account)
     return if source_record.nil?
 
-    Moderation::EventRecorder.record_interaction(actor: @account, target: target_account, event_type: :follow, source_record: source_record)
+    # Key on the ActivityPub Follow activity identity rather than the relationship
+    # record, so the event stays deduped across the FollowRequest -> Follow
+    # conversion: a locked target's pending request may be accepted (request
+    # destroyed, Follow created) and the same activity later re-delivered. Both a
+    # FollowRequest-backed and a Follow-backed recording then share one key.
+    # Falls back to the record-derived key only when the activity has no id.
+    Moderation::EventRecorder.record_interaction(
+      actor: @account,
+      target: target_account,
+      event_type: :follow,
+      source_record: source_record,
+      source_event_key: inbound_follow_source_event_key
+    )
+  end
+
+  def inbound_follow_source_event_key
+    return if @json['id'].blank?
+
+    "activitypub_follow:#{@json['id']}"
   end
 end

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -19,14 +19,20 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
   private
 
   def process_favourite
-    return if @account.favourited?(@original_status)
+    favourite = @original_status.favourites.find_by(account: @account)
 
-    favourite = @original_status.favourites.create!(account: @account)
-
-    if @original_status.account.local?
-      Moderation::EventRecorder.record_interaction(actor: @account, target: @original_status.account, event_type: :favourite, status: @original_status, source_record: favourite)
-      NotifyService.new.call(@original_status.account, :favourite, favourite)
+    if favourite.nil?
+      favourite = @original_status.favourites.create!(account: @account)
+      NotifyService.new.call(@original_status.account, :favourite, favourite) if @original_status.account.local?
     end
+
+    # Record (idempotently) even when the favourite already exists, so that a
+    # re-delivery repairs a ledger event a transient recorder failure missed.
+    record_inbound_favourite(favourite) if @original_status.account.local?
+  end
+
+  def record_inbound_favourite(favourite)
+    Moderation::EventRecorder.record_interaction(actor: @account, target: @original_status.account, event_type: :favourite, status: @original_status, source_record: favourite)
   end
 
   def process_reaction
@@ -50,20 +56,22 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
       return if emoji&.disabled?
     end
 
-    return if @account.reacted?(@original_status, shortcode, emoji)
+    reaction = @original_status.emoji_reactions.find_by(account: @account, name: shortcode)
 
-    reaction = @original_status.emoji_reactions.create!(account: @account, name: shortcode, custom_emoji: emoji, uri: @json['id'])
+    if reaction.nil?
+      reaction = @original_status.emoji_reactions.create!(account: @account, name: shortcode, custom_emoji: emoji, uri: @json['id'])
 
-    if @original_status.account.local?
-      Moderation::EventRecorder.record_interaction(actor: @account, target: @original_status.account, event_type: :reaction, status: @original_status, source_record: reaction)
-    end
-
-    reaction.tap do |reaction|
       if @original_status.account.local? && !@account.silenced? && !@original_status.account.excluded_from_timeline_account_ids.include?(@account.id) && !@original_status.account.excluded_from_timeline_domains.include?(@account.domain)
         NotifyService.new.call(@original_status.account, :emoji_reaction, reaction)
         forward_for_emoji_reaction
         relay_for_emoji_reaction
       end
+    end
+
+    # Record (idempotently) even when the reaction already exists, so that a
+    # re-delivery repairs a ledger event a transient recorder failure missed.
+    if @original_status.account.local?
+      Moderation::EventRecorder.record_interaction(actor: @account, target: @original_status.account, event_type: :reaction, status: @original_status, source_record: reaction)
     end
   rescue Seahorse::Client::NetworkingError
     nil

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -23,7 +23,10 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
     favourite = @original_status.favourites.create!(account: @account)
 
-    NotifyService.new.call(@original_status.account, :favourite, favourite) if @original_status.account.local?
+    if @original_status.account.local?
+      Moderation::EventRecorder.record_interaction(actor: @account, target: @original_status.account, event_type: :favourite, status: @original_status, source_record: favourite)
+      NotifyService.new.call(@original_status.account, :favourite, favourite)
+    end
   end
 
   def process_reaction
@@ -49,7 +52,13 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
     return if @account.reacted?(@original_status, shortcode, emoji)
 
-    @original_status.emoji_reactions.create!(account: @account, name: shortcode, custom_emoji: emoji, uri: @json['id']).tap do |reaction|
+    reaction = @original_status.emoji_reactions.create!(account: @account, name: shortcode, custom_emoji: emoji, uri: @json['id'])
+
+    if @original_status.account.local?
+      Moderation::EventRecorder.record_interaction(actor: @account, target: @original_status.account, event_type: :reaction, status: @original_status, source_record: reaction)
+    end
+
+    reaction.tap do |reaction|
       if @original_status.account.local? && !@account.silenced? && !@original_status.account.excluded_from_timeline_account_ids.include?(@account.id) && !@original_status.account.excluded_from_timeline_domains.include?(@account.domain)
         NotifyService.new.call(@original_status.account, :emoji_reaction, reaction)
         forward_for_emoji_reaction

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -22,7 +22,7 @@
 # incomplete until those paths are covered. See +fingerprint['coverage']+.
 module Moderation
   class EvidenceSnapshotService
-    SCHEMA_VERSION = 3
+    SCHEMA_VERSION = 4
     DEFAULT_WINDOW = 30.days
 
     # Cap the persisted id sets so a pathological subject can't create an
@@ -31,11 +31,17 @@ module Moderation
 
     REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
 
-    # Explicit until inbound ActivityPub interaction paths are wired. Do not
-    # treat snapshot counts or future scores as complete for remote actors.
+    # Inbound ActivityPub coverage is partial: the relationship-style inbound
+    # activities below are now observed, but inbound remote mention/reply/quote
+    # (and follow-request rejections that bypass RejectFollowService) are not
+    # yet hooked. Do not treat snapshot counts or future scores as complete for
+    # remote actors. Coverage is reported per event type so callers can reason
+    # about exactly what is missing.
     INBOUND_ACTIVITYPUB_COVERAGE = {
-      'inbound_activitypub' => 'deferred',
+      'inbound_activitypub' => 'partial',
       'complete_for_remote_subjects' => false,
+      'observed_inbound_event_types' => %w(follow favourite reaction block report reference).freeze,
+      'deferred_inbound_event_types' => %w(mention reply quote follow_reject).freeze,
     }.freeze
 
     def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -1,0 +1,77 @@
+# Moderation signal — inbound ActivityPub coverage audit (PR 6)
+
+- Status: audit + first inbound hooks
+- Scope: record remote-actor → local-target interactions/rejections that were
+  previously observed only from the local side, closing the "remote actor looks
+  inactive" gap in evidence snapshots.
+- Non-goals: scoring, enforcement, inferring remote-server-internal state.
+
+## Why this matters
+
+Until now the ledger only recorded interactions initiated through **local**
+services (`FollowService`, `FavouriteService`, `EmojiReactionService`,
+`BlockService`, …). Inbound ActivityPub activities bypass those services and
+create their records directly, so a remote abuser who mass-follows / favourites
+/ reacts to local accounts and then gets blocked or reported would show up in a
+snapshot with `blocks_received`/`reports_received` > 0 but `unique_contacts`
+= 0 — i.e. "did nothing, but was blocked". Recording the inbound contacts fixes
+that asymmetry.
+
+## Idempotency mechanism (reused, not changed)
+
+`Moderation::EventRecorder` dedupes via `source_event_key`
+(`"#{Model.base_class.name}:#{id}:#{event_type}"`) + a unique index and an
+`upsert_by_source_key` guard. Every inbound hook passes the **created record**
+(`Follow`/`FollowRequest`, `Favourite`, `EmojiReaction`, `Block`) as
+`source_record`, so ActivityPub re-delivery / retries never double-record, and
+the key space does not collide with the local-side hooks (which act on
+different records).
+
+## Inbound path audit
+
+| Activity | Record | Creation site | Prior coverage | PR 6 |
+|---|---|---|---|---|
+| Follow (remote → local) | `FollowRequest` / `Follow` | `activity/follow.rb` `FollowRequest.create!` (both the gated and auto-accept branches originate here) | none (`AuthorizeFollowService`/`follow!`, not `FollowService`) | **hooked** → `follow` |
+| Like → favourite (remote → local status) | `Favourite` | `activity/like.rb#process_favourite` `favourites.create!` | none (not `FavouriteService`) | **hooked** → `favourite` |
+| Like/EmojiReact → reaction (remote → local status) | `EmojiReaction` | `activity/like.rb#process_reaction` `emoji_reactions.create!` | none (not `EmojiReactionService`) | **hooked** → `reaction` |
+| Block (remote → local) | `Block` | `activity/block.rb` `@account.block!` | none (not `BlockService`) | **hooked** → `block` (rejection) |
+| Flag (remote → local) | `Report` | `activity/flag.rb` → `ReportService` | covered | — |
+| Create → reference (remote → local status) | `StatusReference` | `activity/create.rb` → `ProcessStatusReferenceService` | covered (non-quote) | — |
+| Create → mention / reply (remote → local) | `Mention` / thread | `activity/create.rb`, `activity.rb#attach_mentions` (`ProcessMentionsService` is local-only) | none | **deferred** |
+| Create → quote (remote → local) | `Status#quote_id` | `activity/create.rb` (PSR skips quote) | none | **deferred** |
+| Accept (remote accepts local follow request) | `Follow` | `activity/accept.rb` → `follow!` | intentionally skipped | — (already recorded at local request time; recording here would double-count the same logical follow) |
+| Reject (remote rejects local follow request) | destroys `FollowRequest` | `activity/reject.rb` `reject!` (not `RejectFollowService`) | none | **deferred** (`follow_reject`) |
+| Announce (remote boost of local status) | reblog `Status` | `activity/announce.rb` | n/a | out of ledger's event set |
+
+Notes:
+- Inbound favourite/reaction/follow/block always target a **local** account
+  (the activity classes early-return unless the target/status owner is local),
+  so hooks are guarded on `local?` where the target is a status owner.
+- Inbound block on `block.rb` may also call `RejectFollowService` when a local
+  account had a pending follow request to the remote actor; that path already
+  records a `follow_reject` and is unchanged here.
+
+## Coverage metadata
+
+`ModerationEvidenceSnapshot` fingerprints carry `coverage`. It is now reported
+per event type (schema_version bumped 3 → 4):
+
+```json
+{
+  "inbound_activitypub": "partial",
+  "complete_for_remote_subjects": false,
+  "observed_inbound_event_types": ["follow", "favourite", "reaction", "block", "report", "reference"],
+  "deferred_inbound_event_types": ["mention", "reply", "quote", "follow_reject"]
+}
+```
+
+`complete_for_remote_subjects` stays `false` until the deferred inbound
+mention/reply/quote/follow_reject paths are hooked. Do not read a low remote
+count as "no behaviour" while coverage is partial.
+
+## Deferred to a follow-up (PR 6b)
+
+- Inbound remote **mention/reply** (multiple creation sites in `create.rb` /
+  `activity.rb`, silent vs non-silent, async thread resolution).
+- Inbound remote **quote**.
+- Inbound follow-request **reject** (`activity/reject.rb`).

--- a/spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
@@ -1,42 +1,60 @@
 require 'rails_helper'
 
-# PR 6: inbound ActivityPub activities (remote actor -> local target) must be
+# PR 6: inbound ActivityPub activities (remote actor -> local target) are
 # recorded in the moderation ledger, since they bypass the hooked local
-# services. Recording is idempotent via source_event_key.
+# services. Recording is idempotent via source_event_key, and — because
+# recording is failure-tolerant — a later re-delivery must REPAIR a ledger
+# event that a transient recorder failure missed on an earlier delivery.
 RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
   let(:remote) { Fabricate(:account, domain: 'remote.example', uri: 'https://remote.example/users/bob', inbox_url: 'https://remote.example/inbox', protocol: :activitypub) }
   let(:local)  { Fabricate(:account) }
   let(:status) { Fabricate(:status, account: local) }
 
-  def last_interaction
-    ModerationInteractionEvent.order(:id).last
+  def deliver(klass, json)
+    klass.new(json, remote).perform
   end
 
   describe ActivityPub::Activity::Follow do
-    # Locked target keeps this a follow request (no auto-accept / AP delivery).
-    let(:locked_local) { Fabricate(:account, locked: true) }
+    # Unlocked target => auto-accepted: the surviving durable record is the
+    # Follow (the FollowRequest is destroyed by authorization). Stub AP delivery
+    # so the outbound Accept does not hit the network.
+    before { allow(ActivityPub::DeliveryWorker).to receive(:perform_async) }
+
     let(:json) do
       {
         '@context': 'https://www.w3.org/ns/activitystreams',
         id: 'https://remote.example/activities/follow-1',
         type: 'Follow',
         actor: ActivityPub::TagManager.instance.uri_for(remote),
-        object: ActivityPub::TagManager.instance.uri_for(locked_local),
+        object: ActivityPub::TagManager.instance.uri_for(local),
       }.with_indifferent_access
     end
 
     it 'records an inbound follow interaction from the remote actor' do
-      expect { described_class.new(json, remote).perform }.to change(ModerationInteractionEvent, :count).by(1)
+      expect { deliver(described_class, json) }.to change(ModerationInteractionEvent, :count).by(1)
 
-      event = last_interaction
+      event = ModerationInteractionEvent.order(:id).last
       expect(event.event_type).to eq 'follow'
       expect(event.actor_subject.account_id).to eq remote.id
-      expect(event.target_subject.account_id).to eq locked_local.id
+      expect(event.target_subject.account_id).to eq local.id
+      expect(remote.following?(local)).to be true
     end
 
-    it 'does not double-record on re-delivery' do
-      described_class.new(json, remote).perform
-      expect { described_class.new(json, remote).perform }.to_not change(ModerationInteractionEvent, :count)
+    it 'does not double-record on ordinary re-delivery' do
+      deliver(described_class, json)
+      expect { deliver(described_class, json) }.to_not change(ModerationInteractionEvent, :count)
+    end
+
+    it 're-delivery repairs a ledger event missed by a transient recorder failure' do
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+      deliver(described_class, json)
+
+      expect(remote.following?(local)).to be true
+      expect(ModerationInteractionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+      expect { deliver(described_class, json) }.to change(ModerationInteractionEvent, :count).by(1)
+      expect(ModerationInteractionEvent.count).to eq 1
     end
   end
 
@@ -63,9 +81,9 @@ RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
     end
 
     it 'records an inbound favourite toward the local status author' do
-      expect { described_class.new(favourite_json, remote).perform }.to change(ModerationInteractionEvent, :count).by(1)
+      expect { deliver(described_class, favourite_json) }.to change(ModerationInteractionEvent, :count).by(1)
 
-      event = last_interaction
+      event = ModerationInteractionEvent.order(:id).last
       expect(event.event_type).to eq 'favourite'
       expect(event.actor_subject.account_id).to eq remote.id
       expect(event.target_subject.account_id).to eq local.id
@@ -73,17 +91,41 @@ RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
     end
 
     it 'does not double-record a repeated favourite' do
-      described_class.new(favourite_json, remote).perform
-      expect { described_class.new(favourite_json, remote).perform }.to_not change(ModerationInteractionEvent, :count)
+      deliver(described_class, favourite_json)
+      expect { deliver(described_class, favourite_json) }.to_not change(ModerationInteractionEvent, :count)
+    end
+
+    it 'favourite re-delivery repairs a ledger event missed by a recorder failure' do
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+      deliver(described_class, favourite_json)
+
+      expect(remote.favourited?(status)).to be true
+      expect(ModerationInteractionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+      expect { deliver(described_class, favourite_json) }.to change(ModerationInteractionEvent, :count).by(1)
+      expect(ModerationInteractionEvent.count).to eq 1
     end
 
     it 'records an inbound reaction toward the local status author' do
-      expect { described_class.new(reaction_json, remote).perform }.to change(ModerationInteractionEvent, :count).by(1)
+      expect { deliver(described_class, reaction_json) }.to change(ModerationInteractionEvent, :count).by(1)
 
-      event = last_interaction
+      event = ModerationInteractionEvent.order(:id).last
       expect(event.event_type).to eq 'reaction'
       expect(event.actor_subject.account_id).to eq remote.id
       expect(event.target_subject.account_id).to eq local.id
+    end
+
+    it 'reaction re-delivery repairs a ledger event missed by a recorder failure' do
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+      deliver(described_class, reaction_json)
+
+      expect(status.emoji_reactions.exists?(account: remote)).to be true
+      expect(ModerationInteractionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+      expect { deliver(described_class, reaction_json) }.to change(ModerationInteractionEvent, :count).by(1)
+      expect(ModerationInteractionEvent.count).to eq 1
     end
   end
 
@@ -99,7 +141,7 @@ RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
     end
 
     it 'records an inbound block rejection from the remote actor' do
-      expect { described_class.new(json, remote).perform }.to change(ModerationRejectionEvent, :count).by(1)
+      expect { deliver(described_class, json) }.to change(ModerationRejectionEvent, :count).by(1)
 
       event = ModerationRejectionEvent.order(:id).last
       expect(event.event_type).to eq 'block'
@@ -107,9 +149,21 @@ RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
       expect(event.rejected_subject.account_id).to eq local.id
     end
 
-    it 'does not double-record on re-delivery' do
-      described_class.new(json, remote).perform
-      expect { described_class.new(json, remote).perform }.to_not change(ModerationRejectionEvent, :count)
+    it 'does not double-record on ordinary re-delivery' do
+      deliver(described_class, json)
+      expect { deliver(described_class, json) }.to_not change(ModerationRejectionEvent, :count)
+    end
+
+    it 're-delivery repairs a ledger event missed by a transient recorder failure' do
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_return(nil)
+      deliver(described_class, json)
+
+      expect(remote.blocking?(local)).to be true
+      expect(ModerationRejectionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_call_original
+      expect { deliver(described_class, json) }.to change(ModerationRejectionEvent, :count).by(1)
+      expect(ModerationRejectionEvent.count).to eq 1
     end
   end
 end

--- a/spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+# PR 6: inbound ActivityPub activities (remote actor -> local target) must be
+# recorded in the moderation ledger, since they bypass the hooked local
+# services. Recording is idempotent via source_event_key.
+RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
+  let(:remote) { Fabricate(:account, domain: 'remote.example', uri: 'https://remote.example/users/bob', inbox_url: 'https://remote.example/inbox', protocol: :activitypub) }
+  let(:local)  { Fabricate(:account) }
+  let(:status) { Fabricate(:status, account: local) }
+
+  def last_interaction
+    ModerationInteractionEvent.order(:id).last
+  end
+
+  describe ActivityPub::Activity::Follow do
+    # Locked target keeps this a follow request (no auto-accept / AP delivery).
+    let(:locked_local) { Fabricate(:account, locked: true) }
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/follow-1',
+        type: 'Follow',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: ActivityPub::TagManager.instance.uri_for(locked_local),
+      }.with_indifferent_access
+    end
+
+    it 'records an inbound follow interaction from the remote actor' do
+      expect { described_class.new(json, remote).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'follow'
+      expect(event.actor_subject.account_id).to eq remote.id
+      expect(event.target_subject.account_id).to eq locked_local.id
+    end
+
+    it 'does not double-record on re-delivery' do
+      described_class.new(json, remote).perform
+      expect { described_class.new(json, remote).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
+
+  describe ActivityPub::Activity::Like do
+    let(:favourite_json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/like-1',
+        type: 'Like',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: ActivityPub::TagManager.instance.uri_for(status),
+      }.with_indifferent_access
+    end
+
+    let(:reaction_json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/react-1',
+        type: 'EmojiReact',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: ActivityPub::TagManager.instance.uri_for(status),
+        content: '👍',
+      }.with_indifferent_access
+    end
+
+    it 'records an inbound favourite toward the local status author' do
+      expect { described_class.new(favourite_json, remote).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'favourite'
+      expect(event.actor_subject.account_id).to eq remote.id
+      expect(event.target_subject.account_id).to eq local.id
+      expect(event.status_id).to eq status.id
+    end
+
+    it 'does not double-record a repeated favourite' do
+      described_class.new(favourite_json, remote).perform
+      expect { described_class.new(favourite_json, remote).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
+
+    it 'records an inbound reaction toward the local status author' do
+      expect { described_class.new(reaction_json, remote).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reaction'
+      expect(event.actor_subject.account_id).to eq remote.id
+      expect(event.target_subject.account_id).to eq local.id
+    end
+  end
+
+  describe ActivityPub::Activity::Block do
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/block-1',
+        type: 'Block',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: ActivityPub::TagManager.instance.uri_for(local),
+      }.with_indifferent_access
+    end
+
+    it 'records an inbound block rejection from the remote actor' do
+      expect { described_class.new(json, remote).perform }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = ModerationRejectionEvent.order(:id).last
+      expect(event.event_type).to eq 'block'
+      expect(event.rejector_subject.account_id).to eq remote.id
+      expect(event.rejected_subject.account_id).to eq local.id
+    end
+
+    it 'does not double-record on re-delivery' do
+      described_class.new(json, remote).perform
+      expect { described_class.new(json, remote).perform }.to_not change(ModerationRejectionEvent, :count)
+    end
+  end
+end

--- a/spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
@@ -56,6 +56,41 @@ RSpec.describe 'Inbound ActivityPub moderation coverage', type: :model do
       expect { deliver(described_class, json) }.to change(ModerationInteractionEvent, :count).by(1)
       expect(ModerationInteractionEvent.count).to eq 1
     end
+
+    context 'with a locked target (pending -> accepted lifecycle)' do
+      let(:locked) { Fabricate(:account, locked: true) }
+      let(:locked_json) do
+        json.merge(object: ActivityPub::TagManager.instance.uri_for(locked)).with_indifferent_access
+      end
+
+      it 'keeps exactly one follow event across the FollowRequest -> Follow conversion on re-delivery' do
+        # 1. Inbound follow to a locked account -> pending request -> one event.
+        expect { deliver(described_class, locked_json) }.to change(ModerationInteractionEvent, :count).by(1)
+        request = FollowRequest.find_by(account: remote, target_account: locked)
+        expect(request).to be_present
+
+        # 2. Local user accepts: the surviving relationship is now a Follow.
+        request.authorize!
+        expect(remote.following?(locked)).to be true
+        expect(FollowRequest.find_by(account: remote, target_account: locked)).to be_nil
+
+        # 3. Same ActivityPub Follow re-delivered -> existing-Follow branch.
+        expect { deliver(described_class, locked_json) }.to_not change(ModerationInteractionEvent, :count)
+        expect(ModerationInteractionEvent.where(actor_subject: ModerationSubject.find_by(account_id: remote.id)).count).to eq 1
+      end
+
+      it 'repairs a missed ledger event while the request is still pending' do
+        allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+        deliver(described_class, locked_json)
+
+        expect(remote.requested?(locked)).to be true
+        expect(ModerationInteractionEvent.count).to eq 0
+
+        allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+        expect { deliver(described_class, locked_json) }.to change(ModerationInteractionEvent, :count).by(1)
+        expect(ModerationInteractionEvent.count).to eq 1
+      end
+    end
   end
 
   describe ActivityPub::Activity::Like do

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.window_start).to be_present
     expect(snapshot.fingerprint['coverage']).to eq described_class::INBOUND_ACTIVITYPUB_COVERAGE
     expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
-    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'deferred'
+    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
   end
 
   it 'does not put unordered same-window overlap into linked_negative_target_subject_ids' do

--- a/spec/services/moderation/ledger_lifecycle_spec.rb
+++ b/spec/services/moderation/ledger_lifecycle_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Moderation ledger composed lifecycle', type: :service do
       expect(snapshot.linked_negative_target_subject_ids).to include(bob_subject.id)
       expect(snapshot.linked_negative_target_subject_ids).to_not include(carol_subject.id)
       expect(snapshot.correlated_negative_target_subject_ids).to include(carol_subject.id)
-      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'deferred'
+      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
       expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
 
       expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 6 from the status handoff (`moderation-signal-status.md` §20): the top-priority next step, **inbound ActivityPub coverage**. Until now the ledger only recorded interactions initiated through the hooked local services, so inbound activities (remote actor → local target) bypassed recording. A remote abuser who mass-follows / favourites / reacts to local accounts and then gets blocked/reported would show up in an evidence snapshot with `blocks_received`/`reports_received` > 0 but `unique_contacts` = 0 — "did nothing, but was blocked". This closes that asymmetry for the relationship-style inbound activities.

Still recording only — no scoring, no enforcement, no inference of remote-server-internal state.

### Inbound hooks added (record-creation sites that bypass local services)

| Activity | Ledger event | Direction |
| --- | --- | --- |
| `activity/follow.rb` | `follow` (interaction) | remote follower → local account |
| `activity/like.rb` favourite | `favourite` (interaction) | remote → local status author |
| `activity/like.rb` reaction | `reaction` (interaction) | remote → local status author |
| `activity/block.rb` | `block` (rejection) | remote → local account |

Inbound **Flag** (report) and **reference** were already covered via `ReportService` / `ProcessStatusReferenceService`.

### Idempotency

Each hook passes the created record (`FollowRequest`/`Follow`, `Favourite`, `EmojiReaction`, `Block`) as `source_record`, so `Moderation::EventRecorder`'s `source_event_key` + `upsert_by_source_key` dedupe across ActivityPub re-delivery/retries and `RecordNotUnique` races. Keys don't collide with the local-side hooks (different records). Recording is failure-tolerant and never breaks activity processing.

### Coverage metadata (per event type)

Evidence snapshot `schema_version` 3 → 4. The coarse `inbound_activitypub: "deferred"` flag becomes a precise map:

```json
{
  "inbound_activitypub": "partial",
  "complete_for_remote_subjects": false,
  "observed_inbound_event_types": ["follow","favourite","reaction","block","report","reference"],
  "deferred_inbound_event_types": ["mention","reply","quote","follow_reject"]
}
```

`complete_for_remote_subjects` stays `false`; a low remote count must not be read as "no behaviour" while coverage is partial.

### Deliberately deferred (documented for PR 6b)

- Inbound remote **mention/reply** (multiple creation sites, silent vs non-silent, async thread resolution),
- inbound remote **quote**,
- inbound follow-request **reject** (`activity/reject.rb`, bypasses `RejectFollowService`).

Inbound **Accept** is intentionally not recorded (the local follow was already recorded at request time; recording again would double-count the same logical follow).

The full audit (every inbound activity, its record-creation site, prior coverage, and gap classification) is in `docs/moderation-signal-inbound-coverage.md`.

## Testing

New inbound spec (7 examples, 0 failures) covering follow/favourite/reaction/block recording + re-delivery idempotency:

[moderation_inbound_coverage_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderation_inbound_coverage_rspec.log)

Regression: ran the new spec + existing `follow_spec`/`like_spec`/`block_spec` + the full `spec/services/moderation/` suite + interaction/rejection model specs → **91 examples, 0 failures**. The composed lifecycle spec and the snapshot spec were updated for the new `partial` coverage value / schema_version 4. No migration or schema change.

## Scope

Independent of the other open moderation PRs; touches only the three inbound activity classes, the evidence snapshot coverage constant, and specs/docs. No unrelated schema/code drift.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

