### PR TITLE
Moderation ledger: repair bare-URI inbound follow_reject via follow correlation (PR 6d)

### DIFF
--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -47,16 +47,31 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
   # destroyed the FollowRequest, so the rejected local requester cannot be read
   # from it (its URI is an opaque payload id that does not encode the account).
   # Instead correlate the follow-request URI to the outbound follow interaction
-  # recorded at request time under the same activity identity
-  # (activitypub_follow:<uri>) and recover the requester from its actor. Nothing
-  # is repaired only when that anchor is also missing (a double recorder failure).
+  # recorded at request time under the direction-specific activity identity
+  # (activitypub_outbound_follow:<uri>) and recover the requester from its actor.
+  #
+  # URI equality alone must NOT bind identities: a leaked/reused/malicious object
+  # URI must not let remote actor B cause us to record "B rejected local A" from
+  # an anchor that was actually "A -> remote C". So the anchor must satisfy every
+  # invariant of the follow this Reject claims to reject, and we fail closed
+  # otherwise. Nothing is repaired only when the anchor is missing (which,
+  # combined with the reject recorder failure, is the known double-failure gap).
   def repair_inbound_follow_reject_from_uri
     return if object_uri.blank?
 
-    interaction = ModerationInteractionEvent.find_by(source_event_key: "activitypub_follow:#{object_uri}")
+    interaction = ModerationInteractionEvent.find_by(
+      source_event_key: "activitypub_outbound_follow:#{object_uri}",
+      event_type: :follow
+    )
     return if interaction.nil?
 
+    # The anchor's actor must be the local requester...
     rejected_account = interaction.actor_subject&.account
+    return if rejected_account.nil? || !rejected_account.local?
+
+    # ...and its target must be the very remote actor now sending this Reject.
+    return unless interaction.target_subject&.account_id == @account.id
+
     record_inbound_follow_reject(rejected_account)
   end
 

--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -14,9 +14,14 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
 
     return UnfollowService.new.call(follow_from_object.account, @account) unless follow_from_object.nil?
 
-    case @object['type']
-    when 'Follow'
-      reject_embedded_follow
+    if @object.is_a?(Hash)
+      reject_embedded_follow if @object['type'] == 'Follow'
+    else
+      # Bare follow-request URI with no surviving FollowRequest/Follow: on a
+      # re-delivery, the first Reject already destroyed the FollowRequest, so
+      # repair the missed ledger event by correlating the follow-request URI to
+      # the outbound follow interaction that was recorded when we sent it.
+      repair_inbound_follow_reject_from_uri
     end
   end
 
@@ -36,6 +41,23 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
     record_inbound_follow_reject(target_account)
 
     UnfollowService.new.call(target_account, @account) if target_account.following?(@account)
+  end
+
+  # Re-delivery repair for the bare-follow-request-URI shape. reject! has already
+  # destroyed the FollowRequest, so the rejected local requester cannot be read
+  # from it (its URI is an opaque payload id that does not encode the account).
+  # Instead correlate the follow-request URI to the outbound follow interaction
+  # recorded at request time under the same activity identity
+  # (activitypub_follow:<uri>) and recover the requester from its actor. Nothing
+  # is repaired only when that anchor is also missing (a double recorder failure).
+  def repair_inbound_follow_reject_from_uri
+    return if object_uri.blank?
+
+    interaction = ModerationInteractionEvent.find_by(source_event_key: "activitypub_follow:#{object_uri}")
+    return if interaction.nil?
+
+    rejected_account = interaction.actor_subject&.account
+    record_inbound_follow_reject(rejected_account)
   end
 
   # Inbound Reject of a local account's follow request: the remote actor rejected

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -51,12 +51,30 @@ class FollowService < BaseService
                direct_follow!
              end
 
-    Moderation::EventRecorder.record_interaction(actor: @source_account, target: @target_account, event_type: :follow, source_record: follow) if follow
+    if follow
+      Moderation::EventRecorder.record_interaction(
+        actor: @source_account,
+        target: @target_account,
+        event_type: :follow,
+        source_record: follow,
+        source_event_key: follow_source_event_key(follow)
+      )
+    end
 
     follow
   end
 
   private
