### PR TITLE
Moderation ledger: analysis-only behavioral metrics service (PR 9)

### DIFF
--- a/app/services/moderation/behavioral_metrics_service.rb
+++ b/app/services/moderation/behavioral_metrics_service.rb
@@ -81,12 +81,17 @@ module Moderation
       unique_responders  = distinct_ids(rejections, :rejector_subject_id).size
       mutes_received     = rejections_by_type['mute'] + rejections_by_type['mute_notifications']
 
-      # Cohort-aligned: rejectors that were also contacted in this window.
+      # Raw analysis counts: rejectors that were also contacted in this window
+      # (any order). Kept as-is for analysis; NOT used for the rates below.
       linked_set, correlated_set = classify_negative_responders(rejections, contacted_ids)
-      responder_cohort           = linked_set | correlated_set
 
-      # Cohort-aligned: follow-rejects only from targets this window actually followed.
-      follow_reject_cohort = distinct_ids(rejections.where(event_type: :follow_reject), :rejector_subject_id) & followed_ids
+      # Rate cohorts add a temporal requirement: an in-window contact strictly at
+      # or before an in-window rejection from the same responder. This makes a
+      # rate mean "response to a preceding in-window contact", so an out-of-window
+      # contact or a rejection that predates the in-window contact cannot count.
+      responded_rate_cohort = temporal_response_cohort(interactions, rejections)
+      linked_rate_cohort    = temporal_linked_cohort(rejections, window_start, window_end)
+      follow_reject_cohort  = temporal_follow_reject_cohort(interactions, rejections)
 
       first_negative_at = rejections.minimum(:occurred_at)
       continuation      = continuation_after(subject, interactions, first_negative_at)
@@ -106,9 +111,10 @@ module Moderation
         'unique_negative_responders'              => unique_responders,
         'linked_negative_responders'              => linked_set.size,
         'correlated_negative_responders'          => correlated_set.size,
-        # Rates: numerator and denominator share the in-window contact cohort.
-        'negative_response_rate'                  => ratio(responder_cohort.size, unique_targets),
-        'linked_negative_rate'                    => ratio(linked_set.size, unique_targets),
+        # Rates: numerator and denominator share the in-window contact cohort, and
+        # the numerator requires an in-window contact at/before an in-window rejection.
+        'negative_response_rate'                  => ratio(responded_rate_cohort.size, unique_targets),
+        'linked_negative_rate'                    => ratio(linked_rate_cohort.size, unique_targets),
         'follow_reject_rate'                      => ratio(follow_reject_cohort.size, followed_ids.size),
         'first_negative_signal_at'                => first_negative_at&.iso8601,
         'new_targets_after_first_negative_signal' => continuation[:new_targets],
@@ -184,6 +190,51 @@ module Moderation
 
       correlated.subtract(linked)
       [linked, correlated]
+    end
+
+    # Responders with an in-window contact (any type) at or before an in-window
+    # rejection: earliest in-window contact time <= latest in-window rejection
+    # time proves such an ordered pair exists (both restricted to the window).
+    def temporal_response_cohort(interactions, rejections)
+      earliest_contact  = interactions.where.not(target_subject_id: nil).group(:target_subject_id).minimum(:occurred_at)
+      latest_rejection  = rejections.where.not(rejector_subject_id: nil).group(:rejector_subject_id).maximum(:occurred_at)
+      ordered_pair_cohort(earliest_contact, latest_rejection)
+    end
+
+    # Same, restricted to in-window follows -> in-window follow_rejects.
+    def temporal_follow_reject_cohort(interactions, rejections)
+      earliest_follow        = interactions.where(event_type: :follow).where.not(target_subject_id: nil).group(:target_subject_id).minimum(:occurred_at)
+      latest_follow_reject   = rejections.where(event_type: :follow_reject).where.not(rejector_subject_id: nil).group(:rejector_subject_id).maximum(:occurred_at)
+      ordered_pair_cohort(earliest_follow, latest_follow_reject)
+    end
+
+    def ordered_pair_cohort(earliest_contact_by_id, latest_rejection_by_id)
+      cohort = Set.new
+      latest_rejection_by_id.each do |id, rejected_at|
+        contacted_at = earliest_contact_by_id[id]
+        cohort << id if contacted_at && rejected_at && contacted_at <= rejected_at
+      end
+      cohort
+    end
+
+    # Linked rate cohort: the rejection's preceding_interaction_event is itself
+    # in-window, at/before the rejection, and a strong association. (The raw
+    # linked count above may link to a preceding contact from outside the window;
+    # the rate must not.)
+    def temporal_linked_cohort(rejections, window_start, window_end)
+      cohort = Set.new
+
+      rejections.includes(:preceding_interaction_event).find_each do |rejection|
+        interaction = rejection.preceding_interaction_event
+        next if interaction.nil? || interaction.occurred_at.nil? || rejection.rejector_subject_id.nil?
+        next if window_start && interaction.occurred_at < window_start
+        next if window_end && interaction.occurred_at > window_end
+        next unless Moderation::PrecedingContactLink.strong_association?(interaction, rejection)
+
+        cohort << rejection.rejector_subject_id
+      end
+
+      cohort
     end
 
     # Genuinely new targets contacted after the first negative signal in scope: a

--- a/app/services/moderation/behavioral_metrics_service.rb
+++ b/app/services/moderation/behavioral_metrics_service.rb
@@ -13,6 +13,14 @@
 #     subject contacted others and how many independent recipients returned an
 #     explicit negative signal — never the meaning of any content.
 #
+# Rates return raw floats (no rounding); presentation layers round for display.
+#
+# Cohort discipline for anything named a *rate*: numerator and denominator are
+# drawn from the SAME in-window contact cohort, so a rate can never exceed 1 and
+# an out-of-window contact paired with an in-window rejection cannot inflate it.
+# Raw event-window counts (contacts, follows, rejections, unique responders) are
+# kept separately and are unaffected.
+#
 # A "linked" negative responder is a strong temporal association (a preceding
 # contact within the association window), NOT proof the contact caused the
 # rejection — matching Moderation::PrecedingContactLink and the evidence snapshot.
@@ -63,17 +71,25 @@ module Moderation
 
       interactions_by_type = INTERACTION_TYPES.index_with { |type| interactions.where(event_type: type).count }
       contacts_total       = interactions.count
-      unique_targets       = interactions.distinct.count(:target_subject_id)
+      contacted_ids        = distinct_ids(interactions, :target_subject_id)
+      unique_targets       = contacted_ids.size
+      followed_ids         = distinct_ids(interactions.where(event_type: :follow), :target_subject_id)
       follows              = interactions_by_type['follow']
 
