### PR TITLE
Admin: read-only moderation evidence view (PR 7)

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -34,6 +34,7 @@ module Admin
       @moderation_notes        = @account.targeted_moderation_notes.latest
       @warnings                = @account.targeted_account_warnings.latest.custom
       @domain_block            = DomainBlock.rule_for(@account.domain)
+      @moderation_subject      = ModerationSubject.find_by(account_id: @account.id)
     end
 
     def memorialize

--- a/app/controllers/admin/moderation_evidence_snapshots_controller.rb
+++ b/app/controllers/admin/moderation_evidence_snapshots_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Admin
+  # Read-only view over the moderation evidence ledger: the point-in-time
+  # snapshots captured when a moderator action is taken. This surfaces the
+  # recorded reasoning (summary counts, coverage, linked/correlated negative
+  # target sets) for later review. It never scores, judges, or mutates the
+  # ledger.
+  class ModerationEvidenceSnapshotsController < BaseController
+    before_action :set_snapshot, only: [:show]
+
+    PER_PAGE = 25
+
+    def index
+      authorize :moderation_evidence_snapshot, :index?
+
+      @subject   = ModerationSubject.find_by(id: params[:subject_id]) if params[:subject_id].present?
+      @snapshots = filtered_snapshots
+                   .includes(subject: :account, moderation_actions: :moderator_account)
+                   .order(created_at: :desc)
+                   .page(params[:page])
+                   .per(PER_PAGE)
+    end
+
+    def show
+      authorize @snapshot, :show?
+
+      @moderation_actions  = @snapshot.moderation_actions.includes(:moderator_account).order(performed_at: :desc)
+      @linked_subjects     = resolve_subjects(@snapshot.linked_negative_target_subject_ids)
+      @correlated_subjects = resolve_subjects(@snapshot.correlated_negative_target_subject_ids)
+    end
+
+    private
+
+    def set_snapshot
+      @snapshot = ModerationEvidenceSnapshot.includes(subject: :account).find(params[:id])
+    end
+
+    def filtered_snapshots
+      scope = ModerationEvidenceSnapshot.all
+      scope = scope.where(subject_id: @subject.id) if @subject
+      scope
+    end
+
+    # Resolve the persisted subject-id sets to their subjects (and accounts when
+    # still attached) for display, without ever fabricating a missing subject.
+    def resolve_subjects(ids)
+      return {} if ids.blank?
+
+      ModerationSubject.where(id: ids).includes(:account).index_by(&:id)
+    end
+  end
+end

--- a/app/controllers/admin/moderation_evidence_snapshots_controller.rb
+++ b/app/controllers/admin/moderation_evidence_snapshots_controller.rb
@@ -14,7 +14,10 @@ module Admin
     def index
       authorize :moderation_evidence_snapshot, :index?
 
-      @subject   = ModerationSubject.find_by(id: params[:subject_id]) if params[:subject_id].present?
+      # A narrowing parameter must fail closed: a stale/invalid subject_id 404s
+      # (via rescue_from RecordNotFound) rather than silently widening to the
+      # global snapshot list.
+      @subject   = ModerationSubject.find(params[:subject_id]) if params[:subject_id].present?
       @snapshots = filtered_snapshots
                    .includes(subject: :account, moderation_actions: :moderator_account)
                    .order(created_at: :desc)