+
+  # Prefer the ActivityPub Follow activity identity (the follow record's uri) as
+  # the stable source_event_key, matching inbound follows (activity/follow.rb).
+  # This also lets an inbound follow-request Reject correlate back to this
+  # interaction by the same uri after the FollowRequest has been destroyed by
+  # reject!. Falls back to the record-derived key when no uri is present.
+  def follow_source_event_key(follow)
+    uri = follow.try(:uri)
+    "activitypub_follow:#{uri}" if uri.present?
+  end
 
   def mark_home_feed_as_partial!
     redis.set("account:#{@source_account.id}:regeneration", true, nx: true, ex: 1.day.seconds)

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -66,14 +66,16 @@ class FollowService < BaseService
 
   private
 
-  # Prefer the ActivityPub Follow activity identity (the follow record's uri) as
-  # the stable source_event_key, matching inbound follows (activity/follow.rb).
-  # This also lets an inbound follow-request Reject correlate back to this
-  # interaction by the same uri after the FollowRequest has been destroyed by
-  # reject!. Falls back to the record-derived key when no uri is present.
+  # Key the outbound follow interaction on the ActivityPub Follow activity
+  # identity (the follow record's uri) in a *direction-specific* namespace, so an
+  # inbound follow-request Reject can correlate back to it after reject! has
+  # destroyed the FollowRequest. A dedicated outbound namespace keeps these local
+  # anchors from ever colliding with inbound follow ids (which are supplied by
+  # remote actors and keyed activitypub_follow:<id> in activity/follow.rb). Falls
+  # back to the record-derived key when no uri is present.
   def follow_source_event_key(follow)
     uri = follow.try(:uri)
-    "activitypub_follow:#{uri}" if uri.present?
+    "activitypub_outbound_follow:#{uri}" if uri.present?
   end
 
   def mark_home_feed_as_partial!

--- a/app/services/moderation/event_recorder.rb
+++ b/app/services/moderation/event_recorder.rb
@@ -19,7 +19,7 @@
 #
 # Inbound ActivityPub-only paths (remote mention/reply/follow/follow_reject/
 # favourite/reaction/block) are hooked at their record-creation sites, but one
-# hooked shape can still lose an event after a recorder-only failure. See
+# hooked shape can still lose an event under a rare double recorder failure. See
 # Moderation::EvidenceSnapshotService's coverage map (known_inbound_recording_gaps)
 # for the residual reliability limitation.
 module Moderation

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -19,9 +19,9 @@
 # favourites, reactions, blocks, reports, references, and quotes arriving over
 # federation are now observed at their record-creation sites. Every modeled
 # inbound type is hooked, but coverage is reported as 'partial' because one
-# hooked shape (bare-follow-request-URI Reject) can still lose an event after a
-# recorder-only failure. See +fingerprint['coverage']+ for the per-event-type
-# map and +known_inbound_recording_gaps+.
+# hooked shape (bare-follow-request-URI Reject) can still lose an event under a
+# rare double recorder failure. See +fingerprint['coverage']+ for the
+# per-event-type map and +known_inbound_recording_gaps+.
 module Moderation
   class EvidenceSnapshotService
     SCHEMA_VERSION = 6
@@ -35,23 +35,27 @@ module Moderation
 
     # Every modeled inbound event type now has a record-creation-site hook
     # (deferred_inbound_event_types is empty), but "all types hooked" is NOT the
-    # same as "coverage is complete/reliable". A recorder-only failure can still
-    # cause a *permanent* ledger miss for one shape (see known_inbound_recording_gaps),
-    # so inbound_activitypub stays 'partial' and complete_for_remote_subjects
-    # stays false: downstream analysis must not read low/zero counts as absence
-    # of behaviour while any known gap remains.
+    # same as "coverage is complete/reliable". A rare double recorder failure can
+    # still cause a *permanent* ledger miss for one shape (see
+    # known_inbound_recording_gaps), so inbound_activitypub stays 'partial' and
+    # complete_for_remote_subjects stays false: downstream analysis must not read
+    # low/zero counts as absence of behaviour while any known gap remains.
     #
     #   * observed_inbound_event_types    — every modeled type has a hook.
     #   * deferred_inbound_event_types    — types with no hook at all (none left).
     #   * known_inbound_recording_gaps    — hooked types that can still lose an