-      rejections_by_type    = REJECTION_TYPES.index_with { |type| rejections.where(event_type: type).count }
-      rejections_total      = rejections.count
-      unique_responders     = rejections.distinct.count(:rejector_subject_id)
-      linked, correlated    = classify_negative_responders(rejections, interactions_actor_target_ids(interactions))
-      mutes_received        = rejections_by_type['mute'] + rejections_by_type['mute_notifications']
+      rejections_by_type = REJECTION_TYPES.index_with { |type| rejections.where(event_type: type).count }
+      rejections_total   = rejections.count
+      unique_responders  = distinct_ids(rejections, :rejector_subject_id).size
+      mutes_received     = rejections_by_type['mute'] + rejections_by_type['mute_notifications']
 
-      first_negative_at     = rejections.minimum(:occurred_at)
-      continuation          = continuation_after(interactions, first_negative_at)
+      # Cohort-aligned: rejectors that were also contacted in this window.
+      linked_set, correlated_set = classify_negative_responders(rejections, contacted_ids)
+      responder_cohort           = linked_set | correlated_set
+
+      # Cohort-aligned: follow-rejects only from targets this window actually followed.
+      follow_reject_cohort = distinct_ids(rejections.where(event_type: :follow_reject), :rejector_subject_id) & followed_ids
+
+      first_negative_at = rejections.minimum(:occurred_at)
+      continuation      = continuation_after(subject, interactions, first_negative_at)
 
       base.merge(
         'contacts_total'                          => contacts_total,
@@ -88,11 +104,12 @@ module Moderation
         'reports_received'                        => rejections_by_type['report'],
         'mutes_received'                          => mutes_received,
         'unique_negative_responders'              => unique_responders,
-        'linked_negative_responders'              => linked,
-        'correlated_negative_responders'          => correlated,
-        'negative_response_rate'                  => ratio(unique_responders, unique_targets),
-        'linked_negative_rate'                    => ratio(linked, unique_targets),
-        'follow_reject_rate'                      => ratio(rejections_by_type['follow_reject'], follows),
+        'linked_negative_responders'              => linked_set.size,
+        'correlated_negative_responders'          => correlated_set.size,
+        # Rates: numerator and denominator share the in-window contact cohort.
+        'negative_response_rate'                  => ratio(responder_cohort.size, unique_targets),
+        'linked_negative_rate'                    => ratio(linked_set.size, unique_targets),
+        'follow_reject_rate'                      => ratio(follow_reject_cohort.size, followed_ids.size),
         'first_negative_signal_at'                => first_negative_at&.iso8601,
         'new_targets_after_first_negative_signal' => continuation[:new_targets],
         'follows_after_first_negative_signal'     => continuation[:follows]
@@ -140,13 +157,15 @@ module Moderation
       scope
     end
 
-    def interactions_actor_target_ids(interactions)
-      interactions.distinct.pluck(:target_subject_id).compact.to_set
+    def distinct_ids(scope, column)
+      scope.where.not(column => nil).distinct.pluck(column).to_set
     end
 
     # Linked: rejector was contacted first with a preceding-contact link (strong
-    # temporal association). Correlated: rejector was contacted in scope but
-    # without that link. A rejector counted as linked is never also correlated.
+    # temporal association). Correlated: rejector was contacted in this window
+    # but without that link. A rejector counted as linked is never also correlated.
+    # Both sets are restricted to rejectors that were contacted in-window, so the
+    # cohort-aligned rates built from them cannot exceed 1.
     def classify_negative_responders(rejections, contacted_ids)
       linked = Set.new
       correlated = Set.new
@@ -164,33 +183,50 @@ module Moderation
       end
 
       correlated.subtract(linked)
-      [linked.size, correlated.size]
+      [linked, correlated]
     end
 
-    # Contacts that continued after the first negative signal in scope: targets
-    # whose first in-scope contact happened after the signal, and follows sent
-    # after it. Zero when no negative signal was observed in scope.
-    def continuation_after(interactions, first_negative_at)
+    # Genuinely new targets contacted after the first negative signal in scope: a
+    # target contacted after the signal AND with no actor->target contact at or
+    # before that signal in the subject's whole history (re-contacting a target
+    # already contacted before the signal does not count). Plus follows sent
+    # after the signal. Zero when no negative signal was observed in scope.
+    def continuation_after(subject, interactions, first_negative_at)
       return { new_targets: 0, follows: 0 } if first_negative_at.nil?
 
-      first_contact_per_target = interactions.where.not(target_subject_id: nil).group(:target_subject_id).minimum(:occurred_at)
-      new_targets = first_contact_per_target.count { |_id, at| at && at > first_negative_at }
-      follows = interactions.where(event_type: :follow).where('occurred_at > ?', first_negative_at).count
+      after         = interactions.where('occurred_at > ?', first_negative_at)
+      candidate_ids = distinct_ids(after, :target_subject_id)
 
-      { new_targets: new_targets, follows: follows }
+      new_targets =
+        if candidate_ids.empty?
+          0
+        else
+          previously_contacted = ModerationInteractionEvent
+                                  .where(actor_subject_id: subject.id, target_subject_id: candidate_ids.to_a)
+                                  .where('occurred_at <= ?', first_negative_at)
+                                  .distinct.pluck(:target_subject_id)
+                                  .to_set
+          (candidate_ids - previously_contacted).size
+        end
+
+      { new_targets: new_targets, follows: after.where(event_type: :follow).count }
     end
 
     def follow_import_context(subject)
       empty = {
-        'batch_count'                      => 0,
-        'target_total'                     => 0,
-        'resolved_target_total'            => 0,
-        'unresolved_target_total'          => 0,
-        'unknown_target_ratio'             => 0.0,
-        'prior_relationship_known_targets' => 0,
-        'latest_import_at'                 => nil,
+        'batch_count'                       => 0,
+        'target_total'                      => 0,
+        'resolved_target_total'             => 0,
+        'unresolved_target_total'           => 0,
+        # NOTE: unresolved == "did not resolve to a known Account at import time".
+        # This is NOT the design's "unknown target" (no confirmable prior
+        # relationship with the actor); that true unknown_target_ratio is
+        # deferred to the relationship-aware analysis phase.
+        'unresolved_target_ratio'           => 0.0,
+        'prior_relationship_known_targets'  => 0,
+        'latest_import_at'                  => nil,
         'min_account_age_seconds_at_import' => nil,
-        'migration_evidence'               => FollowImportBatch.migration_evidences.keys.index_with { 0 },
+        'migration_evidence'                => FollowImportBatch.migration_evidences.keys.index_with { 0 },
       }
       return empty if subject.nil?
 
@@ -205,7 +241,7 @@ module Moderation
         'target_total'                      => target_total,
         'resolved_target_total'             => batches.sum(:resolved_target_count),
         'unresolved_target_total'           => unresolved_total,
-        'unknown_target_ratio'              => ratio(unresolved_total, target_total),
+        'unresolved_target_ratio'           => ratio(unresolved_total, target_total),
         'prior_relationship_known_targets'  => prior_relationship_known_targets(batches),
         'latest_import_at'                  => batches.maximum(:imported_at)&.iso8601,
         'min_account_age_seconds_at_import' => batches.where.not(account_age_seconds: nil).minimum(:account_age_seconds),
@@ -222,10 +258,11 @@ module Moderation
         .count
     end
 
+    # Raw float (no rounding) — presentation layers round for display.
     def ratio(numerator, denominator)
       return 0.0 if denominator.nil? || denominator.zero?
 
-      (numerator.to_f / denominator).round(4)
+      numerator.to_f / denominator
     end
   end
 end

--- a/app/services/moderation/behavioral_metrics_service.rb
+++ b/app/services/moderation/behavioral_metrics_service.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+# Computes analysis-only behavioural metrics for a moderation subject from the
+# recorded ledger (interaction + rejection events, follow-import batches).
+#
+# This is the Analysis phase's read layer. It is strictly observational:
+#
+#   * READ-ONLY — it never writes to the database (it does not create or update
+#     ModerationSubject rows), so it is safe to call from dashboards/queries.
+#   * No scoring, thresholds, risk labels, recommendations, or enforcement. It
+#     returns plain counts/rates only; interpretation belongs to later phases.
+#   * Metrics are mechanism-independent: they describe how widely / how fast a
+#     subject contacted others and how many independent recipients returned an
+#     explicit negative signal — never the meaning of any content.
+#
+# A "linked" negative responder is a strong temporal association (a preceding
+# contact within the association window), NOT proof the contact caused the
+# rejection — matching Moderation::PrecedingContactLink and the evidence snapshot.
+module Moderation
+  class BehavioralMetricsService
+    # Ordered so the output reads shortest-to-longest.
+    DEFAULT_WINDOWS = {
+      '1h'  => 1.hour,
+      '6h'  => 6.hours,
+      '24h' => 24.hours,
+      '7d'  => 7.days,
+      '30d' => 30.days,
+    }.freeze
+
+    REJECTION_TYPES = %w(block follow_reject remove_follower report mute mute_notifications).freeze
+    INTERACTION_TYPES = %w(follow mention reply quote reference reaction favourite follow_import).freeze
+
+    def call(subject_or_account, now: Time.now.utc, windows: DEFAULT_WINDOWS)
+      subject = resolve_subject(subject_or_account)
+
+      {
+        'subject_id'            => subject&.id,
+        'account_id'            => subject&.account_id,
+        'generated_at'          => now.iso8601,
+        'windows'               => windows.transform_values { |duration| window_metrics(subject, now - duration, now) },
+        'lifetime'              => window_metrics(subject, nil, now),
+        'follow_import_context' => follow_import_context(subject),
+      }
+    end
+
+    private
+
+    # Read-only resolution: accept a ModerationSubject, or find the one bound to
+    # an Account. Never create or touch a row (unlike ModerationSubject.for_account!).
+    def resolve_subject(subject_or_account)
+      return subject_or_account if subject_or_account.is_a?(ModerationSubject)
+      return if subject_or_account.nil?
+
+      ModerationSubject.find_by(account_id: subject_or_account.id)
+    end
+
+    def window_metrics(subject, window_start, window_end)
+      base = empty_window(window_start, window_end)
+      return base if subject.nil?
+
+      interactions = interactions_scope(subject, window_start, window_end)
+      rejections   = rejections_scope(subject, window_start, window_end)
+
+      interactions_by_type = INTERACTION_TYPES.index_with { |type| interactions.where(event_type: type).count }
+      contacts_total       = interactions.count
+      unique_targets       = interactions.distinct.count(:target_subject_id)
+      follows              = interactions_by_type['follow']
+
+      rejections_by_type    = REJECTION_TYPES.index_with { |type| rejections.where(event_type: type).count }
+      rejections_total      = rejections.count
+      unique_responders     = rejections.distinct.count(:rejector_subject_id)
+      linked, correlated    = classify_negative_responders(rejections, interactions_actor_target_ids(interactions))
+      mutes_received        = rejections_by_type['mute'] + rejections_by_type['mute_notifications']
+
+      first_negative_at     = rejections.minimum(:occurred_at)
+      continuation          = continuation_after(interactions, first_negative_at)
+
+      base.merge(
+        'contacts_total'                          => contacts_total,
+        'unique_targets'                          => unique_targets,
+        'follows'                                 => follows,
+        'interactions_by_type'                    => interactions_by_type,
+        'rejections_received_total'               => rejections_total,
+        'rejections_by_type'                      => rejections_by_type,
+        'blocks_received'                         => rejections_by_type['block'],
+        'follow_rejects_received'                 => rejections_by_type['follow_reject'],
+        'remove_follower_received'                => rejections_by_type['remove_follower'],
+        'reports_received'                        => rejections_by_type['report'],
+        'mutes_received'                          => mutes_received,
+        'unique_negative_responders'              => unique_responders,
+        'linked_negative_responders'              => linked,
+        'correlated_negative_responders'          => correlated,
+        'negative_response_rate'                  => ratio(unique_responders, unique_targets),
+        'linked_negative_rate'                    => ratio(linked, unique_targets),
+        'follow_reject_rate'                      => ratio(rejections_by_type['follow_reject'], follows),
+        'first_negative_signal_at'                => first_negative_at&.iso8601,
+        'new_targets_after_first_negative_signal' => continuation[:new_targets],
+        'follows_after_first_negative_signal'     => continuation[:follows]
+      )
+    end
+
+    def empty_window(window_start, window_end)
+      {
+        'window_start'                            => window_start&.iso8601,
+        'window_end'                              => window_end&.iso8601,
+        'contacts_total'                          => 0,
+        'unique_targets'                          => 0,
+        'follows'                                 => 0,
+        'interactions_by_type'                    => INTERACTION_TYPES.index_with { 0 },
+        'rejections_received_total'               => 0,
+        'rejections_by_type'                      => REJECTION_TYPES.index_with { 0 },
+        'blocks_received'                         => 0,
+        'follow_rejects_received'                 => 0,
+        'remove_follower_received'                => 0,
+        'reports_received'                        => 0,
+        'mutes_received'                          => 0,
+        'unique_negative_responders'              => 0,
+        'linked_negative_responders'              => 0,
+        'correlated_negative_responders'          => 0,
+        'negative_response_rate'                  => 0.0,
+        'linked_negative_rate'                    => 0.0,
+        'follow_reject_rate'                      => 0.0,
+        'first_negative_signal_at'                => nil,
+        'new_targets_after_first_negative_signal' => 0,
+        'follows_after_first_negative_signal'     => 0,
+      }
+    end
+
+    def interactions_scope(subject, window_start, window_end)
+      scope = ModerationInteractionEvent.where(actor_subject_id: subject.id)
+      scope = scope.where(occurred_at: window_start..window_end) if window_start
+      scope = scope.where('occurred_at <= ?', window_end) if window_start.nil? && window_end
+      scope
+    end
+
+    def rejections_scope(subject, window_start, window_end)
+      scope = ModerationRejectionEvent.where(rejected_subject_id: subject.id)
+      scope = scope.where(occurred_at: window_start..window_end) if window_start
+      scope = scope.where('occurred_at <= ?', window_end) if window_start.nil? && window_end
+      scope
+    end
+
+    def interactions_actor_target_ids(interactions)
+      interactions.distinct.pluck(:target_subject_id).compact.to_set
+    end
+
+    # Linked: rejector was contacted first with a preceding-contact link (strong
+    # temporal association). Correlated: rejector was contacted in scope but
+    # without that link. A rejector counted as linked is never also correlated.
+    def classify_negative_responders(rejections, contacted_ids)
+      linked = Set.new
+      correlated = Set.new
+
+      rejections.includes(:preceding_interaction_event).find_each do |rejection|
+        rejector_id = rejection.rejector_subject_id
+        next if rejector_id.nil?
+        next unless contacted_ids.include?(rejector_id)
+
+        if Moderation::PrecedingContactLink.strong_association?(rejection.preceding_interaction_event, rejection)
+          linked << rejector_id
+        else
+          correlated << rejector_id
+        end
+      end
+
+      correlated.subtract(linked)
+      [linked.size, correlated.size]
+    end
+
+    # Contacts that continued after the first negative signal in scope: targets
+    # whose first in-scope contact happened after the signal, and follows sent
+    # after it. Zero when no negative signal was observed in scope.
+    def continuation_after(interactions, first_negative_at)
+      return { new_targets: 0, follows: 0 } if first_negative_at.nil?
+
+      first_contact_per_target = interactions.where.not(target_subject_id: nil).group(:target_subject_id).minimum(:occurred_at)
+      new_targets = first_contact_per_target.count { |_id, at| at && at > first_negative_at }
+      follows = interactions.where(event_type: :follow).where('occurred_at > ?', first_negative_at).count
+
+      { new_targets: new_targets, follows: follows }
+    end
+
+    def follow_import_context(subject)
+      empty = {
+        'batch_count'                      => 0,
+        'target_total'                     => 0,
+        'resolved_target_total'            => 0,
+        'unresolved_target_total'          => 0,
+        'unknown_target_ratio'             => 0.0,
+        'prior_relationship_known_targets' => 0,
+        'latest_import_at'                 => nil,
+        'min_account_age_seconds_at_import' => nil,
+        'migration_evidence'               => FollowImportBatch.migration_evidences.keys.index_with { 0 },
+      }
+      return empty if subject.nil?
+
+      batches = FollowImportBatch.where(subject_id: subject.id)
+      return empty if batches.none?
+
+      target_total     = batches.sum(:target_count)
+      unresolved_total = batches.sum(:unresolved_target_count)
+
+      {
+        'batch_count'                       => batches.count,
+        'target_total'                      => target_total,
+        'resolved_target_total'             => batches.sum(:resolved_target_count),
+        'unresolved_target_total'           => unresolved_total,
+        'unknown_target_ratio'              => ratio(unresolved_total, target_total),
+        'prior_relationship_known_targets'  => prior_relationship_known_targets(batches),
+        'latest_import_at'                  => batches.maximum(:imported_at)&.iso8601,
+        'min_account_age_seconds_at_import' => batches.where.not(account_age_seconds: nil).minimum(:account_age_seconds),
+        'migration_evidence'                => FollowImportBatch.migration_evidences.keys.index_with { |k| batches.where(migration_evidence: k).count },
+      }
+    end
+
+    # Targets the actor already followed at import time — a known relationship,
+    # so far less likely to be an external-list scrape.
+    def prior_relationship_known_targets(batches)
+      FollowImportTarget
+        .where(batch_id: batches.select(:id))
+        .where("prior_relationship_state ->> 'following' = 'true'")
+        .count
+    end
+
+    def ratio(numerator, denominator)
+      return 0.0 if denominator.nil? || denominator.zero?
+
+      (numerator.to_f / denominator).round(4)
+    end
+  end
+end

--- a/spec/services/moderation/behavioral_metrics_service_spec.rb
+++ b/spec/services/moderation/behavioral_metrics_service_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::BehavioralMetricsService do
+  subject(:service) { described_class.new }
+
+  let(:now)   { Time.now.utc }
+  let(:actor) { Fabricate(:account, username: 'actor') }
+  let(:b)     { Fabricate(:account, username: 'target_b') }
+  let(:c)     { Fabricate(:account, username: 'target_c') }
+  let(:d)     { Fabricate(:account, username: 'target_d') }
+  let(:g)     { Fabricate(:account, username: 'responder_g') }
+
+  def record_interaction(target, type, at, key)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: type, occurred_at: at, source_event_key: key)
+  end
+
+  def record_rejection(rejector, type, at, key)
+    Moderation::EventRecorder.record_rejection(rejector: rejector, rejected: actor, event_type: type, occurred_at: at, source_event_key: key)
+  end
+
+  # Interactions (actor -> target):
+  #   b follow  @ -120m,  c mention @ -50m,  d follow @ -30m,  g follow @ -20m
+  # Rejections (responder -> actor):
+  #   b block   @ -118m (after the follow  -> linked)
+  #   c reject  @ -48m  (after the mention -> linked)
+  #   g block   @ -25m  (BEFORE actor's -20m follow -> contacted but not linked = correlated)
+  before do
+    record_interaction(b, :follow, now - 120.minutes, 'i-b')
+    record_interaction(c, :mention, now - 50.minutes, 'i-c')
+    record_interaction(d, :follow, now - 30.minutes, 'i-d')
+    record_interaction(g, :follow, now - 20.minutes, 'i-g')
+
+    record_rejection(b, :block, now - 118.minutes, 'r-b')
+    record_rejection(c, :follow_reject, now - 48.minutes, 'r-c')
+    record_rejection(g, :block, now - 25.minutes, 'r-g')
+  end
+
+  describe 'the 24h window' do
+    let(:metrics) { service.call(actor, now: now).dig('windows', '24h') }
+
+    it 'counts contacts, unique targets and follows' do
+      expect(metrics['contacts_total']).to eq 4
+      expect(metrics['unique_targets']).to eq 4
+      expect(metrics['follows']).to eq 3
+      expect(metrics['interactions_by_type']).to include('follow' => 3, 'mention' => 1)
+    end
+
+    it 'counts rejections received and classifies responders' do
+      expect(metrics['rejections_received_total']).to eq 3
+      expect(metrics['blocks_received']).to eq 2
+      expect(metrics['follow_rejects_received']).to eq 1
+      expect(metrics['unique_negative_responders']).to eq 3
+      expect(metrics['linked_negative_responders']).to eq 2
+      expect(metrics['correlated_negative_responders']).to eq 1
+    end
+
+    it 'computes rates guarded against zero denominators' do
+      expect(metrics['negative_response_rate']).to eq 0.75
+      expect(metrics['linked_negative_rate']).to eq 0.5
+      expect(metrics['follow_reject_rate']).to eq 0.3333
+    end
+
+    it 'measures contact continuation after the first negative signal' do
+      expect(metrics['first_negative_signal_at']).to eq((now - 118.minutes).iso8601)
+      expect(metrics['new_targets_after_first_negative_signal']).to eq 3
+      expect(metrics['follows_after_first_negative_signal']).to eq 2
+    end
+  end
+
+  describe 'the 1h window' do
+    let(:metrics) { service.call(actor, now: now).dig('windows', '1h') }
+
+    it 'excludes events older than the window' do
+      expect(metrics['contacts_total']).to eq 3
+      expect(metrics['unique_targets']).to eq 3
+      expect(metrics['follows']).to eq 2
+      expect(metrics['rejections_received_total']).to eq 2
+      expect(metrics['linked_negative_responders']).to eq 1
+      expect(metrics['correlated_negative_responders']).to eq 1
+    end
+
+    it 'measures continuation relative to the first in-window negative signal' do
+      expect(metrics['first_negative_signal_at']).to eq((now - 48.minutes).iso8601)
+      expect(metrics['new_targets_after_first_negative_signal']).to eq 2
+      expect(metrics['follows_after_first_negative_signal']).to eq 2
+    end
+  end
+
+  describe 'lifetime metrics' do
+    it 'has no lower time bound' do
+      lifetime = service.call(actor, now: now)['lifetime']
+      expect(lifetime['window_start']).to be_nil
+      expect(lifetime['contacts_total']).to eq 4
+      expect(lifetime['unique_negative_responders']).to eq 3
+    end
+  end
+
+  describe 'follow-import context' do
+    let!(:batch) do
+      FollowImportBatch.create!(
+        subject: ModerationSubject.for_account!(actor),
+        imported_at: now - 10.minutes,
+        mode: :merge,
+        target_count: 10,
+        resolved_target_count: 7,
+        unresolved_target_count: 3,
+        account_age_seconds: 131,
+        migration_evidence: :weak
+      )
+    end
+
+    before do
+      batch.targets.create!(target_subject: ModerationSubject.for_account!(b), position: 0, prior_relationship_state: { 'following' => true })
+      batch.targets.create!(target_subject: ModerationSubject.for_account!(c), position: 1, prior_relationship_state: { 'following' => false })
+      batch.targets.create!(target_key_hash: 'deadbeef', position: 2)
+    end
+
+    it 'summarizes batches and the unknown-target ratio' do
+      context = service.call(actor, now: now)['follow_import_context']
+
+      expect(context['batch_count']).to eq 1
+      expect(context['target_total']).to eq 10
+      expect(context['unresolved_target_total']).to eq 3
+      expect(context['unknown_target_ratio']).to eq 0.3
+      expect(context['prior_relationship_known_targets']).to eq 1
+      expect(context['min_account_age_seconds_at_import']).to eq 131
+      expect(context['migration_evidence']).to include('weak' => 1, 'none' => 0)
+    end
+  end
+
+  describe 'read-only guarantees' do
+    it 'resolves the subject from an account without writing' do
+      metrics = service.call(actor, now: now)
+      expect(metrics['subject_id']).to eq ModerationSubject.find_by(account_id: actor.id).id
+      expect(metrics['account_id']).to eq actor.id
+    end
+
+    it 'never creates a ModerationSubject for an account with no ledger history' do
+      fresh = Fabricate(:account, username: 'never_seen')
+
+      result = nil
+      expect { result = service.call(fresh, now: now) }.to_not change(ModerationSubject, :count)
+
+      expect(result['subject_id']).to be_nil
+      expect(result.dig('windows', '24h', 'contacts_total')).to eq 0
+      expect(result['follow_import_context']['batch_count']).to eq 0
+    end
+  end
+end

