### PR TITLE
Inbound ActivityPub coverage: mention / reply / quote (PR 6b)

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -69,9 +69,75 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       elsif @options[:delivered_to_account_id].present?
         postprocess_audience_and_deliver
       end
+
+      # Record inbound mention/reply/quote contacts toward local accounts. Runs
+      # for both a freshly processed status and a re-delivery of an existing one,
+      # so a re-delivery repairs a ledger event a transient recorder failure
+      # missed. Idempotent via stable source_event_keys.
+      record_inbound_status_signals(@status)
     end
 
     @status
+  end
+
+  # Record the remote author's inbound contacts toward local accounts carried by
+  # this status: a reply to a local account, mentions of local accounts, and a
+  # quote of a local account's status. Recording is failure-tolerant.
+  def record_inbound_status_signals(status)
+    return if status.nil? || status.account_id != @account.id
+
+    record_inbound_reply(status)
+    record_inbound_mentions(status)
+    record_inbound_quote(status)
+  end
+
+  def record_inbound_reply(status)
+    return unless status.reply? && status.in_reply_to_account_id.present?
+
+    target = Account.find_by(id: status.in_reply_to_account_id)
+    return if target.nil? || !target.local?
+
+    Moderation::EventRecorder.record_interaction(
+      actor: @account,
+      target: target,
+      event_type: :reply,
+      status: status,
+      source_record: status,
+      source_event_key: "activitypub_reply:#{status.uri}"
+    )
+  end
+
+  def record_inbound_mentions(status)
+    status.mentions.where(silent: false).includes(:account).find_each do |mention|
+      account = mention.account
+      next if account.nil? || !account.local?
+      # The replied-to account is recorded as a reply, not a mention.
+      next if account.id == status.in_reply_to_account_id
+
+      Moderation::EventRecorder.record_interaction(
+        actor: @account,
+        target: account,
+        event_type: :mention,
+        status: status,
+        source_record: mention
+      )
+    end
+  end
+
+  def record_inbound_quote(status)
+    return if status.quote_id.blank?
+
+    quoted = status.quote
+    return if quoted&.account.nil? || !quoted.account.local?
+
+    Moderation::EventRecorder.record_interaction(
+      actor: @account,
+      target: quoted.account,
+      event_type: :quote,
+      status: status,
+      source_record: status,
+      source_event_key: "activitypub_quote:#{status.uri}"
+    )
   end
 
   def audience_to

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -22,7 +22,7 @@
 # incomplete until those paths are covered. See +fingerprint['coverage']+.
 module Moderation
   class EvidenceSnapshotService
-    SCHEMA_VERSION = 4
+    SCHEMA_VERSION = 5
     DEFAULT_WINDOW = 30.days
 
     # Cap the persisted id sets so a pathological subject can't create an
@@ -31,17 +31,17 @@ module Moderation
 
     REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
 
-    # Inbound ActivityPub coverage is partial: the relationship-style inbound
-    # activities below are now observed, but inbound remote mention/reply/quote
-    # (and follow-request rejections that bypass RejectFollowService) are not
-    # yet hooked. Do not treat snapshot counts or future scores as complete for
-    # remote actors. Coverage is reported per event type so callers can reason
-    # about exactly what is missing.
+    # Inbound ActivityPub coverage is partial: the inbound event types below are
+    # now observed, but inbound follow-request rejections (Reject that bypasses
+    # RejectFollowService, destroying the FollowRequest) are not yet hooked. Do
+    # not treat snapshot counts or future scores as complete for remote actors.
+    # Coverage is reported per event type so callers can reason about exactly
+    # what is missing.
     INBOUND_ACTIVITYPUB_COVERAGE = {
       'inbound_activitypub' => 'partial',
       'complete_for_remote_subjects' => false,
-      'observed_inbound_event_types' => %w(follow favourite reaction block report reference).freeze,
-      'deferred_inbound_event_types' => %w(mention reply quote follow_reject).freeze,
+      'observed_inbound_event_types' => %w(follow favourite reaction block report reference mention reply quote).freeze,
+      'deferred_inbound_event_types' => %w(follow_reject).freeze,
     }.freeze
 
     def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -37,8 +37,9 @@ different records).
 | Block (remote → local) | `Block` | `activity/block.rb` `@account.block!` | none (not `BlockService`) | **hooked** → `block` (rejection) |
 | Flag (remote → local) | `Report` | `activity/flag.rb` → `ReportService` | covered | — |
 | Create → reference (remote → local status) | `StatusReference` | `activity/create.rb` → `ProcessStatusReferenceService` | covered (non-quote) | — |
