### PR TITLE
Moderation ledger: link follow-import follows to their FollowImportBatch (PR 8)

### DIFF
--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -57,7 +57,11 @@ class FollowService < BaseService
         target: @target_account,
         event_type: :follow,
         source_record: follow,
-        source_event_key: follow_source_event_key(follow)
+        source_event_key: follow_source_event_key(follow),
+        # Only set for follows executed by a follow import; the import passes the
+        # FollowImportBatch id explicitly through :import_batch_id. Normal UI /
+        # API / ActivityPub follows leave it nil, so the ledger column stays NULL.
+        import_batch_id: @options[:import_batch_id]
       )
     end
 

--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -29,12 +29,16 @@ class ImportService < BaseService
 
   def import_follows!
     parse_import_data!(['Account address'])
-    record_follow_import_batch!
-    import_relationships!('follow', 'unfollow', @account.following.map { |account| { acct: account.acct }}, ROWS_PROCESSING_LIMIT, show_reblogs: { header: 'Show boosts', default: true }, notify: { header: 'Notify on new posts', default: false }, languages: { header: 'Languages', default: nil }, delivery: { header: 'Delivery to home', default: true })
+    batch = record_follow_import_batch!
+    # Propagate the batch id to every follow this import executes so the ledger
+    # can link batch -> actual follow. Recording is failure-tolerant, so batch
+    # may be nil (import still proceeds; import_batch_id just stays NULL).
+    import_relationships!('follow', 'unfollow', @account.following.map { |account| { acct: account.acct }}, ROWS_PROCESSING_LIMIT, import_batch_id: batch&.id, show_reblogs: { header: 'Show boosts', default: true }, notify: { header: 'Notify on new posts', default: false }, languages: { header: 'Languages', default: nil }, delivery: { header: 'Delivery to home', default: true })
   end
 
   # Record the follow-import target set into the moderation ledger before the
   # follows are executed (the whole set is known here after CSV parsing).
+  # Returns the FollowImportBatch (or nil when recording failed).
   def record_follow_import_batch!
     accts = @data.take(ROWS_PROCESSING_LIMIT).filter_map { |row| row['Account address']&.strip.presence }
 
@@ -81,13 +85,18 @@ class ImportService < BaseService
     end
   end
 
-  def import_relationships!(action, undo_action, overwrite_scope, limit, extra_fields = {})
+  # +import_batch_id+ is set only for follow imports (see #import_follows!). When
+  # present it is attached to each executed relationship's worker options so the
+  # downstream service can record it into the moderation ledger. All other
+  # imports pass nil and it never appears in the options.
+  def import_relationships!(action, undo_action, overwrite_scope, limit, import_batch_id: nil, **extra_fields)
     local_domain_suffix = "@#{Rails.configuration.x.local_domain}"
     items = @data.take(limit).each_with_object({}) do |row, mapping|
       key = row['Account address']&.strip&.delete_suffix(local_domain_suffix)
       return if key.blank?
 
       extra = extra_fields.each_with_object({}) {|(key, field_settings), extra| extra[key] = row[field_settings[:header]]&.strip || field_settings[:default] }
+      extra[:import_batch_id] = import_batch_id if import_batch_id
 
       if extra[:lists].nil?
         extra.delete(:lists)

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -211,4 +211,60 @@ RSpec.describe ImportService, type: :service do
       end
     end
   end