--- a/app/helpers/admin/moderation_evidence_snapshots_helper.rb
+++ b/app/helpers/admin/moderation_evidence_snapshots_helper.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Admin::ModerationEvidenceSnapshotsHelper
+  # Human label for a moderation subject. Prefers the still-attached account's
+  # acct; otherwise falls back to the denormalized origin/domain the subject
+  # kept, so tombstoned/detached subjects remain identifiable.
+  def moderation_subject_label(subject)
+    return t('admin.moderation_evidence_snapshots.unknown_subject') if subject.nil?
+
+    if subject.account
+      acct = subject.account.local? ? subject.account.username : subject.account.acct
+      "@#{acct}"
+    elsif subject.domain.present?
+      t('admin.moderation_evidence_snapshots.detached_remote_subject', domain: subject.domain)
+    else
+      t('admin.moderation_evidence_snapshots.detached_local_subject')
+    end
+  end
+
+  # Link to the subject's account admin page when the account is still attached,
+  # otherwise render the plain label (the account is gone).
+  def moderation_subject_link(subject)
+    label = moderation_subject_label(subject)
+    return label if subject.nil? || subject.account.nil?
+
+    link_to label, admin_account_path(subject.account.id)
+  end
+
+  def moderation_subject_origin_badge(subject)
+    return if subject.nil?
+
+    content_tag(:span, subject.origin, class: "moderation-evidence__badge moderation-evidence__badge--#{subject.origin}")
+  end
+
+  # Render a persisted subject-id set as resolved subject links, falling back to
+  # the raw id when the subject row is gone (never fabricate identity).
+  def moderation_negative_targets(ids, resolved)
+    return t('admin.moderation_evidence_snapshots.none') if ids.blank?
+
+    safe_join(ids.map do |id|
+      subject = resolved[id]
+      subject ? moderation_subject_link(subject) : "##{id}"
+    end, ', ')
+  end
+
+  def moderation_boolean(value)
+    return t('admin.moderation_evidence_snapshots.unknown') if value.nil?
+
+    t("admin.moderation_evidence_snapshots.boolean.#{value ? 'affirmative' : 'negative'}")
+  end
+
+  def moderation_snapshot_window(snapshot)
+    if snapshot.window_start && snapshot.window_end
+      "#{l(snapshot.window_start)} – #{l(snapshot.window_end)}"
+    elsif snapshot.window_end
+      "… – #{l(snapshot.window_end)}"
+    else
+      t('admin.moderation_evidence_snapshots.all_time')
+    end
+  end
+end

--- a/app/policies/moderation_evidence_snapshot_policy.rb
+++ b/app/policies/moderation_evidence_snapshot_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ModerationEvidenceSnapshotPolicy < ApplicationPolicy
+  def index?
+    staff?
+  end
+
+  def show?
+    staff?
+  end
+end

--- a/app/services/moderation/evidence_snapshot_service.rb
+++ b/app/services/moderation/evidence_snapshot_service.rb
@@ -50,7 +50,7 @@ module Moderation
     # destroys the FollowRequest (whose URI is an opaque payload id that does not
     # encode the requester), so an ordinary recorder-only failure is now repaired
     # on re-delivery by correlating the follow-request URI to the outbound follow
-    # interaction recorded at request time (source_event_key activitypub_follow:<uri>).
+    # interaction recorded at request time (source_event_key activitypub_outbound_follow:<uri>).
     # The event is lost only when BOTH that outbound follow interaction and the
     # inbound reject failed to record, because then no correlation anchor persists.
     # The embedded-Follow Reject shape repairs directly from @object['actor']. A
@@ -67,7 +67,7 @@ module Moderation
           'shape' => 'bare_follow_request_uri',
           'condition' => 'double_recorder_failure',
           'repairable' => false,
-          'reason' => 'An ordinary recorder-only failure is repaired on re-delivery by correlating the follow-request URI to the outbound follow interaction (activitypub_follow:<uri>). The event is lost only when both the outbound follow interaction and the inbound reject failed to record, leaving no correlation anchor.',
+          'reason' => 'An ordinary recorder-only failure is repaired on re-delivery by correlating the follow-request URI to the outbound follow interaction (activitypub_outbound_follow:<uri>). The event is lost only when both the outbound follow interaction and the inbound reject failed to record, leaving no correlation anchor.',
         }.freeze,
       ].freeze,
     }.freeze

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -56,6 +56,11 @@
     = link_to admin_reports_path(target_account_id: @account.id) do
       .dashboard__counters__num= number_with_delimiter @account.targeted_reports.count
       .dashboard__counters__label= t '.targeted_reports'
+  - if @moderation_subject.present?
+    %div
+      = link_to admin_moderation_evidence_snapshots_path(subject_id: @moderation_subject.id) do
+        .dashboard__counters__num= number_with_delimiter @moderation_subject.evidence_snapshots.count
+        .dashboard__counters__label= t 'admin.moderation_evidence_snapshots.title'
   %div
     = link_to admin_action_logs_path(target_account_id: @account.id) do
       .dashboard__counters__text

