### PR TITLE
Admin: read-only behavioral-metrics (Analysis) UI (PR 10)

### DIFF
--- a/app/controllers/admin/moderation_metrics_controller.rb
+++ b/app/controllers/admin/moderation_metrics_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  # Read-only Analysis UI over the moderation ledger: renders the behavioural
+  # metrics computed by Moderation::BehavioralMetricsService for one subject.
+  # It only visualizes observed counts/rates — no scoring, thresholds,
+  # recommendations, or enforcement, and it never mutates the ledger.
+  class ModerationMetricsController < BaseController
+    before_action :set_subject
+
+    def show
+      authorize :moderation_metric, :show?
+
+      @metrics = Moderation::BehavioralMetricsService.new.call(@subject)
+    end
+
+    private
+
+    # :id is the ModerationSubject id. A stale/invalid id fails closed with 404
+    # (via rescue_from ActiveRecord::RecordNotFound).
+    def set_subject
+      @subject = ModerationSubject.find(params[:id])
+    end
+  end
+end

--- a/app/helpers/admin/moderation_metrics_helper.rb
+++ b/app/helpers/admin/moderation_metrics_helper.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Admin::ModerationMetricsHelper
+  # Rows rendered in the windowed metrics table, grouped by section. Each entry
+  # is [i18n_key, metric_key, kind]. `kind` drives formatting only.
+  METRIC_ROWS = {
+    'contact' => [
+      %w(contacts_total contacts_total count),
+      %w(unique_targets unique_targets count),
+      %w(follows follows count),
+    ],
+    'rejections' => [
+      %w(rejections_received_total rejections_received_total count),
+      %w(blocks_received blocks_received count),
+      %w(follow_rejects_received follow_rejects_received count),
+      %w(remove_follower_received remove_follower_received count),
+      %w(reports_received reports_received count),
+      %w(mutes_received mutes_received count),
+    ],
+    'responders' => [
+      %w(unique_negative_responders unique_negative_responders count),
+      %w(linked_negative_responders linked_negative_responders count),
+      %w(correlated_negative_responders correlated_negative_responders count),
+    ],
+    'rates' => [
+      %w(negative_response_rate negative_response_rate rate),
+      %w(linked_negative_rate linked_negative_rate rate),
+      %w(follow_reject_rate follow_reject_rate rate),
+    ],
+    'continuation' => [
+      %w(first_negative_signal_at first_negative_signal_at time),
+      %w(new_targets_after_first_negative_signal new_targets_after_first_negative_signal count),
+      %w(follows_after_first_negative_signal follows_after_first_negative_signal count),
+    ],
+  }.freeze
+
+  # Ordered [label, window_hash] pairs: the configured windows then lifetime.
+  def moderation_metric_columns(metrics)
+    columns = (metrics['windows'] || {}).map { |name, data| [name, data] }
+    columns << [t('admin.moderation_metrics.lifetime'), metrics['lifetime']] if metrics['lifetime']
+    columns
+  end
+
+  # Present a raw metric value for display. Rates (raw 0..1 floats from the
+  # analysis layer) are rounded here for the UI; counts stay integers; times are
+  # localized.
+  def format_moderation_metric(value, kind)
+    case kind
+    when 'rate'
+      value.nil? ? '—' : number_to_percentage(value.to_f * 100, precision: 1)
+    when 'time'
+      value.present? ? l(Time.iso8601(value)) : '—'
+    else
+      number_with_delimiter(value.to_i)
+    end
+  end
+end

--- a/app/policies/moderation_metric_policy.rb
+++ b/app/policies/moderation_metric_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ModerationMetricPolicy < ApplicationPolicy
+  def show?
+    staff?
+  end
+end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -61,6 +61,10 @@
       = link_to admin_moderation_evidence_snapshots_path(subject_id: @moderation_subject.id) do
         .dashboard__counters__num= number_with_delimiter @moderation_subject.evidence_snapshots.count
         .dashboard__counters__label= t 'admin.moderation_evidence_snapshots.title'