--- a/spec/services/moderation/behavioral_metrics_service_spec.rb
+++ b/spec/services/moderation/behavioral_metrics_service_spec.rb
@@ -20,80 +20,147 @@ RSpec.describe Moderation::BehavioralMetricsService do
     Moderation::EventRecorder.record_rejection(rejector: rejector, rejected: actor, event_type: type, occurred_at: at, source_event_key: key)
   end
 
-  # Interactions (actor -> target):
-  #   b follow  @ -120m,  c mention @ -50m,  d follow @ -30m,  g follow @ -20m
-  # Rejections (responder -> actor):
-  #   b block   @ -118m (after the follow  -> linked)
-  #   c reject  @ -48m  (after the mention -> linked)
-  #   g block   @ -25m  (BEFORE actor's -20m follow -> contacted but not linked = correlated)
-  before do
-    record_interaction(b, :follow, now - 120.minutes, 'i-b')
-    record_interaction(c, :mention, now - 50.minutes, 'i-c')
-    record_interaction(d, :follow, now - 30.minutes, 'i-d')
-    record_interaction(g, :follow, now - 20.minutes, 'i-g')
+  context 'with a primary contact/rejection scenario' do
+    # Interactions (actor -> target):
+    #   b follow  @ -120m,  c follow @ -50m,  d mention @ -30m,  g follow @ -20m
+    # Rejections (responder -> actor):
+    #   b block         @ -118m (after the follow  -> linked)
+    #   c follow_reject @ -48m  (after the follow  -> linked; c is in the follow cohort)
+    #   g block         @ -25m  (BEFORE actor's -20m follow -> contacted but not linked = correlated)
+    before do
+      record_interaction(b, :follow, now - 120.minutes, 'i-b')
+      record_interaction(c, :follow, now - 50.minutes, 'i-c')
+      record_interaction(d, :mention, now - 30.minutes, 'i-d')
+      record_interaction(g, :follow, now - 20.minutes, 'i-g')
 