-    #                                       event after a recorder-only failure.
+    #                                       event under the stated failure condition.
     #
-    # The one remaining gap is the bare-follow-request-URI Reject shape: reject!
-    # destroys the FollowRequest before the rejected local requester can be
-    # re-derived, so a recorder-only failure on first delivery is not repaired by
-    # re-delivery. The embedded-Follow Reject shape repairs normally (its rejected
-    # account is derived from @object['actor']). A Reject of an already-established
-    # follow is intentionally modeled as an unfollow, not a follow_reject.
+    # The remaining gap is the bare-follow-request-URI Reject shape. reject!
+    # destroys the FollowRequest (whose URI is an opaque payload id that does not
+    # encode the requester), so an ordinary recorder-only failure is now repaired
+    # on re-delivery by correlating the follow-request URI to the outbound follow
+    # interaction recorded at request time (source_event_key activitypub_follow:<uri>).
+    # The event is lost only when BOTH that outbound follow interaction and the
+    # inbound reject failed to record, because then no correlation anchor persists.
+    # The embedded-Follow Reject shape repairs directly from @object['actor']. A
+    # Reject of an already-established follow is intentionally modeled as an
+    # unfollow, not a follow_reject.
     INBOUND_ACTIVITYPUB_COVERAGE = {
       'inbound_activitypub' => 'partial',
       'complete_for_remote_subjects' => false,
@@ -61,8 +65,9 @@ module Moderation
         {
           'event_type' => 'follow_reject',
           'shape' => 'bare_follow_request_uri',
+          'condition' => 'double_recorder_failure',
           'repairable' => false,
-          'reason' => 'reject! destroys the FollowRequest before the rejected local requester can be re-derived, so a recorder-only failure on first delivery is not repaired by re-delivery.',
+          'reason' => 'An ordinary recorder-only failure is repaired on re-delivery by correlating the follow-request URI to the outbound follow interaction (activitypub_follow:<uri>). The event is lost only when both the outbound follow interaction and the inbound reject failed to record, leaving no correlation anchor.',
         }.freeze,
       ].freeze,
     }.freeze

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -67,8 +67,9 @@ event type (schema_version is now `6`):
     {
       "event_type": "follow_reject",
       "shape": "bare_follow_request_uri",
+      "condition": "double_recorder_failure",
       "repairable": false,
-      "reason": "reject! destroys the FollowRequest before the rejected local requester can be re-derived, so a recorder-only failure on first delivery is not repaired by re-delivery."
+      "reason": "An ordinary recorder-only failure is repaired on re-delivery by correlating the follow-request URI to the outbound follow interaction (activitypub_follow:<uri>). The event is lost only when both the outbound follow interaction and the inbound reject failed to record, leaving no correlation anchor."
     }
   ]
 }
@@ -78,19 +79,21 @@ event type (schema_version is now `6`):
 inbound event type now has a record-creation-site hook, so
 `deferred_inbound_event_types` is empty. But `inbound_activitypub` stays
 `partial` and `complete_for_remote_subjects` stays `false` because one hooked
-shape can still lose an event after a recorder-only failure, tracked explicitly
-in `known_inbound_recording_gaps`. Downstream analysis/scoring must keep using
-these flags as a guard: while any gap remains, low/zero counts must not be read
-as absence of behaviour.
+shape can still lose an event under a rare double recorder failure, tracked
+explicitly in `known_inbound_recording_gaps`. Downstream analysis/scoring must
+keep using these flags as a guard: while any gap remains, low/zero counts must
+not be read as absence of behaviour.
 
-The residual issues are recording-reliability gaps, not missing event types:
+The residual issue is a recording-reliability gap, not a missing event type:
 