--- a/app/views/admin/moderation_evidence_snapshots/index.html.haml
+++ b/app/views/admin/moderation_evidence_snapshots/index.html.haml
@@ -1,0 +1,47 @@
+- content_for :page_title do
+  = t('admin.moderation_evidence_snapshots.title')
+
+- if @subject.present?
+  .filters
+    .filter-subset
+      %strong= t('admin.moderation_evidence_snapshots.filtered_by_subject')
+      %ul
+        %li
+          = moderation_subject_link(@subject)
+          = link_to t('admin.moderation_evidence_snapshots.clear_filter'), admin_moderation_evidence_snapshots_path
+
+  %hr.spacer/
+
+%p.muted-hint= t('admin.moderation_evidence_snapshots.hint')
+
+- if @snapshots.empty?
+  %div.muted-hint.center-text
+    = t('admin.moderation_evidence_snapshots.empty')
+- else
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('admin.moderation_evidence_snapshots.columns.subject')
+          %th= t('admin.moderation_evidence_snapshots.columns.origin')
+          %th= t('admin.moderation_evidence_snapshots.columns.actions')
+          %th= t('admin.moderation_evidence_snapshots.columns.interactions')
+          %th= t('admin.moderation_evidence_snapshots.columns.negative_responders')
+          %th= t('admin.moderation_evidence_snapshots.columns.linked')
+          %th= t('admin.moderation_evidence_snapshots.columns.created_at')
+          %th
+      %tbody
+        - @snapshots.each do |snapshot|
+          %tr
+            %td= moderation_subject_link(snapshot.subject)
+            %td= moderation_subject_origin_badge(snapshot.subject)
+            %td
+              - actions = snapshot.moderation_actions.map { |action| t("admin.moderation_evidence_snapshots.action_types.#{action.action_type}") }
+              = actions.presence&.join(', ') || t('admin.moderation_evidence_snapshots.none')
+            %td= snapshot.summary['interactions_count'].to_i
+            %td= snapshot.summary['negative_responders'].to_i
+            %td= snapshot.summary['linked_negative_target_count'].to_i
+            %td= l(snapshot.created_at)
+            %td= link_to t('admin.moderation_evidence_snapshots.view'), admin_moderation_evidence_snapshot_path(snapshot)
+
+  = paginate @snapshots