-    record_rejection(b, :block, now - 118.minutes, 'r-b')
-    record_rejection(c, :follow_reject, now - 48.minutes, 'r-c')
-    record_rejection(g, :block, now - 25.minutes, 'r-g')
+      record_rejection(b, :block, now - 118.minutes, 'r-b')
+      record_rejection(c, :follow_reject, now - 48.minutes, 'r-c')
+      record_rejection(g, :block, now - 25.minutes, 'r-g')
+    end
+
+    describe 'the 24h window' do
+      let(:metrics) { service.call(actor, now: now).dig('windows', '24h') }
+
+      it 'counts contacts, unique targets and follows' do
+        expect(metrics['contacts_total']).to eq 4
+        expect(metrics['unique_targets']).to eq 4
+        expect(metrics['follows']).to eq 3
+        expect(metrics['interactions_by_type']).to include('follow' => 3, 'mention' => 1)
+      end
+
+      it 'counts rejections received (raw) and classifies the contacted cohort' do
+        expect(metrics['rejections_received_total']).to eq 3
+        expect(metrics['blocks_received']).to eq 2
+        expect(metrics['follow_rejects_received']).to eq 1
+        expect(metrics['unique_negative_responders']).to eq 3
+        expect(metrics['linked_negative_responders']).to eq 2
+        expect(metrics['correlated_negative_responders']).to eq 1
+      end
+
+      it 'computes cohort-aligned rates as raw floats' do
+        # (linked + correlated) / unique in-window targets = 3/4
+        expect(metrics['negative_response_rate']).to eq 0.75
+        expect(metrics['linked_negative_rate']).to eq 0.5
+        # follow_rejects from followed targets (c) / followed targets (b,c,g) = 1/3
+        expect(metrics['follow_reject_rate']).to be_within(1e-9).of(1.0 / 3)
+      end
+
+      it 'counts genuinely-new targets and follows after the first negative signal' do
+        expect(metrics['first_negative_signal_at']).to eq((now - 118.minutes).iso8601)
+        # first signal @ -118m; c(-50), d(-30), g(-20) contacted after with no prior; b(-120) is before
+        expect(metrics['new_targets_after_first_negative_signal']).to eq 3
+        # follows after -118m: c and g (d is a mention)
+        expect(metrics['follows_after_first_negative_signal']).to eq 2
+      end
+    end
+
+    describe 'the 1h window' do
+      let(:metrics) { service.call(actor, now: now).dig('windows', '1h') }
+
+      it 'excludes events older than the window' do
+        expect(metrics['contacts_total']).to eq 3
+        expect(metrics['unique_targets']).to eq 3
+        expect(metrics['follows']).to eq 2
+        expect(metrics['rejections_received_total']).to eq 2
+        expect(metrics['linked_negative_responders']).to eq 1
+        expect(metrics['correlated_negative_responders']).to eq 1
+      end
+
+      it 'keeps rates cohort-aligned within the window' do
+        # (c linked + g correlated) / {c,d,g} = 2/3
+        expect(metrics['negative_response_rate']).to be_within(1e-9).of(2.0 / 3)
+        expect(metrics['linked_negative_rate']).to be_within(1e-9).of(1.0 / 3)
+        # c follow_reject / followed {c,g} = 1/2
+        expect(metrics['follow_reject_rate']).to eq 0.5
+      end
+
+      it 'measures continuation relative to the first in-window negative signal' do
+        expect(metrics['first_negative_signal_at']).to eq((now - 48.minutes).iso8601)
+        # first in-window signal @ -48m; d(-30) and g(-20) contacted after, both new; c(-50) is before
+        expect(metrics['new_targets_after_first_negative_signal']).to eq 2
+        # follows after -48m within window: g only (d is a mention, c is before)
+        expect(metrics['follows_after_first_negative_signal']).to eq 1
+      end
+    end
+
+    describe 'lifetime metrics' do
+      it 'has no lower time bound' do
+        lifetime = service.call(actor, now: now)['lifetime']
+        expect(lifetime['window_start']).to be_nil
+        expect(lifetime['contacts_total']).to eq 4
+        expect(lifetime['unique_negative_responders']).to eq 3
+      end
+    end
   end
 