-- A `Reject` carrying only the bare follow-request URI is recorded on first
-  delivery but cannot self-repair on re-delivery, because `reject!` destroys the
-  `FollowRequest` the requester is read from — a permanent miss after a
-  recorder-only failure (`repairable: false`). The embedded-`Follow` shape
-  repairs normally (its rejected account is derived from `@object['actor']`), so
-  it is not listed as a gap.
+- A `Reject` carrying only the bare follow-request URI is repaired on
+  re-delivery after an ordinary recorder-only failure by correlating the
+  follow-request URI to the outbound follow interaction (see PR 6d below). It is
+  lost only under a *double* recorder failure — when both the outbound follow
+  interaction and the inbound reject failed to record — because then no
+  correlation anchor persists (`condition: double_recorder_failure`). The
+  embedded-`Follow` shape repairs directly from `@object['actor']`, so it is not
+  listed as a gap.
 - A `Reject` of an already-established follow is modeled as an unfollow, not as a
   follow_reject, so it is intentionally not recorded as a rejection.
 
@@ -122,12 +125,39 @@ actor, rejected = the local requester) at every `Reject`-of-follow-request site:
   destroyed the `FollowRequest`.
 - **bare follow-request-URI shape** (`follow_request_from_object`): the local
   requester is captured **before** `reject!` destroys the `FollowRequest`, so it
-  is recorded on first delivery. This shape cannot self-repair on re-delivery
-  (the record it reads from is gone); it is reported in the coverage metadata's
-  `known_inbound_recording_gaps` and is why `inbound_activitypub` stays
-  `partial` / `complete_for_remote_subjects` stays `false`.
+  is recorded on first delivery. Re-delivery repair for this shape is handled in
+  PR 6d below.
 
 Both keep one stable, activity-identity key
 `activitypub_follow_reject:<Reject id>` so retries never double-record. A
 `Reject` of an already-established follow is intentionally treated as an unfollow
 (not a `follow_reject`).
+
+## PR 6d — repairing the bare-URI reject via outbound follow correlation
+
+The bare-URI Reject shape used to be non-repairable: `reject!` destroys the
+`FollowRequest`, and its URI is an opaque payload id (`…/<uuid>`,
+`FollowRequest#set_uri` → `generate_uri_for`) that does **not** encode the
+requester, so a recorder-only failure on first delivery was permanent.
+
+To close the ordinary case, the outbound follow interaction is now keyed on the
+same ActivityPub Follow activity identity as inbound follows:
+
+- `FollowService` records the `follow` interaction with
+  `source_event_key = activitypub_follow:<follow record uri>` (falling back to
+  the record-derived key only when no uri is present). This matches
+  `activity/follow.rb`, which already keys inbound follows on
+  `activitypub_follow:<@json['id']>`.
+
+On a bare-URI Reject re-delivery, `activity/reject.rb#repair_inbound_follow_reject_from_uri`
+looks up `ModerationInteractionEvent` by `activitypub_follow:<object_uri>` (the
+Reject echoes back the follow-request URI) and recovers the local requester from
+its `actor_subject`, then records the `follow_reject` under the stable
+`activitypub_follow_reject:<Reject id>` key.
+
+This is durable correlation, not identity invention: the requester is re-read
+from a ledger row tied to the exact same activity URI. The only remaining loss
+is the **double** recorder failure (both the outbound follow interaction and the
+inbound reject failed to record), so `known_inbound_recording_gaps` narrows to
+`condition: double_recorder_failure` and coverage stays `partial` /
+`complete_for_remote_subjects: false`.

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -140,24 +140,39 @@ The bare-URI Reject shape used to be non-repairable: `reject!` destroys the
 `FollowRequest#set_uri` → `generate_uri_for`) that does **not** encode the
 requester, so a recorder-only failure on first delivery was permanent.
 
-To close the ordinary case, the outbound follow interaction is now keyed on the
-same ActivityPub Follow activity identity as inbound follows:
+To close the ordinary case, the outbound follow interaction is keyed on the
+ActivityPub Follow activity identity in a **direction-specific** namespace:
 
 - `FollowService` records the `follow` interaction with
-  `source_event_key = activitypub_follow:<follow record uri>` (falling back to
-  the record-derived key only when no uri is present). This matches
-  `activity/follow.rb`, which already keys inbound follows on
-  `activitypub_follow:<@json['id']>`.
+  `source_event_key = activitypub_outbound_follow:<follow record uri>` (falling
+  back to the record-derived key only when no uri is present). The dedicated
+  outbound namespace keeps these locally generated anchors from ever colliding
+  with inbound follow ids, which are supplied by remote actors and keyed
+  `activitypub_follow:<@json['id']>` in `activity/follow.rb`.
 
 On a bare-URI Reject re-delivery, `activity/reject.rb#repair_inbound_follow_reject_from_uri`