--- a/app/views/admin/moderation_evidence_snapshots/show.html.haml
+++ b/app/views/admin/moderation_evidence_snapshots/show.html.haml
@@ -1,0 +1,116 @@
+- content_for :page_title do
+  = t('admin.moderation_evidence_snapshots.show_title', id: @snapshot.id)
+
+- coverage = @snapshot.fingerprint['coverage'] || {}
+- summary  = @snapshot.summary || {}
+
+.dashboard__counters
+  %div
+    = link_to admin_moderation_evidence_snapshots_path(subject_id: @snapshot.subject_id) do
+      %div
+        %span.dashboard__counters__num= moderation_subject_label(@snapshot.subject)
+        %span.dashboard__counters__label= t('admin.moderation_evidence_snapshots.columns.subject')
+  %div
+    %div
+      %span.dashboard__counters__num= moderation_subject_origin_badge(@snapshot.subject)
+      %span.dashboard__counters__label= t('admin.moderation_evidence_snapshots.columns.origin')
+  %div
+    %div
+      %span.dashboard__counters__num= l(@snapshot.created_at)
+      %span.dashboard__counters__label= t('admin.moderation_evidence_snapshots.columns.created_at')
+
+%hr.spacer/
+
+%p.muted-hint= t('admin.moderation_evidence_snapshots.association_disclaimer')
+
+%h3= t('admin.moderation_evidence_snapshots.sections.metadata')
+.table-wrapper
+  %table.table
+    %tbody
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.fields.subject')
+        %td= moderation_subject_link(@snapshot.subject)
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.fields.window')
+        %td= moderation_snapshot_window(@snapshot)
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.fields.schema_version')
+        %td= @snapshot.schema_version
+
+%h3= t('admin.moderation_evidence_snapshots.sections.actions')
+- if @moderation_actions.empty?
+  %p.muted-hint= t('admin.moderation_evidence_snapshots.none')
+- else
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('admin.moderation_evidence_snapshots.columns.action')
+          %th= t('admin.moderation_evidence_snapshots.columns.moderator')
+          %th= t('admin.moderation_evidence_snapshots.columns.reason_code')
+          %th= t('admin.moderation_evidence_snapshots.columns.performed_at')
+      %tbody
+        - @moderation_actions.each do |action|
+          %tr
+            %td= t("admin.moderation_evidence_snapshots.action_types.#{action.action_type}")
+            %td
+              - if action.moderator_account
+                = link_to "@#{action.moderator_account.username}", admin_account_path(action.moderator_account.id)
+              - else
+                = t('admin.moderation_evidence_snapshots.system')
+            %td= action.reason_code.presence || '—'
+            %td= l(action.performed_at)
+
+%h3= t('admin.moderation_evidence_snapshots.sections.summary')
+.table-wrapper
+  %table.table
+    %tbody
+      - %w(interactions_count unique_contacts negative_responders linked_negative_target_count correlated_negative_target_count blocks_received follow_rejects_received removed_as_follower reports_received mutes_received).each do |key|
+        %tr
+          %th= t("admin.moderation_evidence_snapshots.summary_keys.#{key}")
+          %td= summary[key].to_i
+
+%h3= t('admin.moderation_evidence_snapshots.sections.coverage')
+.table-wrapper
+  %table.table
+    %tbody
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.coverage.inbound_activitypub')
+        %td= coverage['inbound_activitypub'] || '—'
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.coverage.complete_for_remote_subjects')
+        %td= coverage.key?('complete_for_remote_subjects') ? moderation_boolean(coverage['complete_for_remote_subjects']) : '—'
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.coverage.observed_inbound_event_types')
+        %td= Array(coverage['observed_inbound_event_types']).presence&.join(', ') || t('admin.moderation_evidence_snapshots.none')
+      %tr
+        %th= t('admin.moderation_evidence_snapshots.coverage.deferred_inbound_event_types')
+        %td= Array(coverage['deferred_inbound_event_types']).presence&.join(', ') || t('admin.moderation_evidence_snapshots.none')
+- gaps = Array(coverage['known_inbound_recording_gaps'])
+- if gaps.present?
+  %h4= t('admin.moderation_evidence_snapshots.coverage.known_inbound_recording_gaps')
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('admin.moderation_evidence_snapshots.gap_keys.event_type')
+          %th= t('admin.moderation_evidence_snapshots.gap_keys.shape')
+          %th= t('admin.moderation_evidence_snapshots.gap_keys.condition')
+          %th= t('admin.moderation_evidence_snapshots.gap_keys.repairable')
+          %th= t('admin.moderation_evidence_snapshots.gap_keys.reason')
+      %tbody
+        - gaps.each do |gap|
+          %tr
+            %td= gap['event_type']
+            %td= gap['shape']
+            %td= gap['condition'] || '—'
+            %td= gap.key?('repairable') ? moderation_boolean(gap['repairable']) : '—'
+            %td= gap['reason']
+
+%h3= t('admin.moderation_evidence_snapshots.sections.linked_negative_targets')
+%p.muted-hint= t('admin.moderation_evidence_snapshots.linked_hint')
+%p= moderation_negative_targets(@snapshot.linked_negative_target_subject_ids, @linked_subjects)
+
+%h3= t('admin.moderation_evidence_snapshots.sections.correlated_negative_targets')
+%p.muted-hint= t('admin.moderation_evidence_snapshots.correlated_hint')
+%p= moderation_negative_targets(@snapshot.correlated_negative_target_subject_ids, @correlated_subjects)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,80 @@ en:
       warn: Warn
       web: Web
       whitelisted: Allowed for federation