-  describe 'the 24h window' do
-    let(:metrics) { service.call(actor, now: now).dig('windows', '24h') }
+  describe 'genuinely-new-target semantics' do
+    # actor contacted x BEFORE the first negative signal and re-contacts it
+    # after; x must NOT be counted as a new target after the signal.
+    let(:x) { Fabricate(:account, username: 'recontacted_x') }
+    let(:y) { Fabricate(:account, username: 'fresh_y') }
 
-    it 'counts contacts, unique targets and follows' do
-      expect(metrics['contacts_total']).to eq 4
-      expect(metrics['unique_targets']).to eq 4
-      expect(metrics['follows']).to eq 3
-      expect(metrics['interactions_by_type']).to include('follow' => 3, 'mention' => 1)
+    before do
+      record_interaction(x, :follow, now - 40.minutes, 'nx-1')       # prior contact
+      record_rejection(b, :block, now - 30.minutes, 'nx-r')          # first negative signal
+      record_interaction(x, :mention, now - 20.minutes, 'nx-2')      # re-contact (not new)
+      record_interaction(y, :follow, now - 10.minutes, 'nx-3')       # genuinely new
     end
 
-    it 'counts rejections received and classifies responders' do
-      expect(metrics['rejections_received_total']).to eq 3
-      expect(metrics['blocks_received']).to eq 2
-      expect(metrics['follow_rejects_received']).to eq 1
-      expect(metrics['unique_negative_responders']).to eq 3
-      expect(metrics['linked_negative_responders']).to eq 2
-      expect(metrics['correlated_negative_responders']).to eq 1
-    end
+    it 'excludes re-contacted targets and counts only targets with no prior contact' do
+      metrics = service.call(actor, now: now).dig('windows', '1h')
 