-looks up `ModerationInteractionEvent` by `activitypub_follow:<object_uri>` (the
-Reject echoes back the follow-request URI) and recovers the local requester from
-its `actor_subject`, then records the `follow_reject` under the stable
+looks up `ModerationInteractionEvent` by
+`activitypub_outbound_follow:<object_uri>` (the Reject echoes back the
+follow-request URI) and recovers the local requester from its `actor_subject`,
+then records the `follow_reject` under the stable
 `activitypub_follow_reject:<Reject id>` key.
 
+**URI equality alone does not bind identities.** For a moderation evidence
+ledger, a leaked/reused/malicious object URI must not let remote actor B cause us
+to record "B rejected local A" from an anchor that was actually "A → remote C".
+The repair therefore fails closed unless the anchor satisfies every invariant of
+the follow this Reject claims to reject:
+
+- `event_type == follow` (enforced in the query);
+- the anchor's `actor_subject` resolves to a **local** requester;
+- the anchor's `target_subject` is the very remote actor now sending the Reject
+  (`target_subject.account_id == @account.id`);
+- the source key / URI matches the rejected Follow activity identity.
+
 This is durable correlation, not identity invention: the requester is re-read
-from a ledger row tied to the exact same activity URI. The only remaining loss
-is the **double** recorder failure (both the outbound follow interaction and the
-inbound reject failed to record), so `known_inbound_recording_gaps` narrows to
+from a ledger row tied to the exact same activity URI *and* the same
+actor/target identities. The only remaining loss is the **double** recorder
+failure (both the outbound follow interaction and the inbound reject failed to
+record), so `known_inbound_recording_gaps` narrows to
 `condition: double_recorder_failure` and coverage stays `partial` /
 `complete_for_remote_subjects: false`.

--- a/spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-# PR 6c: an inbound ActivityPub Reject of a *local* account's follow request
-# (remote actor -> local requester) is recorded in the moderation ledger as a
+# An inbound ActivityPub Reject of a *local* account's follow request (remote
+# actor -> local requester) is recorded in the moderation ledger as a
 # follow_reject rejection. The Reject bypasses RejectFollowService and destroys
 # the FollowRequest, so the recorder is keyed on the Reject activity identity
 # (activitypub_follow_reject:<Reject id>) rather than the destroyed record.
@@ -10,9 +10,12 @@ require 'rails_helper'
 #   * embedded Follow  — the rejected local account is derived from the embedded
 #     Follow's actor, so recording still works (and REPAIRS a missed ledger
 #     event on re-delivery) after reject! has destroyed the FollowRequest.
-#   * bare follow-request URI — the local requester is captured before reject!
-#     destroys the FollowRequest, so it records on first delivery but cannot
-#     self-repair on re-delivery (the record it reads from is gone).
+#   * bare follow-request URI — the FollowRequest's URI is an opaque payload id
+#     that does not encode the requester, so after reject! destroys it a
+#     re-delivery repairs an ordinary recorder-only failure by correlating that
+#     URI to the outbound follow interaction recorded at request time
+#     (activitypub_follow:<uri>). The event is lost only under a double recorder
+#     failure (both the outbound follow and the inbound reject failed to record).
 RSpec.describe 'Inbound ActivityPub follow-reject moderation coverage', type: :model do
   let(:remote) { Fabricate(:account, domain: 'remote.example', uri: 'https://remote.example/users/bob', inbox_url: 'https://remote.example/inbox', protocol: :activitypub) }
   let(:local)  { Fabricate(:account) }
@@ -70,19 +73,31 @@ RSpec.describe 'Inbound ActivityPub follow-reject moderation coverage', type: :m
     end
   end
 
