### PR TITLE
Moderation ledger: inbound ActivityPub follow_reject coverage (PR 6c)

### DIFF
--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -3,7 +3,15 @@
 class ActivityPub::Activity::Reject < ActivityPub::Activity
   def perform
     return reject_follow_for_relay if relay_follow?
-    return follow_request_from_object.reject! unless follow_request_from_object.nil?
+
+    unless follow_request_from_object.nil?
+      # Capture the local requester before reject! destroys the FollowRequest.
+      rejected_account = follow_request_from_object.account
+      follow_request_from_object.reject!
+      record_inbound_follow_reject(rejected_account)
+      return
+    end
+
     return UnfollowService.new.call(follow_from_object.account, @account) unless follow_from_object.nil?
 
     case @object['type']
@@ -22,7 +30,26 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
     follow_request = FollowRequest.find_by(account: target_account, target_account: @account)
     follow_request&.reject!
 
+    # Record the inbound follow-request rejection. The rejected account is taken
+    # from the embedded Follow's actor, so this still works (and repairs a missed
+    # ledger event on re-delivery) after reject! has destroyed the FollowRequest.
+    record_inbound_follow_reject(target_account)
+
     UnfollowService.new.call(target_account, @account) if target_account.following?(@account)
+  end
+
+  # Inbound Reject of a local account's follow request: the remote actor rejected
+  # the local requester. Keyed on the Reject activity identity (not the
+  # destroyed FollowRequest) so it is stable across re-delivery. Failure-tolerant.
+  def record_inbound_follow_reject(rejected_account)
+    return if rejected_account.nil? || !rejected_account.local? || @json['id'].blank?
+
+    Moderation::EventRecorder.record_rejection(
+      rejector: @account,
+      rejected: rejected_account,
+      event_type: :follow_reject,
+      source_event_key: "activitypub_follow_reject:#{@json['id']}"
+    )
   end
 
   def reject_follow_for_relay

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -17,9 +17,9 @@
 #
 # This phase performs recording only: no scoring, throttling, or enforcement.
 #
-# Known coverage limitation: inbound ActivityPub-only paths (remote
-# mention/reply/follow/favourite/reaction/block) are not yet hooked. Snapshots
-# and future scores for remote actors are therefore incomplete.
+# Inbound ActivityPub-only paths (remote mention/reply/follow/follow_reject/
+# favourite/reaction/block) are hooked at their record-creation sites. See
+# Moderation::EvidenceSnapshotService's coverage map for residual limitations.
 module Moderation
   class EventRecorder
     class << self

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -18,8 +18,10 @@
 # This phase performs recording only: no scoring, throttling, or enforcement.
 #
 # Inbound ActivityPub-only paths (remote mention/reply/follow/follow_reject/
-# favourite/reaction/block) are hooked at their record-creation sites. See
-# Moderation::EvidenceSnapshotService's coverage map for residual limitations.
+# favourite/reaction/block) are hooked at their record-creation sites, but one
+# hooked shape can still lose an event after a recorder-only failure. See
+# Moderation::EvidenceSnapshotService's coverage map (known_inbound_recording_gaps)
+# for the residual reliability limitation.
 module Moderation
   class EventRecorder
     class << self

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -17,9 +17,11 @@
 #
 # Inbound ActivityPub coverage: mentions, replies, follows, follow rejects,
 # favourites, reactions, blocks, reports, references, and quotes arriving over
-# federation are now observed at their record-creation sites. See
-# +fingerprint['coverage']+ for the per-event-type coverage map and its residual
-# recording limitations.
+# federation are now observed at their record-creation sites. Every modeled
+# inbound type is hooked, but coverage is reported as 'partial' because one
+# hooked shape (bare-follow-request-URI Reject) can still lose an event after a
+# recorder-only failure. See +fingerprint['coverage']+ for the per-event-type
+# map and +known_inbound_recording_gaps+.
 module Moderation
   class EvidenceSnapshotService
     SCHEMA_VERSION = 6
@@ -31,24 +33,38 @@ module Moderation
 
     REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
 