-    it 'computes rates guarded against zero denominators' do
-      expect(metrics['negative_response_rate']).to eq 0.75
-      expect(metrics['linked_negative_rate']).to eq 0.5
-      expect(metrics['follow_reject_rate']).to eq 0.3333
-    end
-
-    it 'measures contact continuation after the first negative signal' do
-      expect(metrics['first_negative_signal_at']).to eq((now - 118.minutes).iso8601)
-      expect(metrics['new_targets_after_first_negative_signal']).to eq 3
-      expect(metrics['follows_after_first_negative_signal']).to eq 2
+      expect(metrics['first_negative_signal_at']).to eq((now - 30.minutes).iso8601)
+      # after the signal: x (re-contacted, prior at -40m) and y (new). Only y counts.
+      expect(metrics['new_targets_after_first_negative_signal']).to eq 1
     end
   end
 
-  describe 'the 1h window' do
-    let(:metrics) { service.call(actor, now: now).dig('windows', '1h') }
+  describe 'rate cohort boundaries' do
+    let(:h) { Fabricate(:account, username: 'boundary_h') }
+    let(:k) { Fabricate(:account, username: 'boundary_k') }
 
-    it 'excludes events older than the window' do
-      expect(metrics['contacts_total']).to eq 3
-      expect(metrics['unique_targets']).to eq 3
-      expect(metrics['follows']).to eq 2
-      expect(metrics['rejections_received_total']).to eq 2
+    # h is contacted just OUTSIDE the 1h window but rejects INSIDE it; k is
+    # contacted and rejects inside. A naive rate (raw responders / in-window
+    # targets) would be 2/1 = 2.0. The cohort-aligned rate must stay <= 1.
+    before do
+      record_interaction(h, :follow, now - 70.minutes, 'b-i-h')
+      record_interaction(k, :follow, now - 10.minutes, 'b-i-k')
+      record_rejection(h, :block, now - 30.minutes, 'b-r-h')
+      record_rejection(k, :block, now - 5.minutes, 'b-r-k')
+    end
+
+    it 'does not let an out-of-window contact inflate an in-window rate above 1' do
+      metrics = service.call(actor, now: now).dig('windows', '1h')
+
+      # Raw event-window counts are preserved: both h and k rejected in-window,
+      # but only k was contacted in-window.
+      expect(metrics['unique_negative_responders']).to eq 2
+      expect(metrics['unique_targets']).to eq 1
+
+      # Cohort-aligned rate counts only k (contacted in-window and linked): 1/1.
       expect(metrics['linked_negative_responders']).to eq 1