-  context 'bare follow-request-URI shape' do
+  # Bare-URI shape with the outbound follow interaction present as a correlation
+  # anchor: a realistic outbound follow to the remote records the follow
+  # interaction under activitypub_follow:<uri>, which the reject repair uses.
+  context 'bare follow-request-URI shape (single recorder-only failure is repairable)' do
+    before { allow(ActivityPub::DeliveryWorker).to receive(:perform_async) }
+
+    let!(:follow_request) { FollowService.new.call(local, remote) }
+
     let(:json) do
       {
         '@context': 'https://www.w3.org/ns/activitystreams',
         id: 'https://remote.example/activities/reject-2',
         type: 'Reject',
         actor: ActivityPub::TagManager.instance.uri_for(remote),
-        object: 'https://remote.example/activities/follow-2',
+        object: follow_request.uri,
       }.with_indifferent_access
     end
 
-    before do
-      Fabricate(:follow_request, account: local, target_account: remote, uri: 'https://remote.example/activities/follow-2')
+    it 'records the outbound follow interaction under the AP activity-identity key' do
+      interaction = ModerationInteractionEvent.find_by(source_event_key: "activitypub_follow:#{follow_request.uri}")
+
+      expect(interaction).to be_present
+      expect(interaction.event_type).to eq 'follow'
+      expect(interaction.actor_subject.account_id).to eq local.id
+      expect(interaction.target_subject.account_id).to eq remote.id
     end
 
     it 'records a follow_reject on first delivery with a stable activity-identity key' do
@@ -96,16 +111,66 @@ RSpec.describe 'Inbound ActivityPub follow-reject moderation coverage', type: :m
       expect(local.requested?(remote)).to be false
     end
 
-    it 'does not double-record on re-delivery (the FollowRequest is already gone)' do
+    it 'repairs a recorder-only reject failure on re-delivery via the follow correlation' do
+      # First delivery: reject! destroys the FollowRequest, but the reject
+      # recorder transiently fails, so no rejection is written.
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_return(nil)
       deliver(json)
+
+      expect(local.requested?(remote)).to be false
+      expect(ModerationRejectionEvent.count).to eq 0
+
+      # Re-delivery: the FollowRequest is gone, so the requester is recovered
+      # from the surviving outbound follow interaction anchor.
+      allow(Moderation::EventRecorder).to receive(:record_rejection).and_call_original
+      expect { deliver(json) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = ModerationRejectionEvent.order(:id).last
+      expect(event.event_type).to eq 'follow_reject'
+      expect(event.rejector_subject.account_id).to eq remote.id
+      expect(event.rejected_subject.account_id).to eq local.id
+      expect(event.source_event_key).to eq 'activitypub_follow_reject:https://remote.example/activities/reject-2'
+    end
+
+    it 'does not double-record on ordinary re-delivery' do
+      deliver(json)
+      expect(ModerationRejectionEvent.count).to eq 1
       expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
       expect(ModerationRejectionEvent.count).to eq 1
     end
+  end
 
-    # Known, documented limitation: unlike the embedded-Follow shape, this shape
-    # cannot self-repair because reject! has already destroyed the FollowRequest
-    # the rejected account is read from.
-    it 'cannot repair a missed ledger event on re-delivery' do
+  # Bare-URI shape with NO correlation anchor: the outbound follow interaction
+  # was never recorded (its recorder also failed), modeling the residual double
+  # recorder failure. A recorder-only reject failure then cannot be repaired.
+  context 'bare follow-request-URI shape (double recorder failure is not repairable)' do
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/reject-2b',
+        type: 'Reject',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: 'https://remote.example/activities/follow-2b',
+      }.with_indifferent_access
+    end
+
+    before do
+      # Fabricate the FollowRequest directly so no follow interaction anchor
+      # exists (as if the outbound follow recording had also failed).
+      Fabricate(:follow_request, account: local, target_account: remote, uri: 'https://remote.example/activities/follow-2b')
+    end
+
+    it 'records a follow_reject on first delivery (captured before reject!)' do
+      expect { deliver(json) }.to change(ModerationRejectionEvent, :count).by(1)
+
+      event = ModerationRejectionEvent.order(:id).last
+      expect(event.event_type).to eq 'follow_reject'
+      expect(event.rejector_subject.account_id).to eq remote.id
+      expect(event.rejected_subject.account_id).to eq local.id
+      expect(event.source_event_key).to eq 'activitypub_follow_reject:https://remote.example/activities/reject-2b'
+    end
+
+    it 'cannot repair a missed ledger event on re-delivery (no correlation anchor)' do
       allow(Moderation::EventRecorder).to receive(:record_rejection).and_return(nil)
       deliver(json)
 