+    %div
+      = link_to admin_moderation_metric_path(@moderation_subject.id) do
+        .dashboard__counters__num= fa_icon 'bar-chart'
+        .dashboard__counters__label= t 'admin.moderation_metrics.title'
   %div
     = link_to admin_action_logs_path(target_account_id: @account.id) do
       .dashboard__counters__text

--- a/app/views/admin/moderation_metrics/show.html.haml
+++ b/app/views/admin/moderation_metrics/show.html.haml
@@ -40,6 +40,14 @@
             %td= t("admin.moderation_metrics.metrics.#{label_key}")
             - columns.each do |_label, data|
               %td= format_moderation_metric(data[metric_key], kind)
+        - if section == 'contact'
+          %tr
+            %th{ colspan: columns.size + 1 }= t('admin.moderation_metrics.sections.interaction_types')
+          - Moderation::BehavioralMetricsService::INTERACTION_TYPES.each do |type|
+            %tr
+              %td= t("admin.moderation_metrics.interaction_types.#{type}")
+              - columns.each do |_label, data|
+                %td= number_with_delimiter((data['interactions_by_type'] || {})[type].to_i)
 
 %h3= t('admin.moderation_metrics.sections.follow_import')
 - if import_context['batch_count'].to_i.zero?
@@ -72,3 +80,8 @@
         %tr
           %th= t('admin.moderation_metrics.import.min_account_age_seconds_at_import')
           %td= import_context['min_account_age_seconds_at_import'].present? ? number_with_delimiter(import_context['min_account_age_seconds_at_import']) : '—'