-    # Inbound ActivityPub coverage is complete for the modeled event types: every
-    # inbound event type below is now observed at its record-creation site,
-    # including inbound follow-request rejections (Reject of a local account's
-    # follow request). Coverage is reported per event type so callers can reason
-    # about exactly what is observed.
+    # Every modeled inbound event type now has a record-creation-site hook
+    # (deferred_inbound_event_types is empty), but "all types hooked" is NOT the
+    # same as "coverage is complete/reliable". A recorder-only failure can still
+    # cause a *permanent* ledger miss for one shape (see known_inbound_recording_gaps),
+    # so inbound_activitypub stays 'partial' and complete_for_remote_subjects
+    # stays false: downstream analysis must not read low/zero counts as absence
+    # of behaviour while any known gap remains.
     #
-    # Residual limitations (recording gaps, not new event types):
-    #   * An inbound Reject that carries only the bare follow-request URI is
-    #     recorded on first delivery but cannot self-repair on re-delivery,
-    #     because reject! destroys the FollowRequest the requester is read from.
-    #     The embedded-Follow shape repairs normally.
-    #   * A Reject of an already-established follow is modeled as an unfollow, not
-    #     as a follow_reject, so it is intentionally not recorded as a rejection.
+    #   * observed_inbound_event_types    — every modeled type has a hook.
+    #   * deferred_inbound_event_types    — types with no hook at all (none left).
+    #   * known_inbound_recording_gaps    — hooked types that can still lose an
+    #                                       event after a recorder-only failure.
+    #
+    # The one remaining gap is the bare-follow-request-URI Reject shape: reject!
+    # destroys the FollowRequest before the rejected local requester can be
+    # re-derived, so a recorder-only failure on first delivery is not repaired by
+    # re-delivery. The embedded-Follow Reject shape repairs normally (its rejected
+    # account is derived from @object['actor']). A Reject of an already-established
+    # follow is intentionally modeled as an unfollow, not a follow_reject.
     INBOUND_ACTIVITYPUB_COVERAGE = {
-      'inbound_activitypub' => 'complete',
-      'complete_for_remote_subjects' => true,
+      'inbound_activitypub' => 'partial',
+      'complete_for_remote_subjects' => false,
       'observed_inbound_event_types' => %w(follow follow_reject favourite reaction block report reference mention reply quote).freeze,
       'deferred_inbound_event_types' => [].freeze,
+      'known_inbound_recording_gaps' => [
+        {
+          'event_type' => 'follow_reject',
+          'shape' => 'bare_follow_request_uri',
+          'repairable' => false,
+          'reason' => 'reject! destroys the FollowRequest before the rejected local requester can be re-derived, so a recorder-only failure on first delivery is not repaired by re-delivery.',
+        }.freeze,
+      ].freeze,
     }.freeze
 
     def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -15,14 +15,14 @@
 #
 # Recording/summarising only — no scoring or thresholds.
 #
-# Coverage limitation: inbound ActivityPub-only mentions, replies, follows,
-# favourites, reactions, and blocks are not yet observed. A remote subject can
-# therefore accumulate local blocks/reports while the triggering remote
-# contacts are missing. Snapshots (and future scores) for remote actors are
-# incomplete until those paths are covered. See +fingerprint['coverage']+.
+# Inbound ActivityPub coverage: mentions, replies, follows, follow rejects,
+# favourites, reactions, blocks, reports, references, and quotes arriving over
+# federation are now observed at their record-creation sites. See
+# +fingerprint['coverage']+ for the per-event-type coverage map and its residual
+# recording limitations.
 module Moderation
   class EvidenceSnapshotService
-    SCHEMA_VERSION = 5
+    SCHEMA_VERSION = 6
     DEFAULT_WINDOW = 30.days
 
     # Cap the persisted id sets so a pathological subject can't create an
@@ -31,17 +31,24 @@ module Moderation
 
     REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
 