+    moderation_evidence_snapshots:
+      title: Moderation evidence
+      show_title: "Evidence snapshot #%{id}"
+      hint: Point-in-time evidence snapshots captured when a moderator action is taken. Read-only; no scoring or judgement is applied here.
+      empty: No evidence snapshots have been recorded yet.
+      view: View
+      none: None
+      unknown: Unknown
+      unknown_subject: Unknown subject
+      detached_remote_subject: "Deleted remote account (%{domain})"
+      detached_local_subject: Deleted local account
+      all_time: All time
+      filtered_by_subject: "Filtered by subject:"
+      clear_filter: (clear)
+      system: System
+      association_disclaimer: A linked negative target is a strong temporal association (a preceding contact within the window), not proof that the contact caused the rejection.
+      linked_hint: Accounts this subject contacted that later returned a negative signal, with a preceding-contact link inside the association window.
+      correlated_hint: Same-window overlap without a preceding-contact link. A weaker correlation only.
+      columns:
+        subject: Subject
+        origin: Origin
+        actions: Actions
+        interactions: Interactions
+        negative_responders: Negative responders
+        linked: Linked
+        created_at: Captured at
+        action: Action
+        moderator: Moderator
+        reason_code: Reason code
+        performed_at: Performed at
+      action_types:
+        warn: Warn
+        limit: Limit
+        freeze: Freeze
+        suspend: Suspend
+        delete: Delete
+        other: Other
+      sections:
+        metadata: Metadata
+        actions: Related moderation actions
+        summary: Summary
+        coverage: Observation coverage
+        linked_negative_targets: Linked negative targets
+        correlated_negative_targets: Correlated negative targets
+      fields:
+        subject: Subject
+        window: Window
+        schema_version: Schema version
+      summary_keys:
+        interactions_count: Interactions
+        unique_contacts: Unique contacts
+        negative_responders: Negative responders
+        linked_negative_target_count: Linked negative targets
+        correlated_negative_target_count: Correlated negative targets
+        blocks_received: Blocks received
+        follow_rejects_received: Follow rejects received
+        removed_as_follower: Removed as follower
+        reports_received: Reports received
+        mutes_received: Mutes received
+      coverage:
+        inbound_activitypub: Inbound ActivityPub
+        complete_for_remote_subjects: Complete for remote subjects
+        observed_inbound_event_types: Observed inbound event types
+        deferred_inbound_event_types: Deferred inbound event types
+        known_inbound_recording_gaps: Known inbound recording gaps
+      gap_keys:
+        event_type: Event type
+        shape: Shape
+        condition: Condition
+        repairable: Repairable
+        reason: Reason
+      boolean:
+        affirmative: 'Yes'
+        negative: 'No'
     action_logs:
       action_types:
         assigned_to_self_report: Assign Report

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,80 @@ ja:
       warn: 警告
       web: Web
       whitelisted: 連合許可済み
+    moderation_evidence_snapshots:
+      title: モデレーション証跡
+      show_title: "証跡スナップショット #%{id}"
+      hint: モデレーターがアクションを行った時点で取得される証跡スナップショットです。閲覧専用で、ここでスコア付けや判断は行いません。
+      empty: まだ証跡スナップショットは記録されていません。
+      view: 表示
+      none: なし
+      unknown: 不明
+      unknown_subject: 不明な対象
+      detached_remote_subject: "削除済みのリモートアカウント (%{domain})"
+      detached_local_subject: 削除済みのローカルアカウント
+      all_time: 全期間
+      filtered_by_subject: "対象で絞り込み中:"
+      clear_filter: (解除)
+      system: システム
+      association_disclaimer: リンクされた否定的対象は、期間内の先行接触による強い時間的関連であり、その接触が拒否の原因であることの証明ではありません。
+      linked_hint: この対象が接触し、その後に否定的シグナルを返したアカウントのうち、関連期間内に先行接触リンクを持つもの。
+      correlated_hint: 先行接触リンクを持たない同一期間内の重なり。より弱い相関にすぎません。
+      columns:
+        subject: 対象
+        origin: 由来
+        actions: アクション
+        interactions: インタラクション
+        negative_responders: 否定的反応者
+        linked: リンク
+        created_at: 取得日時
+        action: アクション
+        moderator: モデレーター
+        reason_code: 理由コード
+        performed_at: 実行日時
+      action_types:
+        warn: 警告
+        limit: 制限
+        freeze: 凍結
+        suspend: 停止
+        delete: 削除
+        other: その他
+      sections:
+        metadata: メタデータ
+        actions: 関連するモデレーションアクション
+        summary: サマリー
+        coverage: 観測カバレッジ
+        linked_negative_targets: リンクされた否定的対象
+        correlated_negative_targets: 相関する否定的対象
+      fields:
+        subject: 対象
+        window: 期間
+        schema_version: スキーマバージョン
+      summary_keys:
+        interactions_count: インタラクション数
+        unique_contacts: ユニーク接触数
+        negative_responders: 否定的反応者数
+        linked_negative_target_count: リンクされた否定的対象数
+        correlated_negative_target_count: 相関する否定的対象数
+        blocks_received: 受けたブロック数
+        follow_rejects_received: 受けたフォロー拒否数
+        removed_as_follower: フォロワー解除数
+        reports_received: 受けた通報数
+        mutes_received: 受けたミュート数
+      coverage:
+        inbound_activitypub: 受信 ActivityPub
+        complete_for_remote_subjects: リモート対象で完全
+        observed_inbound_event_types: 観測済みの受信イベント種別
+        deferred_inbound_event_types: 保留中の受信イベント種別
+        known_inbound_recording_gaps: 既知の受信記録ギャップ
+      gap_keys:
+        event_type: イベント種別
+        shape: 形状
+        condition: 条件
+        repairable: 修復可能
+        reason: 理由
+      boolean:
+        affirmative: はい
+        negative: いいえ
     action_logs:
       action_types:
         assigned_to_self_report: 通報の担当者に設定

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -52,6 +52,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
     n.item :moderation, safe_join([fa_icon('gavel fw'), t('moderation.title')]), admin_reports_url, if: proc { current_user.staff? } do |s|
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_url
+      s.item :moderation_evidence_snapshots, safe_join([fa_icon('folder-open fw'), t('admin.moderation_evidence_snapshots.title')]), admin_moderation_evidence_snapshots_url, highlights_on: %r{/admin/moderation_evidence}
       s.item :reports, safe_join([fa_icon('flag fw'), t('admin.reports.title')]), admin_reports_url, highlights_on: %r{/admin/reports}
       s.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_url, highlights_on: %r{/admin/accounts|/admin/pending_accounts}
       s.item :invites, safe_join([fa_icon('user-plus fw'), t('admin.invites.title')]), admin_invites_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,7 @@ Rails.application.routes.draw do
 
     resources :email_domain_blocks, only: [:index, :new, :create, :destroy]
     resources :action_logs, only: [:index]