-| Create → mention / reply (remote → local) | `Mention` / thread | `activity/create.rb`, `activity.rb#attach_mentions` (`ProcessMentionsService` is local-only) | none | **deferred** |
-| Create → quote (remote → local) | `Status#quote_id` | `activity/create.rb` (PSR skips quote) | none | **deferred** |
+| Create → mention (remote → local) | `Mention` | `activity/create.rb` `attach_mentions` (`ProcessMentionsService` is local-only) | none | **hooked (PR 6b)** → `mention` |
+| Create → reply (remote → local) | `Status#in_reply_to_account_id` | `activity/create.rb` thread resolution | none | **hooked (PR 6b)** → `reply` |
+| Create → quote (remote → local) | `Status#quote_id` | `activity/create.rb` (PSR skips quote) | none | **hooked (PR 6b)** → `quote` |
 | Accept (remote accepts local follow request) | `Follow` | `activity/accept.rb` → `follow!` | intentionally skipped | — (already recorded at local request time; recording here would double-count the same logical follow) |
 | Reject (remote rejects local follow request) | destroys `FollowRequest` | `activity/reject.rb` `reject!` (not `RejectFollowService`) | none | **deferred** (`follow_reject`) |
 | Announce (remote boost of local status) | reblog `Status` | `activity/announce.rb` | n/a | out of ledger's event set |
@@ -60,18 +61,34 @@ per event type (schema_version bumped 3 → 4):
 {
   "inbound_activitypub": "partial",
   "complete_for_remote_subjects": false,
-  "observed_inbound_event_types": ["follow", "favourite", "reaction", "block", "report", "reference"],
-  "deferred_inbound_event_types": ["mention", "reply", "quote", "follow_reject"]
+  "observed_inbound_event_types": ["follow", "favourite", "reaction", "block", "report", "reference", "mention", "reply", "quote"],
+  "deferred_inbound_event_types": ["follow_reject"]
 }
 ```
 
-`complete_for_remote_subjects` stays `false` until the deferred inbound
-mention/reply/quote/follow_reject paths are hooked. Do not read a low remote
-count as "no behaviour" while coverage is partial.
+`complete_for_remote_subjects` stays `false` until the last deferred inbound
+path (follow-request reject) is hooked. Do not read a low remote count as "no
+behaviour" while coverage is partial.
 
-## Deferred to a follow-up (PR 6b)
+## PR 6b — inbound mention / reply / quote
 
-- Inbound remote **mention/reply** (multiple creation sites in `create.rb` /
-  `activity.rb`, silent vs non-silent, async thread resolution).
-- Inbound remote **quote**.
-- Inbound follow-request **reject** (`activity/reject.rb`).
+`activity/create.rb#create_status` runs a single chokepoint,
+`record_inbound_status_signals`, for both a freshly processed status and a
+re-delivery of an existing one (so a re-delivery repairs a ledger event a
+transient recorder failure missed):
+
+- **reply** — when the inbound status replies to a local account
+  (`in_reply_to_account_id` is local); keyed on `activitypub_reply:<status.uri>`.
+- **mention** — for each non-silent mention of a local account, excluding the
+  replied-to account (recorded as a reply); keyed on the `Mention` record.
+- **quote** — when the inbound status quotes a local account's status; keyed on
+  `activitypub_quote:<status.uri>`.
+
+Reply/quote use activity-identity keys (the status URI) so they stay stable and
+deduped across re-delivery. Silent (audience) mentions are not recorded.
+
+## Deferred to a follow-up
+
+- Inbound follow-request **reject** (`activity/reject.rb`): the `Reject` bypasses
+  `RejectFollowService` and destroys the `FollowRequest`, so a stable key would
+  need to derive from the Reject activity id rather than the destroyed record.

--- a/spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb
@@ -92,6 +92,28 @@ RSpec.describe ActivityPub::Activity::Create, 'moderation inbound coverage' do
       described_class.new(json_for(object_json), sender).perform
       expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
     end