-      expect(metrics['correlated_negative_responders']).to eq 1
-    end
-
-    it 'measures continuation relative to the first in-window negative signal' do
-      expect(metrics['first_negative_signal_at']).to eq((now - 48.minutes).iso8601)
-      expect(metrics['new_targets_after_first_negative_signal']).to eq 2
-      expect(metrics['follows_after_first_negative_signal']).to eq 2
-    end
-  end
-
-  describe 'lifetime metrics' do
-    it 'has no lower time bound' do
-      lifetime = service.call(actor, now: now)['lifetime']
-      expect(lifetime['window_start']).to be_nil
-      expect(lifetime['contacts_total']).to eq 4
-      expect(lifetime['unique_negative_responders']).to eq 3
+      expect(metrics['negative_response_rate']).to eq 1.0
+      expect(metrics['negative_response_rate']).to be <= 1.0
     end
   end
 
@@ -117,13 +184,14 @@ RSpec.describe Moderation::BehavioralMetricsService do
       batch.targets.create!(target_key_hash: 'deadbeef', position: 2)
     end
 
-    it 'summarizes batches and the unknown-target ratio' do
+    it 'summarizes batches and the unresolved-target ratio (not the design unknown ratio)' do
       context = service.call(actor, now: now)['follow_import_context']
 
       expect(context['batch_count']).to eq 1
       expect(context['target_total']).to eq 10
       expect(context['unresolved_target_total']).to eq 3
-      expect(context['unknown_target_ratio']).to eq 0.3
+      expect(context['unresolved_target_ratio']).to eq 0.3
+      expect(context).to_not have_key('unknown_target_ratio')
       expect(context['prior_relationship_known_targets']).to eq 1
       expect(context['min_account_age_seconds_at_import']).to eq 131
       expect(context['migration_evidence']).to include('weak' => 1, 'none' => 0)
@@ -132,7 +200,10 @@ RSpec.describe Moderation::BehavioralMetricsService do
 
   describe 'read-only guarantees' do
     it 'resolves the subject from an account without writing' do
+      record_interaction(b, :follow, now - 5.minutes, 'ro-1')
+
       metrics = service.call(actor, now: now)
+
       expect(metrics['subject_id']).to eq ModerationSubject.find_by(account_id: actor.id).id
       expect(metrics['account_id']).to eq actor.id
     end

--- a/spec/services/moderation/behavioral_metrics_service_spec.rb
+++ b/spec/services/moderation/behavioral_metrics_service_spec.rb
@@ -57,9 +57,12 @@ RSpec.describe Moderation::BehavioralMetricsService do
         expect(metrics['correlated_negative_responders']).to eq 1
       end
 
-      it 'computes cohort-aligned rates as raw floats' do
-        # (linked + correlated) / unique in-window targets = 3/4
-        expect(metrics['negative_response_rate']).to eq 0.75
+      it 'computes cohort-aligned rates as raw floats, requiring contact-before-rejection' do
+        # Responders with an in-window contact at/before an in-window rejection:
+        # b (-120 follow <= -118 block) and c (-50 follow <= -48 reject). g is
+        # excluded: its -20m follow is AFTER its -25m block. So 2/4.
+        expect(metrics['negative_response_rate']).to eq 0.5
+        # linked rate cohort (b, c) / unique targets (4) = 2/4
         expect(metrics['linked_negative_rate']).to eq 0.5
         # follow_rejects from followed targets (c) / followed targets (b,c,g) = 1/3
         expect(metrics['follow_reject_rate']).to be_within(1e-9).of(1.0 / 3)
@@ -86,11 +89,12 @@ RSpec.describe Moderation::BehavioralMetricsService do
         expect(metrics['correlated_negative_responders']).to eq 1
       end
 
-      it 'keeps rates cohort-aligned within the window' do
-        # (c linked + g correlated) / {c,d,g} = 2/3
-        expect(metrics['negative_response_rate']).to be_within(1e-9).of(2.0 / 3)
+      it 'keeps rates cohort-aligned and contact-before-rejection within the window' do
+        # Only c has an in-window contact (-50 follow) at/before its in-window
+        # rejection (-48). g's -20 follow is after its -25 block, so excluded. 1/3.
+        expect(metrics['negative_response_rate']).to be_within(1e-9).of(1.0 / 3)
         expect(metrics['linked_negative_rate']).to be_within(1e-9).of(1.0 / 3)
-        # c follow_reject / followed {c,g} = 1/2
+        # c follow_reject (followed at -50, rejected at -48) / followed {c,g} = 1/2
         expect(metrics['follow_reject_rate']).to eq 0.5
       end
 