+    resources :moderation_evidence_snapshots, only: [:index, :show], path: 'moderation_evidence'
     resources :warning_presets, except: [:new]
 
     resources :announcements, except: [:show] do

--- a/docs/moderation-signal-inbound-coverage.md
+++ b/docs/moderation-signal-inbound-coverage.md
@@ -69,7 +69,7 @@ event type (schema_version is now `6`):
       "shape": "bare_follow_request_uri",
       "condition": "double_recorder_failure",
       "repairable": false,
-      "reason": "An ordinary recorder-only failure is repaired on re-delivery by correlating the follow-request URI to the outbound follow interaction (activitypub_follow:<uri>). The event is lost only when both the outbound follow interaction and the inbound reject failed to record, leaving no correlation anchor."
+      "reason": "An ordinary recorder-only failure is repaired on re-delivery by correlating the follow-request URI to the outbound follow interaction (activitypub_outbound_follow:<uri>). The event is lost only when both the outbound follow interaction and the inbound reject failed to record, leaving no correlation anchor."
     }
   ]
 }

--- a/spec/controllers/admin/moderation_evidence_snapshots_controller_spec.rb
+++ b/spec/controllers/admin/moderation_evidence_snapshots_controller_spec.rb
@@ -29,6 +29,17 @@ describe Admin::ModerationEvidenceSnapshotsController, type: :controller do
         expect(assigns(:snapshots)).to include(snapshot_a)
         expect(assigns(:snapshots)).to_not include(snapshot_b)
       end
+
+      it 'fails closed with 404 for a stale subject_id instead of widening to the global list' do
+        stale_id = ModerationSubject.maximum(:id).to_i + 1
+
+        get :index, params: { subject_id: stale_id }
+
+        expect(response).to have_http_status(404)
+        # The action aborted before building a scope, so it never fell back to
+        # the unfiltered global snapshot list.
+        expect(assigns(:snapshots)).to be_nil
+      end
     end
 
     describe 'GET #show' do