-    # Inbound ActivityPub coverage is partial: the inbound event types below are
-    # now observed, but inbound follow-request rejections (Reject that bypasses
-    # RejectFollowService, destroying the FollowRequest) are not yet hooked. Do
-    # not treat snapshot counts or future scores as complete for remote actors.
-    # Coverage is reported per event type so callers can reason about exactly
-    # what is missing.
+    # Inbound ActivityPub coverage is complete for the modeled event types: every
+    # inbound event type below is now observed at its record-creation site,
+    # including inbound follow-request rejections (Reject of a local account's
+    # follow request). Coverage is reported per event type so callers can reason
+    # about exactly what is observed.
+    #
+    # Residual limitations (recording gaps, not new event types):
+    #   * An inbound Reject that carries only the bare follow-request URI is
+    #     recorded on first delivery but cannot self-repair on re-delivery,
+    #     because reject! destroys the FollowRequest the requester is read from.
+    #     The embedded-Follow shape repairs normally.
+    #   * A Reject of an already-established follow is modeled as an unfollow, not
+    #     as a follow_reject, so it is intentionally not recorded as a rejection.
     INBOUND_ACTIVITYPUB_COVERAGE = {
-      'inbound_activitypub' => 'partial',
-      'complete_for_remote_subjects' => false,
-      'observed_inbound_event_types' => %w(follow favourite reaction block report reference mention reply quote).freeze,
-      'deferred_inbound_event_types' => %w(follow_reject).freeze,
+      'inbound_activitypub' => 'complete',
+      'complete_for_remote_subjects' => true,
+      'observed_inbound_event_types' => %w(follow follow_reject favourite reaction block report reference mention reply quote).freeze,
+      'deferred_inbound_event_types' => [].freeze,
     }.freeze
 
     def call(subject_or_account, window: DEFAULT_WINDOW, now: Time.now.utc)

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -59,21 +59,38 @@ event type (schema_version is now `6`):
 
 ```json
 {
-  "inbound_activitypub": "complete",
-  "complete_for_remote_subjects": true,
+  "inbound_activitypub": "partial",
+  "complete_for_remote_subjects": false,
   "observed_inbound_event_types": ["follow", "follow_reject", "favourite", "reaction", "block", "report", "reference", "mention", "reply", "quote"],
-  "deferred_inbound_event_types": []
+  "deferred_inbound_event_types": [],
+  "known_inbound_recording_gaps": [
+    {
+      "event_type": "follow_reject",
+      "shape": "bare_follow_request_uri",
+      "repairable": false,
+      "reason": "reject! destroys the FollowRequest before the rejected local requester can be re-derived, so a recorder-only failure on first delivery is not repaired by re-delivery."
+    }
+  ]
 }
 ```
 
-`complete_for_remote_subjects` is now `true`: every modeled inbound event type
-is observed at its record-creation site. The two residual limitations are
-recording gaps, not new event types:
+**"All modeled types hooked" is not "coverage complete/reliable".** Every modeled
+inbound event type now has a record-creation-site hook, so
+`deferred_inbound_event_types` is empty. But `inbound_activitypub` stays
+`partial` and `complete_for_remote_subjects` stays `false` because one hooked
+shape can still lose an event after a recorder-only failure, tracked explicitly
+in `known_inbound_recording_gaps`. Downstream analysis/scoring must keep using
+these flags as a guard: while any gap remains, low/zero counts must not be read
+as absence of behaviour.
+
+The residual issues are recording-reliability gaps, not missing event types:
 
 - A `Reject` carrying only the bare follow-request URI is recorded on first
   delivery but cannot self-repair on re-delivery, because `reject!` destroys the
-  `FollowRequest` the requester is read from. The embedded-`Follow` shape
-  repairs normally (its rejected account is derived from `@object['actor']`).
+  `FollowRequest` the requester is read from — a permanent miss after a
+  recorder-only failure (`repairable: false`). The embedded-`Follow` shape
+  repairs normally (its rejected account is derived from `@object['actor']`), so
+  it is not listed as a gap.
 - A `Reject` of an already-established follow is modeled as an unfollow, not as a
   follow_reject, so it is intentionally not recorded as a rejection.
 
@@ -106,8 +123,9 @@ actor, rejected = the local requester) at every `Reject`-of-follow-request site:
 - **bare follow-request-URI shape** (`follow_request_from_object`): the local
   requester is captured **before** `reject!` destroys the `FollowRequest`, so it
   is recorded on first delivery. This shape cannot self-repair on re-delivery
-  (the record it reads from is gone), which is the first residual limitation
-  above.
+  (the record it reads from is gone); it is reported in the coverage metadata's
+  `known_inbound_recording_gaps` and is why `inbound_activitypub` stays
+  `partial` / `complete_for_remote_subjects` stays `false`.
 
 Both keep one stable, activity-identity key
 `activitypub_follow_reject:<Reject id>` so retries never double-record. A

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -41,7 +41,7 @@ different records).
 | Create → reply (remote → local) | `Status#in_reply_to_account_id` | `activity/create.rb` thread resolution | none | **hooked (PR 6b)** → `reply` |
 | Create → quote (remote → local) | `Status#quote_id` | `activity/create.rb` (PSR skips quote) | none | **hooked (PR 6b)** → `quote` |
 | Accept (remote accepts local follow request) | `Follow` | `activity/accept.rb` → `follow!` | intentionally skipped | — (already recorded at local request time; recording here would double-count the same logical follow) |