+
+  # Assert the follow-import -> batch-id propagation at ImportService's enqueue
+  # boundary, capturing the worker args it produces. This avoids executing the
+  # follows inline (that path renders a notification mailer needing a webpack
+  # manifest not built in the test env) and does not depend on Sidekiq's queue
+  # internals. The worker -> FollowService -> ledger legs are covered in
+  # relationship_worker_spec and interaction_hooks_spec.
+  context 'follow-import moderation ledger linkage' do
+    subject { ImportService.new }
+
+    # Inline CSV (no trailing blank row) so the generic import_relationships!
+    # loop enqueues both targets; a trailing blank row trips its existing
+    # `return if key.blank?` guard, which is unrelated to this change.
+    let(:csv_text) { "Account address,Show boosts\nbob,true\neve@example.com,false" }
+    let(:import)   { Import.create(account: account, type: 'following', data: attachment_fixture('new-following-imports.txt')) }
+
+    # Capture every relationship-worker enqueue (both perform_async and the
+    # push_bulk block form) as plain args arrays.
+    def capture_enqueues!
+      captured = []
+      allow(Import::RelationshipWorker).to receive(:perform_async) { |*args| captured << args }
+      allow(Import::RelationshipWorker).to receive(:push_bulk) do |items, &block|
+        items.each { |item| captured << block.call(item) }
+      end
+      captured
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:import_data).and_return(csv_text)
+    end
+
+    it 'stamps the FollowImportBatch id onto every follow it enqueues' do
+      captured = capture_enqueues!
+
+      subject.call(import)
+
+      batch = FollowImportBatch.find_by(import_id: import.id)
+      expect(batch).to be_present
+
+      follow_args = captured.select { |args| args[2] == 'follow' }
+      # bob (local) and eve (remote) are both followed by this import.
+      expect(follow_args.size).to eq 2
+      expect(follow_args.map { |args| args[3]['import_batch_id'] }.uniq).to eq [batch.id]
+    end
+
+    it 'omits import_batch_id from the enqueued follows when batch recording failed, without raising' do
+      allow(Moderation::FollowImportRecorder).to receive(:record_batch).and_return(nil)
+      captured = capture_enqueues!
+
+      expect { subject.call(import) }.to_not raise_error
+
+      follow_args = captured.select { |args| args[2] == 'follow' }
+      expect(follow_args).to be_present
+      follow_args.each { |args| expect(args[3]).to_not have_key('import_batch_id') }
+    end
+  end
 end

--- a/spec/services/moderation/interaction_hooks_spec.rb
+++ b/spec/services/moderation/interaction_hooks_spec.rb
@@ -16,13 +16,22 @@ RSpec.describe 'Moderation interaction hooks', type: :service do
   end
 
   describe FollowService do
-    it 'records a follow interaction' do
+    it 'records a follow interaction with no import_batch_id for a normal follow' do
       expect { FollowService.new.call(alice, bob) }.to change(ModerationInteractionEvent, :count).by(1)
 
       event = last_interaction
       expect(event.event_type).to eq 'follow'
       expect(event.actor_subject.account_id).to eq alice.id
       expect(event.target_subject.account_id).to eq bob.id
+      expect(event.import_batch_id).to be_nil
+    end
+
+    it 'records the import_batch_id when a follow import passes one through' do
+      expect { FollowService.new.call(alice, bob, import_batch_id: 4242) }.to change(ModerationInteractionEvent, :count).by(1)
+
+      event = last_interaction
+      expect(event.event_type).to eq 'follow'
+      expect(event.import_batch_id).to eq 4242
     end
   end
 

--- a/spec/workers/import/relationship_worker_spec.rb
+++ b/spec/workers/import/relationship_worker_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Import::RelationshipWorker do
+  let(:account) { Fabricate(:account) }
+  let(:target)  { Fabricate(:account, username: 'import_target') }
+
+  before do
+    resolver = instance_double(ResolveAccountService, call: target)
+    allow(ResolveAccountService).to receive(:new).and_return(resolver)
+  end
+
+  describe 'follow imports carrying an import_batch_id' do
+    it 'passes the import_batch_id through to FollowService' do
+      follow_service = instance_double(FollowService, call: nil)
+      allow(FollowService).to receive(:new).and_return(follow_service)
+
+      described_class.new.perform(account.id, 'import_target', 'follow', { 'import_batch_id' => 99, 'reblogs' => true })
+
+      expect(follow_service).to have_received(:call)
+        .with(account, target, hash_including(import_batch_id: 99))
+    end
+  end
+
+  describe 'ordinary follows (no import context)' do
+    it 'does not pass an import_batch_id to FollowService' do
+      follow_service = instance_double(FollowService, call: nil)
+      allow(FollowService).to receive(:new).and_return(follow_service)
+
+      described_class.new.perform(account.id, 'import_target', 'follow', { 'reblogs' => true })
+
+      expect(follow_service).to have_received(:call)
+        .with(account, target, hash_excluding(:import_batch_id))
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes an observation-data-quality gap: follow interaction events executed by a **Follow Import** were recorded with `import_batch_id = NULL`, so the ledger had `batch -> target` (from `follow_import_targets`) and `actor -> target follow` (from `moderation_interaction_events`) but no direct `batch -> actually-executed follow` link. This PR propagates the `FollowImportBatch` id all the way to each executed follow.

Scope is strictly this data-quality fix — no scoring, risk, or Adaptive Follow Gate.

## Cause