+        %tr
+          %th= t('admin.moderation_metrics.import.migration_evidence')
+          %td
+            - evidence = import_context['migration_evidence'] || {}
+            = safe_join(%w(none weak strong).map { |key| "#{t("admin.moderation_metrics.import.migration_evidence_values.#{key}")}: #{number_with_delimiter(evidence[key].to_i)}" }, ', ')

--- a/app/views/admin/moderation_metrics/show.html.haml
+++ b/app/views/admin/moderation_metrics/show.html.haml
@@ -1,0 +1,74 @@
+- content_for :page_title do
+  = t('admin.moderation_metrics.title')
+
+- columns = moderation_metric_columns(@metrics)
+- import_context = @metrics['follow_import_context'] || {}
+
+.dashboard__counters
+  %div
+    = link_to admin_moderation_evidence_snapshots_path(subject_id: @subject.id) do
+      %div
+        %span.dashboard__counters__num= moderation_subject_label(@subject)
+        %span.dashboard__counters__label= t('admin.moderation_metrics.subject')
+  %div
+    %div
+      %span.dashboard__counters__num= moderation_subject_origin_badge(@subject)
+      %span.dashboard__counters__label= t('admin.moderation_evidence_snapshots.columns.origin')
+  %div
+    %div
+      %span.dashboard__counters__num= l(Time.iso8601(@metrics['generated_at']))
+      %span.dashboard__counters__label= t('admin.moderation_metrics.generated_at')
+
+%hr.spacer/
+
+%p.muted-hint= t('admin.moderation_metrics.hint')
+%p.muted-hint= t('admin.moderation_metrics.association_disclaimer')
+
+.table-wrapper
+  %table.table
+    %thead
+      %tr
+        %th= t('admin.moderation_metrics.metric')
+        - columns.each do |label, _data|
+          %th= label
+    %tbody
+      - Admin::ModerationMetricsHelper::METRIC_ROWS.each do |section, rows|
+        %tr
+          %th{ colspan: columns.size + 1 }= t("admin.moderation_metrics.sections.#{section}")
+        - rows.each do |label_key, metric_key, kind|
+          %tr
+            %td= t("admin.moderation_metrics.metrics.#{label_key}")
+            - columns.each do |_label, data|
+              %td= format_moderation_metric(data[metric_key], kind)
+
+%h3= t('admin.moderation_metrics.sections.follow_import')
+- if import_context['batch_count'].to_i.zero?
+  %p.muted-hint= t('admin.moderation_metrics.no_follow_import')
+- else
+  .table-wrapper
+    %table.table
+      %tbody
+        %tr
+          %th= t('admin.moderation_metrics.import.batch_count')
+          %td= number_with_delimiter(import_context['batch_count'].to_i)
+        %tr
+          %th= t('admin.moderation_metrics.import.target_total')
+          %td= number_with_delimiter(import_context['target_total'].to_i)
+        %tr
+          %th= t('admin.moderation_metrics.import.resolved_target_total')
+          %td= number_with_delimiter(import_context['resolved_target_total'].to_i)
+        %tr
+          %th= t('admin.moderation_metrics.import.unresolved_target_total')
+          %td= number_with_delimiter(import_context['unresolved_target_total'].to_i)
+        %tr
+          %th= t('admin.moderation_metrics.import.unresolved_target_ratio')
+          %td= number_to_percentage(import_context['unresolved_target_ratio'].to_f * 100, precision: 1)
+        %tr
+          %th= t('admin.moderation_metrics.import.prior_relationship_known_targets')
+          %td= number_with_delimiter(import_context['prior_relationship_known_targets'].to_i)
+        %tr
+          %th= t('admin.moderation_metrics.import.latest_import_at')
+          %td= import_context['latest_import_at'].present? ? l(Time.iso8601(import_context['latest_import_at'])) : '—'
+        %tr
+          %th= t('admin.moderation_metrics.import.min_account_age_seconds_at_import')
+          %td= import_context['min_account_age_seconds_at_import'].present? ? number_with_delimiter(import_context['min_account_age_seconds_at_import']) : '—'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,50 @@ en:
       warn: Warn
       web: Web
       whitelisted: Allowed for federation
+    moderation_metrics:
+      title: Behavioral metrics
+      subject: Subject
+      generated_at: Generated at
+      lifetime: Lifetime
+      metric: Metric
+      hint: Read-only analysis of observed behaviour over time windows. No scoring, thresholds, or enforcement is applied here.
+      association_disclaimer: A linked response is a strong temporal association (a preceding contact within the window), not proof that the contact caused the rejection.
+      no_follow_import: No follow-import batches recorded for this subject.
+      sections:
+        contact: Contact volume and spread
+        rejections: Rejections received
+        responders: Negative responders
+        rates: Response rates
+        continuation: Continuation after first negative signal
+        follow_import: Follow-import context
+      metrics:
+        contacts_total: Contacts
+        unique_targets: Unique targets
+        follows: Follows
+        rejections_received_total: Rejections received
+        blocks_received: Blocks received
+        follow_rejects_received: Follow rejects received
+        remove_follower_received: Removed as follower
+        reports_received: Reports received
+        mutes_received: Mutes received
+        unique_negative_responders: Unique negative responders
+        linked_negative_responders: Linked negative responders
+        correlated_negative_responders: Correlated negative responders
+        negative_response_rate: Negative response rate
+        linked_negative_rate: Linked negative rate
+        follow_reject_rate: Follow reject rate
+        first_negative_signal_at: First negative signal at
+        new_targets_after_first_negative_signal: New targets after first negative signal
+        follows_after_first_negative_signal: Follows after first negative signal
+      import:
+        batch_count: Batches
+        target_total: Total targets
+        resolved_target_total: Resolved targets
+        unresolved_target_total: Unresolved targets
+        unresolved_target_ratio: Unresolved target ratio
+        prior_relationship_known_targets: Prior-known relationship targets
+        latest_import_at: Latest import at
+        min_account_age_seconds_at_import: Min account age at import (seconds)
     moderation_evidence_snapshots:
       title: Moderation evidence
       show_title: "Evidence snapshot #%{id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,15 +269,25 @@ en:
       lifetime: Lifetime
       metric: Metric
       hint: Read-only analysis of observed behaviour over time windows. No scoring, thresholds, or enforcement is applied here.
-      association_disclaimer: A linked response is a strong temporal association (a preceding contact within the window), not proof that the contact caused the rejection.
+      association_disclaimer: A linked negative responder reflects a strong temporal association with the recorded preceding contact (which may fall outside the displayed window). The linked negative rate counts only responders whose preceding contact is within the displayed window. Neither is proof that the contact caused the rejection.
       no_follow_import: No follow-import batches recorded for this subject.
       sections:
         contact: Contact volume and spread
+        interaction_types: Interaction breakdown by type
         rejections: Rejections received
         responders: Negative responders
         rates: Response rates
         continuation: Continuation after first negative signal
         follow_import: Follow-import context
+      interaction_types:
+        follow: Follows
+        mention: Mentions
+        reply: Replies
+        quote: Quotes
+        reference: References
+        reaction: Reactions
+        favourite: Favourites
+        follow_import: Follow-import contacts
       metrics:
         contacts_total: Contacts
         unique_targets: Unique targets
@@ -306,6 +316,11 @@ en:
         prior_relationship_known_targets: Prior-known relationship targets
         latest_import_at: Latest import at
         min_account_age_seconds_at_import: Min account age at import (seconds)
+        migration_evidence: Migration evidence
+        migration_evidence_values:
+          none: none
+          weak: weak
+          strong: strong
     moderation_evidence_snapshots:
       title: Moderation evidence
       show_title: "Evidence snapshot #%{id}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -258,15 +258,25 @@ ja:
       lifetime: 全期間
       metric: メトリクス
       hint: 観測された行動を時間ウィンドウごとに集計した閲覧専用の分析です。ここでスコア付け・しきい値・エンフォースメントは行いません。
-      association_disclaimer: リンクされた反応は、期間内の先行接触による強い時間的関連であり、その接触が拒否の原因であることの証明ではありません。
+      association_disclaimer: リンクされた否定的反応者は、記録された先行接触との強い時間的関連を表します（先行接触は表示ウィンドウの外にある場合があります）。リンク否定率は、先行接触が表示ウィンドウ内にある反応者のみを数えます。いずれも、その接触が拒否の原因であることの証明ではありません。
       no_follow_import: この対象の Follow Import バッチは記録されていません。
       sections:
         contact: 接触量と広がり
+        interaction_types: 種別ごとのインタラクション内訳
         rejections: 受けた拒否
         responders: 否定的反応者
         rates: 反応率
         continuation: 最初の否定シグナル以降の継続
         follow_import: Follow Import コンテキスト
+      interaction_types:
+        follow: フォロー
+        mention: メンション
+        reply: リプライ
+        quote: 引用
+        reference: 参照
+        reaction: リアクション
+        favourite: お気に入り
+        follow_import: Follow Import 接触
       metrics:
         contacts_total: 接触数
         unique_targets: ユニーク対象数
@@ -295,6 +305,11 @@ ja:
         prior_relationship_known_targets: 既知関係の対象数
         latest_import_at: 最新インポート日時
         min_account_age_seconds_at_import: インポート時の最小アカウント年齢（秒）
+        migration_evidence: 移行の根拠
+        migration_evidence_values:
+          none: なし
+          weak: 弱
+          strong: 強
     moderation_evidence_snapshots:
       title: モデレーション証跡
       show_title: "証跡スナップショット #%{id}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,50 @@ ja:
       warn: 警告
       web: Web
       whitelisted: 連合許可済み
+    moderation_metrics:
+      title: 行動メトリクス
+      subject: 対象
+      generated_at: 生成日時
+      lifetime: 全期間
+      metric: メトリクス
+      hint: 観測された行動を時間ウィンドウごとに集計した閲覧専用の分析です。ここでスコア付け・しきい値・エンフォースメントは行いません。
+      association_disclaimer: リンクされた反応は、期間内の先行接触による強い時間的関連であり、その接触が拒否の原因であることの証明ではありません。
+      no_follow_import: この対象の Follow Import バッチは記録されていません。
+      sections:
+        contact: 接触量と広がり
+        rejections: 受けた拒否
+        responders: 否定的反応者
+        rates: 反応率
+        continuation: 最初の否定シグナル以降の継続
+        follow_import: Follow Import コンテキスト
+      metrics:
+        contacts_total: 接触数
+        unique_targets: ユニーク対象数
+        follows: フォロー数
+        rejections_received_total: 受けた拒否数
+        blocks_received: 受けたブロック数
+        follow_rejects_received: 受けたフォロー拒否数
+        remove_follower_received: フォロワー解除数
+        reports_received: 受けた通報数
+        mutes_received: 受けたミュート数
+        unique_negative_responders: ユニーク否定的反応者数
+        linked_negative_responders: リンクされた否定的反応者数
+        correlated_negative_responders: 相関する否定的反応者数
+        negative_response_rate: 否定的反応率
+        linked_negative_rate: リンク否定率
+        follow_reject_rate: フォロー拒否率
+        first_negative_signal_at: 最初の否定シグナル日時
+        new_targets_after_first_negative_signal: 否定シグナル後の新規対象数
+        follows_after_first_negative_signal: 否定シグナル後のフォロー数
+      import:
+        batch_count: バッチ数
+        target_total: 対象総数
+        resolved_target_total: 解決済み対象数
+        unresolved_target_total: 未解決対象数
+        unresolved_target_ratio: 未解決対象比率
+        prior_relationship_known_targets: 既知関係の対象数
+        latest_import_at: 最新インポート日時
+        min_account_age_seconds_at_import: インポート時の最小アカウント年齢（秒）
     moderation_evidence_snapshots:
       title: モデレーション証跡
       show_title: "証跡スナップショット #%{id}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,6 +254,7 @@ Rails.application.routes.draw do
     resources :email_domain_blocks, only: [:index, :new, :create, :destroy]
     resources :action_logs, only: [:index]
     resources :moderation_evidence_snapshots, only: [:index, :show], path: 'moderation_evidence'
+    resources :moderation_metrics, only: [:show], path: 'moderation_metrics'
     resources :warning_presets, except: [:new]
 
     resources :announcements, except: [:show] do

--- a/spec/controllers/admin/moderation_metrics_controller_spec.rb
+++ b/spec/controllers/admin/moderation_metrics_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::ModerationMetricsController, type: :controller do
+  render_views false
+
+  let(:subject_record) { Fabricate(:moderation_subject) }
+
+  context 'as an admin' do
+    before { sign_in Fabricate(:user, admin: true) }
+
+    describe 'GET #show' do
+      it 'returns 200 and assigns the computed metrics for the subject' do
+        get :show, params: { id: subject_record.id }
+
+        expect(response).to have_http_status(200)
+        expect(assigns(:subject)).to eq subject_record
+        expect(assigns(:metrics)['subject_id']).to eq subject_record.id
+        expect(assigns(:metrics)['windows']).to include('1h', '24h', '30d')
+      end
+
+      it 'fails closed with 404 for a stale subject id' do
+        get :show, params: { id: ModerationSubject.maximum(:id).to_i + 1 }
+
+        expect(response).to have_http_status(404)
+        expect(assigns(:metrics)).to be_nil
+      end
+    end
+  end
+
+  context 'as a non-staff user' do
+    before { sign_in Fabricate(:user) }
+
+    it 'is forbidden' do
+      get :show, params: { id: subject_record.id }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/helpers/admin/moderation_metrics_helper_spec.rb
+++ b/spec/helpers/admin/moderation_metrics_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ModerationMetricsHelper, type: :helper do
+  describe '#moderation_metric_columns' do
+    it 'lists the windows in order and appends lifetime' do
+      metrics = { 'windows' => { '1h' => { 'contacts_total' => 1 }, '24h' => { 'contacts_total' => 2 } }, 'lifetime' => { 'contacts_total' => 3 } }
+
+      labels = helper.moderation_metric_columns(metrics).map(&:first)
+
+      expect(labels).to eq ['1h', '24h', I18n.t('admin.moderation_metrics.lifetime')]
+    end
+  end
+
+  describe '#format_moderation_metric' do
+    it 'renders a raw-float rate as a rounded percentage' do
+      expect(helper.format_moderation_metric(1.0 / 3, 'rate')).to eq '33.3%'
+      expect(helper.format_moderation_metric(nil, 'rate')).to eq '—'
+    end
+
+    it 'renders counts as delimited integers' do
+      expect(helper.format_moderation_metric(1234, 'count')).to eq '1,234'
+    end
+
+    it 'renders an ISO time as a localized time and blank as a dash' do
+      time = Time.now.utc.iso8601
+      expect(helper.format_moderation_metric(time, 'time')).to eq I18n.l(Time.iso8601(time))
+      expect(helper.format_moderation_metric(nil, 'time')).to eq '—'
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **Analysis UI** from the roadmap: a read-only admin page that visualizes `Moderation::BehavioralMetricsService` (PR #40) for one subject. It only displays observed counts/rates — **no scoring, thresholds, recommendations, or enforcement**, and it never mutates the ledger.

## What's included

- **Route** — `resources :moderation_metrics, only: [:show], path: 'moderation_metrics'` under `namespace :admin` (`:id` is the `ModerationSubject` id).
- **Policy** — `ModerationMetricPolicy#show?` requires `staff?`; the controller also inherits `require_staff!`.
- **Controller** — `Admin::ModerationMetricsController#show`: loads the subject (a stale/invalid id **fails closed** with 404 via `ModerationSubject.find`) and calls the metrics service.
- **View** — a windowed metrics table (columns `1h/6h/24h/7d/30d` + `lifetime`) grouped into: contact volume/spread, an **interaction breakdown by type** (follow/mention/reply/quote/reference/reaction/favourite/follow_import), rejections received, negative responders, response rates, and continuation after the first negative signal; plus a follow-import context section that includes the **migration_evidence** (none/weak/strong) breakdown. Carries the linked-association disclaimer (see below).
- **Helper** — formats values for display: rates (raw floats from the analysis layer) are rounded to a percentage here, counts are delimited integers, times are localized.
- **Account page link** — a "Behavioral metrics" counter on the admin account page when a `ModerationSubject` exists.
- **i18n** — full `admin.moderation_metrics.*` strings in `en` and `ja`.

## Linked-association disclaimer

The page states, and the code honors, the distinction the metrics service makes: a **raw linked negative responder** reflects a strong temporal association with the recorded preceding contact (which may fall outside the displayed window), while the **linked negative rate** counts only responders whose preceding contact is within the displayed window. Neither is causal proof.

## Testing

```
$ bundle exec rspec spec/controllers/admin/moderation_metrics_controller_spec.rb \
    spec/helpers/admin/moderation_metrics_helper_spec.rb
7 examples, 0 failures
```

Manual GUI verification against the dev server (real pack manifest), via computer-use + video review: account-page link → metrics page; the windowed table with all section groupings, the interaction breakdown, and percentage rate values; the follow-import context including the migration_evidence breakdown; and fail-closed 404 on a stale subject id.

[admin_behavioral_metrics_walkthrough.mp4](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_behavioral_metrics_walkthrough.mp4)

[Windowed behavioral metrics table](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetrics_windows_table.webp)

[Interaction breakdown by type](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetrics_interaction_breakdown.webp)

[Follow-import context with migration evidence](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetrics_import_migration_evidence.webp)

[Stale subject id returns 404](https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetrics_stale_subject_404.webp)

Head: `4cd782e859bae25bd695c360301794bc0f1ba7fb`

Do not merge — for review.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