-| Reject (remote rejects local follow request) | destroys `FollowRequest` | `activity/reject.rb` `reject!` (not `RejectFollowService`) | none | **deferred** (`follow_reject`) |
+| Reject (remote rejects local follow request) | destroys `FollowRequest` | `activity/reject.rb` `reject!` (not `RejectFollowService`) | none | **hooked (PR 6c)** → `follow_reject` (rejection) |
 | Announce (remote boost of local status) | reblog `Status` | `activity/announce.rb` | n/a | out of ledger's event set |
 
 Notes:
@@ -54,21 +54,28 @@ Notes:
 
 ## Coverage metadata
 
-`ModerationEvidenceSnapshot` fingerprints carry `coverage`. It is now reported
-per event type (schema_version bumped 3 → 4):
+`ModerationEvidenceSnapshot` fingerprints carry `coverage`. It is reported per
+event type (schema_version is now `6`):
 
 ```json
 {
-  "inbound_activitypub": "partial",
-  "complete_for_remote_subjects": false,
-  "observed_inbound_event_types": ["follow", "favourite", "reaction", "block", "report", "reference", "mention", "reply", "quote"],
-  "deferred_inbound_event_types": ["follow_reject"]
+  "inbound_activitypub": "complete",
+  "complete_for_remote_subjects": true,
+  "observed_inbound_event_types": ["follow", "follow_reject", "favourite", "reaction", "block", "report", "reference", "mention", "reply", "quote"],
+  "deferred_inbound_event_types": []
 }
 ```
 
-`complete_for_remote_subjects` stays `false` until the last deferred inbound
-path (follow-request reject) is hooked. Do not read a low remote count as "no
-behaviour" while coverage is partial.
+`complete_for_remote_subjects` is now `true`: every modeled inbound event type
+is observed at its record-creation site. The two residual limitations are
+recording gaps, not new event types:
+
+- A `Reject` carrying only the bare follow-request URI is recorded on first
+  delivery but cannot self-repair on re-delivery, because `reject!` destroys the
+  `FollowRequest` the requester is read from. The embedded-`Follow` shape
+  repairs normally (its rejected account is derived from `@object['actor']`).
+- A `Reject` of an already-established follow is modeled as an unfollow, not as a
+  follow_reject, so it is intentionally not recorded as a rejection.
 
 ## PR 6b — inbound mention / reply / quote
 
@@ -87,8 +94,22 @@ transient recorder failure missed):
 Reply/quote use activity-identity keys (the status URI) so they stay stable and
 deduped across re-delivery. Silent (audience) mentions are not recorded.
 
-## Deferred to a follow-up
+## PR 6c — inbound follow-request reject
 
-- Inbound follow-request **reject** (`activity/reject.rb`): the `Reject` bypasses
-  `RejectFollowService` and destroys the `FollowRequest`, so a stable key would
-  need to derive from the Reject activity id rather than the destroyed record.
+`activity/reject.rb` records a `follow_reject` rejection (rejector = the remote
+actor, rejected = the local requester) at every `Reject`-of-follow-request site:
+
+- **embedded-`Follow` shape** (`reject_embedded_follow`): the rejected local
+  account is derived from `@object['actor']`, so the hook still records — and
+  **repairs a missed ledger event on re-delivery** — after `reject!` has
+  destroyed the `FollowRequest`.
+- **bare follow-request-URI shape** (`follow_request_from_object`): the local
+  requester is captured **before** `reject!` destroys the `FollowRequest`, so it
+  is recorded on first delivery. This shape cannot self-repair on re-delivery
+  (the record it reads from is gone), which is the first residual limitation
+  above.
+
+Both keep one stable, activity-identity key
+`activitypub_follow_reject:<Reject id>` so retries never double-record. A
+`Reject` of an already-established follow is intentionally treated as an unfollow
+(not a `follow_reject`).