--- a/spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
+++ b/spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe 'Inbound ActivityPub follow-reject moderation coverage', type: :m
       }.with_indifferent_access
     end
 
-    it 'records the outbound follow interaction under the AP activity-identity key' do
-      interaction = ModerationInteractionEvent.find_by(source_event_key: "activitypub_follow:#{follow_request.uri}")
+    it 'records the outbound follow interaction under the direction-specific AP activity-identity key' do
+      interaction = ModerationInteractionEvent.find_by(source_event_key: "activitypub_outbound_follow:#{follow_request.uri}")
 
       expect(interaction).to be_present
       expect(interaction.event_type).to eq 'follow'
@@ -137,6 +137,46 @@ RSpec.describe 'Inbound ActivityPub follow-reject moderation coverage', type: :m
       expect(ModerationRejectionEvent.count).to eq 1
       expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
       expect(ModerationRejectionEvent.count).to eq 1
+    end
+  end
+
+  # Adversarial: URI equality alone must not bind identities. An outbound follow
+  # local -> remote_other creates the anchor; a *different* remote then sends a
+  # bare-URI Reject echoing that other follow's URI (as if leaked/reused). The
+  # target-identity invariant must reject the correlation, so no follow_reject is
+  # synthesized for the wrong remote.
+  context 'bare follow-request-URI shape, cross-account anchor (must not repair)' do
+    before { allow(ActivityPub::DeliveryWorker).to receive(:perform_async) }
+
+    let(:remote_other) do
+      Fabricate(:account, domain: 'other.example', uri: 'https://other.example/users/carol', inbox_url: 'https://other.example/inbox', protocol: :activitypub)
+    end
+    let!(:other_follow_request) { FollowService.new.call(local, remote_other) }
+
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/reject-evil',
+        type: 'Reject',
+        actor: ActivityPub::TagManager.instance.uri_for(remote),
+        object: other_follow_request.uri,
+      }.with_indifferent_access
+    end
+
+    it 'has an anchor whose target is the other remote, not the Reject actor' do
+      interaction = ModerationInteractionEvent.find_by(source_event_key: "activitypub_outbound_follow:#{other_follow_request.uri}")
+
+      expect(interaction).to be_present
+      expect(interaction.actor_subject.account_id).to eq local.id
+      expect(interaction.target_subject.account_id).to eq remote_other.id
+    end
+
+    it 'does not synthesize a follow_reject when the anchor targets a different remote' do
+      # No FollowRequest exists for (local -> remote), so the repair path runs and
+      # the target-identity invariant must reject the mismatched anchor.
+      expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
+      expect { deliver(json) }.to_not change(ModerationRejectionEvent, :count)
+      expect(ModerationRejectionEvent.count).to eq 0
     end
   end
 

--- a/spec/services/moderation/evidence_snapshot_service_spec.rb
+++ b/spec/services/moderation/evidence_snapshot_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Moderation::EvidenceSnapshotService, type: :service do
     expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
     expect(snapshot.fingerprint.dig('coverage', 'inbound_activitypub')).to eq 'partial'
     gaps = snapshot.fingerprint.dig('coverage', 'known_inbound_recording_gaps')
-    expect(gaps).to include(a_hash_including('event_type' => 'follow_reject', 'shape' => 'bare_follow_request_uri', 'repairable' => false))
+    expect(gaps).to include(a_hash_including('event_type' => 'follow_reject', 'shape' => 'bare_follow_request_uri', 'condition' => 'double_recorder_failure', 'repairable' => false))
   end
 
   it 'does not put unordered same-window overlap into linked_negative_target_subject_ids' do

--- a/spec/services/moderation/ledger_lifecycle_spec.rb
+++ b/spec/services/moderation/ledger_lifecycle_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Moderation ledger composed lifecycle', type: :service do
       expect(snapshot.fingerprint.dig('coverage', 'complete_for_remote_subjects')).to be false
       expect(snapshot.fingerprint.dig('coverage', 'observed_inbound_event_types')).to include('follow_reject')
       expect(snapshot.fingerprint.dig('coverage', 'known_inbound_recording_gaps'))