+
+    it 're-delivery repairs a missed reply event with a stable activity-identity key' do
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+      described_class.new(json_for(object_json), sender).perform
+
+      status = sender.statuses.find_by(uri: object_json[:id])
+      expect(status).to be_present
+      expect(status.in_reply_to_account_id).to eq parent_author.id
+      expect(ModerationInteractionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+      expect { described_class.new(json_for(object_json), sender).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reply'
+      expect(event.actor_subject.account_id).to eq sender.id
+      expect(event.target_subject.account_id).to eq parent_author.id
+      expect(event.source_event_key).to eq "activitypub_reply:#{status.uri}"
+
+      # Ordinary further re-delivery stays at exactly one event.
+      expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
   end
 
   describe 'inbound quote of a local status' do
@@ -124,6 +146,28 @@ RSpec.describe ActivityPub::Activity::Create, 'moderation inbound coverage' do
 
     it 'does not double-record on re-delivery' do
       described_class.new(json_for(object_json), sender).perform
+      expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
+
+    it 're-delivery repairs a missed quote event with a stable activity-identity key' do
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+      described_class.new(json_for(object_json), sender).perform
+
+      status = sender.statuses.find_by(uri: object_json[:id])
+      expect(status).to be_present
+      expect(status.quote_id).to eq quoted.id
+      expect(ModerationInteractionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+      expect { described_class.new(json_for(object_json), sender).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'quote'
+      expect(event.actor_subject.account_id).to eq sender.id
+      expect(event.target_subject.account_id).to eq quoted_author.id
+      expect(event.source_event_key).to eq "activitypub_quote:#{status.uri}"
+
+      # Ordinary further re-delivery stays at exactly one event.
       expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
     end
   end

--- a/spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+# PR 6b: inbound ActivityPub Create carrying a mention / reply / quote toward a
+# local account is recorded in the moderation ledger. A single chokepoint in
+# create_status runs for both a freshly processed status and a re-delivery of an
+# existing one, so re-delivery repairs a ledger event a transient recorder
+# failure missed. Recording is idempotent via stable source_event_keys.
+RSpec.describe ActivityPub::Activity::Create, 'moderation inbound coverage' do
+  let(:sender) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/actor', followers_url: 'https://example.com/followers', protocol: :activitypub, inbox_url: 'https://example.com/inbox') }
+
+  def uri_for(record)
+    ActivityPub::TagManager.instance.uri_for(record)
+  end
+
+  def json_for(object_json)
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: [uri_for(sender), '#create'].join,
+      type: 'Create',
+      actor: uri_for(sender),
+      object: object_json,
+    }.with_indifferent_access
+  end
+
+  def last_interaction
+    ModerationInteractionEvent.order(:id).last
+  end
+
+  before { sender.update(uri: uri_for(sender)) }
+
+  describe 'inbound mention of a local account' do
+    let(:recipient) { Fabricate(:account) }
+    let(:object_json) do
+      {
+        id: 'https://example.com/statuses/mention-1',
+        type: 'Note',
+        content: 'hello there',
+        tag: [{ type: 'Mention', href: uri_for(recipient) }],
+      }
+    end
+
+    it 'records a mention interaction toward the local account' do
+      expect { described_class.new(json_for(object_json), sender).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'mention'
+      expect(event.actor_subject.account_id).to eq sender.id
+      expect(event.target_subject.account_id).to eq recipient.id
+    end
+
+    it 'does not double-record on re-delivery' do
+      described_class.new(json_for(object_json), sender).perform
+      expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
+
+    it 're-delivery repairs a ledger event missed by a recorder failure' do
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_return(nil)
+      described_class.new(json_for(object_json), sender).perform
+
+      expect(sender.statuses.first.mentions.exists?(account: recipient)).to be true
+      expect(ModerationInteractionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_interaction).and_call_original
+      expect { described_class.new(json_for(object_json), sender).perform }.to change(ModerationInteractionEvent, :count).by(1)
+      expect(ModerationInteractionEvent.count).to eq 1
+    end
+  end
+
+  describe 'inbound reply to a local account' do
+    let(:parent_author) { Fabricate(:account) }
+    let(:parent)        { Fabricate(:status, account: parent_author) }
+    let(:object_json) do
+      {
+        id: 'https://example.com/statuses/reply-1',
+        type: 'Note',
+        content: 'replying',
+        inReplyTo: uri_for(parent),
+        tag: [{ type: 'Mention', href: uri_for(parent_author) }],
+      }
+    end
+
+    it 'records a reply (not a mention) toward the replied-to local author' do
+      expect { described_class.new(json_for(object_json), sender).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'reply'
+      expect(event.actor_subject.account_id).to eq sender.id
+      expect(event.target_subject.account_id).to eq parent_author.id
+    end
+
+    it 'does not double-record on re-delivery' do
+      described_class.new(json_for(object_json), sender).perform
+      expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
+
+  describe 'inbound quote of a local status' do
+    let(:quoted_author) { Fabricate(:account) }
+    let(:quoted)        { Fabricate(:status, account: quoted_author) }
+    let(:object_json) do
+      {
+        id: 'https://example.com/statuses/quote-1',
+        type: 'Note',
+        content: 'quoting',
+        quoteUri: uri_for(quoted),
+      }
+    end
+
+    before do
+      allow_any_instance_of(ResolveURLService).to receive(:call).and_return(quoted)
+      # The quote URL is passed to ProcessStatusReferenceService, which resolves
+      # the domain via Node; stub it so the test does not hit the network.
+      allow(Node).to receive(:resolve_domain).and_return(nil)
+    end
+
+    it 'records a quote interaction toward the quoted local author' do
+      expect { described_class.new(json_for(object_json), sender).perform }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'quote'
+      expect(event.actor_subject.account_id).to eq sender.id
+      expect(event.target_subject.account_id).to eq quoted_author.id
+    end
+
+    it 'does not double-record on re-delivery' do
+      described_class.new(json_for(object_json), sender).perform
+      expect { described_class.new(json_for(object_json), sender).perform }.to_not change(ModerationInteractionEvent, :count)
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the inbound ActivityPub coverage started in #34 (PR 6). That PR hooked the relationship-style inbound activities (follow/favourite/reaction/block); this one hooks the remaining high-value inbound contact signals carried by an inbound remote status: **mention, reply, quote** toward local accounts. Still recording only — no scoring/enforcement.

Inbound remote statuses bypassed the hooked local services (`ProcessMentionsService` is local-only via `return unless status.local?`; `PostStatusService` isn't used inbound). This closes that gap: a remote account mass-mentioning/replying to local users now shows those contacts in the ledger, not just the blocks/reports it later receives.

### Implementation

A single chokepoint in `ActivityPub::Activity::Create#create_status`, `record_inbound_status_signals(@status)`, runs for **both** a freshly processed status and a re-delivery of an existing one (`@status` is set either way), so — matching the durability requirement from #34 — a re-delivery repairs a ledger event a transient recorder failure missed.

| Signal | Condition | Idempotency key |
| --- | --- | --- |
| `reply` | `in_reply_to_account_id` is local | `activitypub_reply:<status.uri>` |
| `mention` | each **non-silent** mention of a local account, **excluding** the replied-to account (that's the reply) | the `Mention` record (`Mention:<id>:mention`) |
| `quote` | the quoted status's author is local | `activitypub_quote:<status.uri>` |

Reply/quote key on the **activity identity** (the status URI), stable across re-delivery. Silent (audience) mentions are not recorded. The replied-to account is recorded once, as a `reply`, never also as a `mention`.

### Coverage metadata

Evidence snapshot `schema_version` 4 → 5; mention/reply/quote move from `deferred` to `observed`:

```json
{
  "inbound_activitypub": "partial",
  "complete_for_remote_subjects": false,
  "observed_inbound_event_types": ["follow","favourite","reaction","block","report","reference","mention","reply","quote"],
  "deferred_inbound_event_types": ["follow_reject"]
}
```

`complete_for_remote_subjects` stays `false`: inbound follow-request **reject** (`activity/reject.rb`) is still deferred — it bypasses `RejectFollowService` and destroys the `FollowRequest`, so a stable key must derive from the Reject activity id rather than the destroyed record. Documented in `docs/moderation-signal-inbound-coverage.md`.

## Testing

New spec covers mention/reply/quote recording, re-delivery idempotency, and recorder-failure repair (7 examples, 0 failures). Full moderation-relevant regression set:

[moderation_inbound_create_rspec.log](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderation_inbound_create_rspec.log)

```
spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb
spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb
spec/lib/activitypub/activity/follow_spec.rb spec/lib/activitypub/activity/like_spec.rb spec/lib/activitypub/activity/block_spec.rb
spec/services/moderation/  + interaction/rejection model specs
=> 104 examples, 0 failures
```

Regression note: the existing `create_spec.rb` shows **13 pre-existing failures with and without this change** (verified against the base `fedibird` `create.rb`) — they are environment issues (`qrtool` binary not installed for media processing, and an out-of-ISO8601-range date test), unrelated to this hook. No migration or schema change.

## Scope

Touches only `activity/create.rb`, the snapshot coverage constant, docs, and the new spec. Independent of other open moderation PRs.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