--- a/spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+# PR 6c: an inbound ActivityPub Reject of a *local* account's follow request
+# (remote actor -> local requester) is recorded in the moderation ledger as a
+# follow_reject rejection. The Reject bypasses RejectFollowService and destroys
+# the FollowRequest, so the recorder is keyed on the Reject activity identity
+# (activitypub_follow_reject:<Reject id>) rather than the destroyed record.
+#
+# There are two inbound shapes:
+#   * embedded Follow  — the rejected local account is derived from the embedded
+#     Follow's actor, so recording still works (and REPAIRS a missed ledger
+#     event on re-delivery) after reject! has destroyed the FollowRequest.
+#   * bare follow-request URI — the local requester is captured before reject!
+#     destroys the FollowRequest, so it records on first delivery but cannot
+#     self-repair on re-delivery (the record it reads from is gone).
+RSpec.describe 'Inbound ActivityPub follow-reject moderation coverage', type: :model do
+  let(:remote) { Fabricate(:account, domain: 'remote.example', uri: 'https://remote.example/users/bob', inbox_url: 'https://remote.example/inbox', protocol: :activitypub) }
+  let(:local)  { Fabricate(:account) }
+
+  def deliver(json)
+    ActivityPub::Activity::Reject.new(json, remote).perform
+  end
+
+  context 'embedded-Follow shape' do
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/reject-1',
+        type: 'Reject',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: {
+          id: 'https://remote.example/activities/follow-1',
+          type: 'Follow',
+          actor: ActivityPub::TagManager.instance.uri_for(local),
+          object: ActivityPub::TagManager.instance.uri_for(remote),
+        },
+      }.with_indifferent_access
+    end
+
+    before { Fabricate(:follow_request, account: local, target_account: remote) }
+
+    it 'records a follow_reject rejection from the remote actor with a stable activity-identity key' do
+      expect { deliver(json) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = ModerationRejectionEvent.order(:id).last
+      expect(event.event_type).to eq 'follow_reject'
+      expect(event.rejector_subject.account_id).to eq remote.id
+      expect(event.rejected_subject.account_id).to eq local.id
+      expect(event.source_event_key).to eq 'activitypub_follow_reject:https://remote.example/activities/reject-1'
+      expect(local.requested?(remote)).to be false
+    end
+
+    it 'does not double-record on ordinary re-delivery' do
+      deliver(json)
+      expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
+    end
+
+    it 're-delivery repairs a ledger event missed by a transient recorder failure' do
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_return(nil)
+      deliver(json)
+
+      expect(local.requested?(remote)).to be false
+      expect(ModerationRejectionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_call_original
+      expect { deliver(json) }.to change(ModerationRejectionEvent, :count).by(1)
+      expect(ModerationRejectionEvent.count).to eq 1
+      expect(ModerationRejectionEvent.order(:id).last.source_event_key)
+        .to eq 'activitypub_follow_reject:https://remote.example/activities/reject-1'
+    end
+  end
+
+  context 'bare follow-request-URI shape' do
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/reject-2',
+        type: 'Reject',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: 'https://remote.example/activities/follow-2',
+      }.with_indifferent_access
+    end
+
+    before do
+      Fabricate(:follow_request, account: local, target_account: remote, uri: 'https://remote.example/activities/follow-2')
+    end
+
+    it 'records a follow_reject on first delivery with a stable activity-identity key' do
+      expect { deliver(json) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = ModerationRejectionEvent.order(:id).last
+      expect(event.event_type).to eq 'follow_reject'
+      expect(event.rejector_subject.account_id).to eq remote.id
+      expect(event.rejected_subject.account_id).to eq local.id
+      expect(event.source_event_key).to eq 'activitypub_follow_reject:https://remote.example/activities/reject-2'
+      expect(local.requested?(remote)).to be false
+    end
+
+    it 'does not double-record on re-delivery (the FollowRequest is already gone)' do
+      deliver(json)
+      expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
+      expect(ModerationRejectionEvent.count).to eq 1
+    end
+
+    # Known, documented limitation: unlike the embedded-Follow shape, this shape
+    # cannot self-repair because reject! has already destroyed the FollowRequest
+    # the rejected account is read from.
+    it 'cannot repair a missed ledger event on re-delivery' do
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_return(nil)
+      deliver(json)
+
+      expect(local.requested?(remote)).to be false
+      expect(ModerationRejectionEvent.count).to eq 0
+
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_call_original
+      expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
+      expect(ModerationRejectionEvent.count).to eq 0
+    end
+  end
+
+  context 'Reject of an already-established follow' do
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/reject-3',
+        type: 'Reject',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: 'https://remote.example/activities/follow-3',
+      }.with_indifferent_access
+    end
+
+    before do
+      # UnfollowService (the modeled handling of this shape) emits an outbound
+      # Undo; stub delivery so it does not hit the network.
+      allow(ActivityPub::DeliveryWorker).to receive(:perform_async)
+      Fabricate(:follow, account: local, target_account: remote, uri: 'https://remote.example/activities/follow-3')
+    end
+
+    it 'is treated as an unfollow and is intentionally not recorded as a follow_reject' do
+      expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
+      expect(local.following?(remote)).to be false
+    end
+  end
+end

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.window_end).to be_present
     expect(snapshot.window_start).to be_present
     expect(snapshot.fingerprint['coverage']).to eq described_class::INBOUND_ACTIVITYPUB_COVERAGE