@@ -161,6 +165,55 @@ RSpec.describe Moderation::BehavioralMetricsService do
       expect(metrics['linked_negative_responders']).to eq 1
       expect(metrics['negative_response_rate']).to eq 1.0
       expect(metrics['negative_response_rate']).to be <= 1.0
+    end
+  end
+
+  describe 'rate temporal ordering' do
+    # A rate must count only a rejection that responds to a preceding in-window
+    # contact. An out-of-window contact, or an in-window contact that lands after
+    # the rejection, must not enter any *_rate numerator.
+    let(:p) { Fabricate(:account, username: 'ordering_p') }
+    let(:q) { Fabricate(:account, username: 'ordering_q') }
+    let(:r) { Fabricate(:account, username: 'ordering_r') }
+
+    it 'excludes a rejection whose only in-window contact comes after it (negative/linked rate)' do
+      # follow OUTSIDE window -> reject inside -> mention inside (after the reject)
+      record_interaction(p, :follow, now - 70.minutes, 'o1-i')
+      record_rejection(p, :follow_reject, now - 30.minutes, 'o1-r')
+      record_interaction(p, :mention, now - 20.minutes, 'o1-i2')
+
+      metrics = service.call(actor, now: now).dig('windows', '1h')
+
+      # p is contacted in-window (mention) and, for analysis, still links to the
+      # out-of-window follow — but neither rate counts it.
+      expect(metrics['unique_targets']).to eq 1
+      expect(metrics['linked_negative_responders']).to eq 1
+      expect(metrics['negative_response_rate']).to eq 0.0
+      expect(metrics['linked_negative_rate']).to eq 0.0
+    end
+
+    it 'excludes a follow_reject whose only in-window follow comes after it (follow_reject rate)' do
+      # follow OUTSIDE window -> follow_reject inside -> re-follow inside (after)
+      record_interaction(q, :follow, now - 70.minutes, 'o2-i')
+      record_rejection(q, :follow_reject, now - 30.minutes, 'o2-r')
+      record_interaction(q, :follow, now - 20.minutes, 'o2-i2')
+
+      metrics = service.call(actor, now: now).dig('windows', '1h')
+
+      expect(metrics['follow_rejects_received']).to eq 1
+      expect(metrics['follow_reject_rate']).to eq 0.0
+    end
+
+    it 'includes a rejection that responds to a preceding in-window contact' do
+      # follow inside -> follow_reject inside (after the follow)
+      record_interaction(r, :follow, now - 40.minutes, 'o3-i')
+      record_rejection(r, :follow_reject, now - 20.minutes, 'o3-r')
+
+      metrics = service.call(actor, now: now).dig('windows', '1h')
+
+      expect(metrics['negative_response_rate']).to eq 1.0
+      expect(metrics['linked_negative_rate']).to eq 1.0
+      expect(metrics['follow_reject_rate']).to eq 1.0
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Starts the Analysis phase from the design memo: a **read-only, analysis-only** service, `Moderation::BehavioralMetricsService`, that computes mechanism-independent behavioural metrics for a moderation subject from the existing ledger. It produces plain counts/rates for later phases (Analysis UI, calibration, risk scoring) to consume.

Explicitly **not** in this PR (deferred per roadmap): risk scores, thresholds, recommendations, enforcement, Adaptive Follow Gate, Move-aware relationship confidence, Target Receptiveness, inferred follow campaigns, and the true relationship-aware `unknown_target_ratio`.

## Guardrails honored

- **Read-only** (never creates/updates `ModerationSubject`); **no scoring/enforcement**; **mechanism-independent**; "linked" = strong temporal association, not causal proof (`Moderation::PrecedingContactLink`). No DB migration.

## What it computes

For each window (`1h/6h/24h/7d/30d`) and `lifetime`:
- **Raw event-window counts**: `contacts_total`, `unique_targets`, `follows`, `interactions_by_type`, rejections by type (`blocks_received`, `follow_rejects_received`, `remove_follower_received`, `reports_received`, `mutes_received`), `unique_negative_responders`, `linked_negative_responders`, `correlated_negative_responders`.
- **Rates** (raw floats): `negative_response_rate`, `linked_negative_rate`, `follow_reject_rate`.
- **Continuation after rejection**: `first_negative_signal_at`, `new_targets_after_first_negative_signal`, `follows_after_first_negative_signal`.

Plus a subject-level **follow-import context**: `batch_count`, target totals, `unresolved_target_ratio`, `prior_relationship_known_targets`, `latest_import_at`, `min_account_age_seconds_at_import`, `migration_evidence` breakdown.

## Rate semantics (cohort + temporal ordering)

Raw counts are kept as-is. Anything named a *rate* is both **cohort-aligned** (numerator ⊆ denominator over the same in-window contact cohort → rate ≤ 1) and **temporally ordered** (the counted rejection must respond to a preceding in-window contact):

- `negative_response_rate` = responders whose earliest in-window contact is `<=` their latest in-window rejection, over unique in-window targets.
- `follow_reject_rate` = targets whose earliest in-window *follow* is `<=` their latest in-window *follow_reject*, over targets followed in-window.
- `linked_negative_rate` = rejections whose `preceding_interaction_event` is itself in-window and at/before the rejection (strong association), over unique in-window targets.

So an out-of-window contact paired with an in-window rejection, or an in-window contact that lands *after* the rejection, cannot enter a rate numerator.

## Review history

- Round 1: renamed `unknown_target_ratio` → `unresolved_target_ratio` (true unknown ratio deferred to relationship-aware phase); first cohort alignment; `new_targets_after_first_negative_signal` fixed to genuinely-new targets (no prior contact at/before the signal in full history); `ratio()` returns raw float.
- Round 2 (this): added the **contact-before-rejection temporal requirement** to all rates, with specs.

## Testing

```
$ bundle exec rspec spec/services/moderation/behavioral_metrics_service_spec.rb
16 examples, 0 failures

$ bundle exec rspec spec/services/moderation spec/models/moderation
77 examples, 0 failures
```

Covers the 24h/1h windows (cohort-aligned + ordered rates as raw floats), lifetime, genuinely-new-target semantics (re-contacted target excluded), rate-cohort boundary (out-of-window contact keeps the rate ≤ 1), rate temporal ordering (out-of-window/after-rejection contacts excluded; in-window contact → later rejection included), follow-import context (`unresolved_target_ratio`, no `unknown_target_ratio` key), and the read-only guarantee.

Head: `cd3149e437366d32f83fe05be66e8c3c1221c202`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