-        .to include(a_hash_including('event_type' => 'follow_reject', 'repairable' => false))
+        .to include(a_hash_including('event_type' => 'follow_reject', 'condition' => 'double_recorder_failure', 'repairable' => false))
 
       expect { status.destroy! }.to_not change(ModerationInteractionEvent, :count)
       expect(ModerationInteractionEvent.exists?(contact.id)).to be true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the ordinary recorder-only-failure case of the bare-follow-request-URI `Reject` gap that PR [#36](https://github.com/fedibird/mastodon/pull/36) documented, using ActivityPub activity-identity `source_event_key`s (not JSONB metadata search), consistent with the inbound-follow scheme from #34, with identity-bound correlation.

### The problem

The bare-URI `Reject` shape destroys the `FollowRequest`, and its URI is an opaque payload id (`…/<uuid>` via `FollowRequest#set_uri` → `generate_uri_for`) that does **not** encode the requester. So a recorder-only failure on first delivery was previously permanent.

### The fix (identity-bound durable correlation)

- **`app/services/follow_service.rb`** — record the outbound `follow` interaction with a **direction-specific** `source_event_key = activitypub_outbound_follow:<follow record uri>` (falling back to the record-derived key when no uri is present). The dedicated outbound namespace keeps locally generated anchors from ever colliding with inbound follow ids, which are remote-supplied and keyed `activitypub_follow:<@json['id']>` in `activity/follow.rb`.
- **`app/lib/activitypub/activity/reject.rb`** — on a bare-URI `Reject` re-delivery (`repair_inbound_follow_reject_from_uri`), look up `ModerationInteractionEvent` by `activitypub_outbound_follow:<object_uri>` and **fail closed** unless every invariant holds:
  - `event_type == follow` (enforced in the query);
  - the anchor's `actor_subject` resolves to a **local** requester;
  - the anchor's `target_subject` is the very remote actor sending this Reject (`target_subject.account_id == @account.id`);
  - the source key / URI matches the rejected Follow activity identity.
  Only then is the `follow_reject` recorded under the stable `activitypub_follow_reject:<Reject id>` key.

URI equality alone no longer binds identities: a leaked/reused/malicious object URI cannot make us record "B rejected local A" off an anchor that was actually "A → remote C".

### Coverage stays honest

`complete_for_remote_subjects` is **not** raised. The only residual loss is a **double** recorder failure (both the outbound follow interaction and the inbound reject failed to record, leaving no anchor): `known_inbound_recording_gaps` keeps `condition: double_recorder_failure`; `inbound_activitypub` stays `partial`, `complete_for_remote_subjects` stays `false`.

### Preserved behavior

Embedded-`Follow` repair (from `@object['actor']`), idempotency / no double-recording, the stable `activitypub_follow_reject:<Reject id>` key, and established-follow `Reject` remaining modeled as an unfollow.

## Testing

`spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb`: outbound follow keyed `activitypub_outbound_follow:<uri>`; bare-URI single recorder-only failure repaired on re-delivery; no double-recording; the double-failure boundary (no anchor) unrepairable; and the **adversarial cross-account anchor** case (outbound `local → remote_other`, bare-URI Reject from a different `remote` echoing that URI → no `follow_reject` recorded), with the positive `local → same remote` repair still passing.

```
$ bundle exec rspec spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb
12 examples, 0 failures

$ bundle exec rspec spec/services/moderation spec/models/moderation \
    spec/models/moderation_interaction_event_spec.rb spec/models/moderation_rejection_event_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb \
    spec/services/reject_follow_service_spec.rb spec/lib/activitypub/activity/follow_spec.rb
128 examples, 0 failures
```

Pre-existing failures unrelated to this change (confirmed failing on the base with these changes stashed): `follow_service_spec` (2, webpack manifest) and `refollow_worker_spec:22` (1, `delivery:` kwarg drift).

Head: `cd9694132dbaa115c6e8b81b3f60a47cd335ea47`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