-    expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
-    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
+    expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be true
+    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'complete'
   end
 
   it 'does not put unordered same-window overlap into linked_negative_target_subject_ids' do

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -39,8 +39,15 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.window_end).to be_present
     expect(snapshot.window_start).to be_present
     expect(snapshot.fingerprint['coverage']).to eq described_class::INBOUND_ACTIVITYPUB_COVERAGE
-    expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be true
-    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'complete'
+    # Every modeled inbound type is hooked (deferred is empty)...
+    expect(snapshot.fingerprint.dig('coverage', 'observed_inbound_event_types')).to include('follow_reject')
+    expect(snapshot.fingerprint.dig('coverage', 'deferred_inbound_event_types')).to eq []
+    # ...but a known recorder-only-failure gap keeps coverage honestly partial,
+    # so downstream analysis does not read missing evidence as absence of behaviour.
+    expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+    expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
+    gaps = snapshot.fingerprint.dig('coverage', 'known_inbound_recording_gaps')
+    expect(gaps).to include(a_hash_including('event_type' => 'follow_reject', 'shape' => 'bare_follow_request_uri', 'repairable' => false))
   end
 
   it 'does not put unordered same-window overlap into linked_negative_target_subject_ids' do

--- a/spec/services/moderation/ledger_lifecycle_spec.rb
+++ b/spec/services/moderation/ledger_lifecycle_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe 'Moderation ledger composed lifecycle', type: :service do
       expect(snapshot.linked_negative_target_subject_ids).to include(bob_subject.id)
       expect(snapshot.linked_negative_target_subject_ids).to_not include(carol_subject.id)
       expect(snapshot.correlated_negative_target_subject_ids).to include(carol_subject.id)
-      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
-      expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'complete'
+      expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be true
 
       expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)
       expect(ModerationInteractionEvent.exists?(contact.id)).to be true

--- a/spec/services/moderation/ledger_lifecycle_spec.rb
+++ b/spec/services/moderation/ledger_lifecycle_spec.rb
@@ -64,8 +64,11 @@ RSpec.describe 'Moderation ledger composed lifecycle', type: :service do
       expect(snapshot.linked_negative_target_subject_ids).to include(bob_subject.id)
       expect(snapshot.linked_negative_target_subject_ids).to_not include(carol_subject.id)
       expect(snapshot.correlated_negative_target_subject_ids).to include(carol_subject.id)
-      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'complete'
-      expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be true
+      expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
+      expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
+      expect(snapshot.fingerprint.dig('coverage', 'observed_inbound_event_types')).to include('follow_reject')
+      expect(snapshot.fingerprint.dig('coverage', 'known_inbound_recording_gaps'))
+        .to include(a_hash_including('event_type' => 'follow_reject', 'repairable' => false))
 
       expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)
       expect(ModerationInteractionEvent.exists?(contact.id)).to be true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes inbound ActivityPub coverage for the moderation-signal ledger by recording the last deferred inbound event type: an inbound `Reject` of a **local** account's follow request (remote actor → local requester).

Such a `Reject` bypasses `RejectFollowService` and destroys the `FollowRequest`, so it was previously invisible to the ledger. It is now recorded as a `follow_reject` rejection (rejector = the remote actor, rejected = the local requester) at every reject-of-follow-request site in `app/lib/activitypub/activity/reject.rb`.