--- a/spec/controllers/admin/moderation_evidence_snapshots_controller_spec.rb
+++ b/spec/controllers/admin/moderation_evidence_snapshots_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::ModerationEvidenceSnapshotsController, type: :controller do
+  render_views false
+
+  let(:subject_a) { Fabricate(:moderation_subject) }
+  let(:subject_b) { Fabricate(:moderation_subject) }
+  let!(:snapshot_a) { Fabricate(:moderation_evidence_snapshot, subject: subject_a) }
+  let!(:snapshot_b) { Fabricate(:moderation_evidence_snapshot, subject: subject_b) }
+
+  context 'as an admin' do
+    before { sign_in Fabricate(:user, admin: true) }
+
+    describe 'GET #index' do
+      it 'returns 200 and lists all snapshots' do
+        get :index
+
+        expect(response).to have_http_status(200)
+        expect(assigns(:snapshots)).to include(snapshot_a, snapshot_b)
+      end
+
+      it 'filters by subject_id when given' do
+        get :index, params: { subject_id: subject_a.id }
+
+        expect(response).to have_http_status(200)
+        expect(assigns(:subject)).to eq subject_a
+        expect(assigns(:snapshots)).to include(snapshot_a)
+        expect(assigns(:snapshots)).to_not include(snapshot_b)
+      end
+    end
+
+    describe 'GET #show' do
+      it 'returns 200 for a snapshot' do
+        get :show, params: { id: snapshot_a.id }
+
+        expect(response).to have_http_status(200)
+        expect(assigns(:snapshot)).to eq snapshot_a
+      end
+
+      it 'resolves the negative-target subject sets' do
+        snapshot_a.update!(fingerprint: {
+          'linked_negative_target_subject_ids' => [subject_b.id],
+          'correlated_negative_target_subject_ids' => [],
+        })
+
+        get :show, params: { id: snapshot_a.id }
+
+        expect(assigns(:linked_subjects)).to eq(subject_b.id => subject_b)
+      end
+    end
+  end
+
+  context 'as a non-staff user' do
+    before { sign_in Fabricate(:user) }
+
+    it 'forbids the index' do
+      get :index
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'forbids show' do
+      get :show, params: { id: snapshot_a.id }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/helpers/admin/moderation_evidence_snapshots_helper_spec.rb
+++ b/spec/helpers/admin/moderation_evidence_snapshots_helper_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ModerationEvidenceSnapshotsHelper, type: :helper do
+  describe '#moderation_subject_label' do
+    it 'labels a local account by username' do
+      account = Fabricate(:account, username: 'alice')
+      subject = Fabricate(:moderation_subject, account: account, origin: :local)
+
+      expect(helper.moderation_subject_label(subject)).to eq '@alice'
+    end
+
+    it 'labels a remote account by acct' do
+      account = Fabricate(:account, username: 'bob', domain: 'remote.example')
+      subject = Fabricate(:moderation_subject, account: account, origin: :remote, domain: 'remote.example')
+
+      expect(helper.moderation_subject_label(subject)).to eq '@bob@remote.example'
+    end
+
+    it 'falls back to the domain for a detached remote subject' do
+      subject = Fabricate(:moderation_subject, account: nil, origin: :remote, domain: 'gone.example')
+
+      expect(helper.moderation_subject_label(subject)).to eq I18n.t('admin.moderation_evidence_snapshots.detached_remote_subject', domain: 'gone.example')
+    end
+
+    it 'falls back to a generic label for a detached local subject' do
+      subject = Fabricate(:moderation_subject, account: nil, origin: :local, domain: nil)
+
+      expect(helper.moderation_subject_label(subject)).to eq I18n.t('admin.moderation_evidence_snapshots.detached_local_subject')
+    end
+  end
+
+  describe '#moderation_negative_targets' do
+    it 'returns the none label for a blank set' do
+      expect(helper.moderation_negative_targets([], {})).to eq I18n.t('admin.moderation_evidence_snapshots.none')
+    end
+
+    it 'renders resolved subjects and falls back to a raw id when unresolved' do
+      account = Fabricate(:account, username: 'carol')
+      subject = Fabricate(:moderation_subject, account: account, origin: :local)
+
+      rendered = helper.moderation_negative_targets([subject.id, 999], { subject.id => subject })
+
+      expect(rendered).to include('@carol')
+      expect(rendered).to include('#999')
+    end
+  end
+
+  describe '#moderation_boolean' do
+    it 'renders localized yes/no and unknown' do
+      expect(helper.moderation_boolean(true)).to eq I18n.t('admin.moderation_evidence_snapshots.boolean.affirmative')
+      expect(helper.moderation_boolean(false)).to eq I18n.t('admin.moderation_evidence_snapshots.boolean.negative')
+      expect(helper.moderation_boolean(nil)).to eq I18n.t('admin.moderation_evidence_snapshots.unknown')
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **read-only** admin UI over the moderation evidence ledger built in PRs #26–#37. It surfaces the point-in-time evidence snapshots captured whenever a moderator action is taken, so the recorded reasoning can be reviewed later. It never scores, judges, infers, or mutates the ledger — this is the observation/visualization layer only.