`ImportService#import_follows!` created the `FollowImportBatch` (via `Moderation::FollowImportRecorder.record_batch`) but **discarded the return value**. The batch id was therefore never carried into the follows the import enqueued.

## Where the batch context was lost

The follow-import execution path is:

`ImportService#import_follows!` → `record_follow_import_batch!` (creates the batch) → `import_relationships!('follow', …)` → enqueues `Import::RelationshipWorker` (async) → `FollowService#call` → `Moderation::EventRecorder.record_interaction`.

The batch existed only in `record_follow_import_batch!`; nothing passed its id into `import_relationships!`, so the enqueued `Import::RelationshipWorker` jobs (and thus `FollowService`) never saw it, and `record_interaction` fell back to `import_batch_id: nil`.

## Fixed data flow (explicit argument propagation — no thread-local / CurrentAttributes)

1. `import_follows!` keeps the batch: `batch = record_follow_import_batch!` and passes `import_batch_id: batch&.id` into `import_relationships!`.
2. `import_relationships!` gains an explicit `import_batch_id:` keyword (existing per-field options moved to `**extra_fields`, so all other callers are unchanged) and stamps `import_batch_id` into each enqueued relationship's worker options — so it survives the async `Import::RelationshipWorker` boundary as an explicit job argument.
3. `Import::RelationshipWorker` already forwards its `options` to `FollowService#call`; no signature change needed.
4. `FollowService#call` records `import_batch_id: @options[:import_batch_id]` on the follow interaction.

Because the id rides in the worker's JSON options (not implicit context), it cannot leak into other requests/jobs, and Sidekiq retries of a specific follow keep the same batch id.

## No impact on normal follows

`@options[:import_batch_id]` is only present for follow imports. UI, API (`api/v1/accounts#follow`), ActivityPub inbound follows, `RefollowWorker`, bootstrap, etc. all call `FollowService` without it, so `import_batch_id` stays `NULL` for them. No DB migration (the existing `moderation_interaction_events.import_batch_id` column is used). `source_event_key` / outbound-follow anchor behavior and idempotency/failure-tolerance are unchanged. If `record_batch` fails (returns nil), the import still runs and `import_batch_id` simply stays `NULL`.

## Testing

```
$ bundle exec rspec spec/workers/import/relationship_worker_spec.rb spec/services/moderation/interaction_hooks_spec.rb
19 examples, 0 failures

$ bundle exec rspec spec/services/import_service_spec.rb -e "follow-import moderation ledger linkage"
2 examples, 0 failures

$ bundle exec rspec spec/services/moderation spec/models/moderation \
    spec/lib/activitypub/activity/moderation_inbound_coverage_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_reject_coverage_spec.rb \
    spec/lib/activitypub/activity/moderation_inbound_create_coverage_spec.rb
95 examples, 0 failures
```

Coverage of the reviewer's expected cases:
- **Follow import → follow interaction has `import_batch_id == FollowImportBatch.id`**, and **multiple targets in one batch share it** — `import_service_spec` captures the enqueued follow args and asserts both carry the created batch's id; `interaction_hooks_spec` proves `FollowService` writes it to the event; `relationship_worker_spec` proves the worker forwards it. (These are split because this env's inline-execution import path renders a notification mailer that needs a webpack manifest not built in test — pre-existing; `import_service_spec` already fails 12/13 on the base for that reason. The split covers each hop deterministically without that flakiness.)
- **Normal `FollowService` / API follow → `import_batch_id == nil`** — `interaction_hooks_spec` (all UI/API/AP paths call `FollowService` without the option) and `relationship_worker_spec` (`hash_excluding(:import_batch_id)`).
- **Recording failure doesn't fail the import** — `import_service_spec` stubs `record_batch` to nil and asserts the import proceeds without raising and enqueues follows without `import_batch_id`.
- **Regression** — moderation ledger + inbound coverage specs unchanged (95 examples). `follow_service_spec` keeps its 2 pre-existing webpack-manifest failures (unchanged by this PR).

## Note on the current flow (per your "if the flow conflicts" ask)

`FollowImportBatch` is already created up front (before follows execute), so no ordering conflict — the only change needed was to stop discarding it and thread its id through. I did not switch to a 5th positional worker arg (kept it inside the existing JSON `options` hash) to avoid changing the job signature for in-flight jobs during rolling deploys.

Head: `14fffa574b85bfe82e695404bb8f314caa39c620`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