Recording-only, failure-tolerant, idempotent — consistent with the rest of the ledger work. No scoring, enforcement, or inference of remote-server-internal state.

## What changed

- **`app/lib/activitypub/activity/reject.rb`** — records `follow_reject` at both reject shapes:
  - **embedded-`Follow` shape** (`reject_embedded_follow`): the rejected local account is derived from `@object['actor']`, so recording still works — and **repairs a missed ledger event on re-delivery** — after `reject!` has destroyed the `FollowRequest`.
  - **bare follow-request-URI shape**: the local requester is captured **before** `reject!` destroys the `FollowRequest`, so it records on first delivery.
  - Both use one stable, activity-identity key `activitypub_follow_reject:<Reject id>` so retries never double-record.
  - A `Reject` of an already-established follow is intentionally modeled as an unfollow (not a `follow_reject`).
- **`app/services/moderation/evidence_snapshot_service.rb`** — `follow_reject` moved to `observed_inbound_event_types`; `deferred_inbound_event_types` empty (every modeled type has a hook). Coverage stays **honestly partial**: `inbound_activitypub` = `partial`, `complete_for_remote_subjects` = `false`, and a new **`known_inbound_recording_gaps`** field records the non-repairable bare-URI Reject shape. `SCHEMA_VERSION` bumped `5 → 6`.
- **`app/services/moderation/event_recorder.rb`** — coverage note refreshed to point at `known_inbound_recording_gaps`.
- **`docs/moderation-signal-inbound-coverage.md`** — Reject row hooked, coverage JSON refreshed, PR 6c section, and a "'all types hooked' ≠ 'coverage complete/reliable'" explanation.

## Coverage semantics (addressing review)

Per review, **"all modeled types hooked" is not "coverage complete/reliable"**. The bare-follow-request-URI Reject shape can lose a `follow_reject` **permanently** after a recorder-only failure (`reject!` destroys the `FollowRequest` before the rejected local requester can be re-derived), so `complete_for_remote_subjects: true` would let downstream analysis misread missing evidence as absence of behaviour.

Chosen approach (reviewer option A): keep `inbound_activitypub` `partial` and `complete_for_remote_subjects` `false`; keep `follow_reject` observed with an empty deferred list; add an explicit reliability field so callers can distinguish "hooked" from "reliable":

```json
{
  "inbound_activitypub": "partial",
  "complete_for_remote_subjects": false,
  "observed_inbound_event_types": ["follow", "follow_reject", "favourite", "reaction", "block", "report", "reference", "mention", "reply", "quote"],
  "deferred_inbound_event_types": [],
  "known_inbound_recording_gaps": [
    { "event_type": "follow_reject", "shape": "bare_follow_request_uri", "repairable": false, "reason": "reject! destroys the FollowRequest before the rejected local requester can be re-derived, so a recorder-only failure on first delivery is not repaired by re-delivery." }
  ]
}
```

Option B (recover the requester from the destroyed record's URI) was considered but rejected: the local account is only recoverable when the follow-request URI has the `…/users/<name>#follows/<id>` fallback form, so it cannot guarantee universal repairability and would still require honest gap reporting — the reviewer also preferred A and warned against overreach.

Preserved behavior: embedded-Follow repair, stable `activitypub_follow_reject:<Reject id>` key, no double-recording, established-follow Reject remaining modeled as unfollow.

## Testing

New spec `spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb` covers: records `follow_reject` (rejector remote / rejected local) with the stable key; idempotent re-delivery; recorder-failure **repair** for the embedded-Follow shape vs. documented **no-repair** for the bare-URI shape; and the established-follow no-record case. Snapshot specs now assert `partial`/`false`, `follow_reject` observed, and the `known_inbound_recording_gaps` entry.

```
$ bundle exec rspec spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb \
    spec/services/moderation/evidence_snapshot_service_spec.rb \
    spec/services/moderation/ledger_lifecycle_spec.rb \
    spec/lib/activitypub/activity/reject_spec.rb
28 examples, 0 failures

$ bundle exec rspec spec/services/moderation \
    spec/models/moderation_interaction_event_spec.rb \
    spec/models/moderation_rejection_event_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
85 examples, 0 failures
```

Head: `35309503173a554b32badd46af5f152f6b172d85`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