## What's included

- **Route** — `resources :moderation_evidence_snapshots, only: [:index, :show], path: 'moderation_evidence'` under `namespace :admin`.
- **Policy** — `ModerationEvidenceSnapshotPolicy` (`index?`/`show?` require `staff?`); the controller also inherits `require_staff!` from `Admin::BaseController`.
- **Controller** — `Admin::ModerationEvidenceSnapshotsController`:
  - `index`: paginated list, newest first, eager-loads `subject → account` and `moderation_actions → moderator_account`; optional `?subject_id=` filter that **fails closed** (a stale/invalid id 404s via `ModerationSubject.find`, never widening to the global list).
  - `show`: the snapshot plus its related moderation actions, with the persisted linked/correlated negative-target subject-id sets resolved to `ModerationSubject`s (never fabricating a missing subject).
- **Views** — index table and a detail page (metadata, related moderation actions, full summary counts, observation coverage incl. `known_inbound_recording_gaps`, and the linked/correlated negative-target sets). The detail page carries the standing disclaimer that a linked negative target is a **strong temporal association, not causal proof**.
- **Helpers** — subject label/link (falls back to origin/domain for detached/tombstoned subjects), origin badge, negative-target rendering (raw `#id` fallback when a subject row is gone), window formatting, localized boolean.
- **Navigation** — a "Moderation evidence" item in the moderation sidebar group.
- **Account page link** — the admin account page shows an evidence-snapshot counter linking to that subject's filtered evidence, when a `ModerationSubject` exists.
- **i18n** — full `admin.moderation_evidence_snapshots.*` strings in `en` and `ja`.

## Review fixes (this round)

1. **Fail-closed `subject_id` filter** — a stale/invalid id now 404s instead of silently returning the global snapshot list; added a controller regression asserting 404 and that no scope is built.
2. **Stale gap-reason text** — the `known_inbound_recording_gaps.reason` (surfaced verbatim to moderators) still referenced #37's old key `activitypub_follow:<uri>`; corrected to `activitypub_outbound_follow:<uri>` in `EvidenceSnapshotService` (constant + comment) and the docs. New snapshots store the corrected text.

## Testing

```
$ bundle exec rspec spec/controllers/admin/moderation_evidence_snapshots_controller_spec.rb \
    spec/helpers/admin/moderation_evidence_snapshots_helper_spec.rb \
    spec/services/moderation/evidence_snapshot_service_spec.rb \
    spec/services/moderation/ledger_lifecycle_spec.rb
22 examples, 0 failures
```

Manual GUI verification against the dev server (real pack manifest), all rendered without error:
- **index** (with `@evidenced_spammer` rows), **filtered index** (`subject_id=1` → "Filtered by subject"), **show** (summary 12 / 6 / 4, coverage `partial`, gaps table), **detached/tombstoned fallback** (index + detail render "Deleted remote account (gone.example)" and "Deleted local account" as plain text), **coverage/gap section** (reason now reads `activitypub_outbound_follow:<uri>`), and **fail-closed 404** on `subject_id=999999999`.

Review-fix walkthrough (404 → detached rows → detached detail → corrected reason):

[admin_evidence_review_fixes_walkthrough.mp4](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_evidence_review_fixes_walkthrough.mp4)

[Stale subject_id returns 404](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevidence_stale_subject_404.webp)

[Index with detached subject fallback labels](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevidence_index_detached_subjects.webp)

[Gap reason shows activitypub_outbound_follow](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevidence_gap_reason_corrected.webp)

General end-to-end walkthrough (index → detail → account counter → filtered index):

[admin_moderation_evidence_walkthrough.mp4](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_moderation_evidence_walkthrough.mp4)

[Evidence detail coverage and linked targets](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevidence_detail_coverage.webp)

Head: `f3c7916c8b079cea8aed50d1d550d8759345816c`

Do not merge — for review.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

