### PR TITLE
Moderation ledger: analysis-only metrics distribution service (PR 11)

### DIFF
--- a/app/services/moderation/behavioral_metrics_service.rb
+++ b/app/services/moderation/behavioral_metrics_service.rb
@@ -100,6 +100,9 @@ module Moderation
         'contacts_total'                          => contacts_total,
         'unique_targets'                          => unique_targets,
         'follows'                                 => follows,
+        # Distinct targets actually followed in-window — the true denominator for
+        # follow_reject_rate and its eligibility (not the follows event count).
+        'unique_follow_targets'                   => followed_ids.size,
         'interactions_by_type'                    => interactions_by_type,
         'rejections_received_total'               => rejections_total,
         'rejections_by_type'                      => rejections_by_type,
@@ -129,6 +132,7 @@ module Moderation
         'contacts_total'                          => 0,
         'unique_targets'                          => 0,
         'follows'                                 => 0,
+        'unique_follow_targets'                   => 0,
         'interactions_by_type'                    => INTERACTION_TYPES.index_with { 0 },
         'rejections_received_total'               => 0,
         'rejections_by_type'                      => REJECTION_TYPES.index_with { 0 },

--- a/app/services/moderation/metrics_distribution_service.rb
+++ b/app/services/moderation/metrics_distribution_service.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Aggregates Moderation::BehavioralMetricsService output across a set of subjects
+# into per-window, per-feature distribution summaries (n, nonzero, min, max,
+# mean, percentiles). This is the Observation / Calibration read layer: it lets
+# an operator inspect how a feature is distributed across a chosen cohort so that
+# sensible thresholds can be reasoned about later.
+#
+# Strictly observational and read-only:
+#
+#   * It never writes to the database (it only reads via BehavioralMetricsService,
+#     which itself is read-only).
+#   * No scoring, thresholds, labels, recommendations, or enforcement — it reports
+#     distributions only.
+#   * It does NOT scan the whole population on its own: the caller passes the
+#     subject set (e.g. a sample, or a hand-labelled cohort such as "known
+#     legitimate high-volume users" vs "known problematic"), so distributions can
+#     be compared across cohorts without this service inventing labels.
+module Moderation
+  class MetricsDistributionService
+    # Scalar behavioural features worth summarising for calibration.
+    DEFAULT_FEATURES = %w(
+      contacts_total
+      unique_targets
+      follows
+      rejections_received_total
+      unique_negative_responders
+      linked_negative_responders
+      correlated_negative_responders
+      negative_response_rate
+      linked_negative_rate
+      follow_reject_rate
+      new_targets_after_first_negative_signal
+      follows_after_first_negative_signal
+    ).freeze
+
+    PERCENTILES = [10, 25, 50, 75, 90, 95, 99].freeze
+
+    def initialize(metrics_service: Moderation::BehavioralMetricsService.new)
+      @metrics_service = metrics_service
+    end
+
+    def call(subjects, now: Time.now.utc, windows: Moderation::BehavioralMetricsService::DEFAULT_WINDOWS, features: DEFAULT_FEATURES)
+      window_names = windows.keys + ['lifetime']
+      collected    = window_names.index_with { |name| features.index_with { [] } }
+      subject_count = 0
+
+      subjects.each do |subject|
+        subject_count += 1
+        metrics = @metrics_service.call(subject, now: now, windows: windows)
+
+        window_names.each do |name|
+          data = name == 'lifetime' ? metrics['lifetime'] : metrics.dig('windows', name)
+          next if data.nil?
+
+          features.each do |feature|
+            value = data[feature]
+            collected[name][feature] << value if value.is_a?(Numeric)
+          end
+        end
+      end
+
+      {
+        'generated_at'  => now.iso8601,
+        'subject_count' => subject_count,
+        'features'      => features,
+        'windows'       => window_names.index_with { |name| features.index_with { |feature| summarize(collected[name][feature]) } },
+      }
+    end
+
+    private
+
+    def summarize(values)
+      return empty_summary if values.empty?
+
+      sorted = values.sort
+      {
+        'n'           => sorted.size,
+        'nonzero'     => sorted.count { |value| value != 0 },
+        'min'         => sorted.first,
+        'max'         => sorted.last,
+        'mean'        => sorted.sum.to_f / sorted.size,
+        'percentiles' => PERCENTILES.index_with { |p| percentile(sorted, p) },
+      }
+    end
+
+    def empty_summary
+      { 'n' => 0, 'nonzero' => 0, 'min' => nil, 'max' => nil, 'mean' => nil, 'percentiles' => PERCENTILES.index_with { nil } }
+    end
+
+    # Linear-interpolated percentile over an already-sorted array (numpy-style
+    # "linear" method: rank = p/100 * (n - 1)).
+    def percentile(sorted, percent)
+      return sorted.first.to_f if sorted.size == 1
+
+      rank  = (percent / 100.0) * (sorted.size - 1)
+      lower = rank.floor
+      upper = rank.ceil
+      return sorted[lower].to_f if lower == upper
+
+      weight = rank - lower
+      (sorted[lower] * (1 - weight)) + (sorted[upper] * weight)
+    end
+  end
+end

--- a/app/services/moderation/metrics_distribution_service.rb
+++ b/app/services/moderation/metrics_distribution_service.rb
@@ -16,6 +16,13 @@
 #     subject set (e.g. a sample, or a hand-labelled cohort such as "known
 #     legitimate high-volume users" vs "known problematic"), so distributions can
 #     be compared across cohorts without this service inventing labels.
+#
+# Feature eligibility: a metric that is not applicable to a subject (a zero
+# denominator such as no contacts / no followed targets, or no negative signal
+# for the continuation metrics) is EXCLUDED from that feature's distribution
+# rather than counted as a real 0, so the distribution is not skewed. Each
+# summary reports +n+ (the eligible sample) and +excluded_n+; +subject_count+ is
+# the whole (de-duplicated) cohort. A genuine 0 from an eligible subject is kept.
 module Moderation
   class MetricsDistributionService
     # Scalar behavioural features worth summarising for calibration.
@@ -23,6 +30,7 @@ module Moderation
       contacts_total
       unique_targets
       follows
+      unique_follow_targets
       rejections_received_total
       unique_negative_responders
       linked_negative_responders
@@ -36,16 +44,33 @@ module Moderation
 
     PERCENTILES = [10, 25, 50, 75, 90, 95, 99].freeze
 
+    # Per-feature eligibility: a feature only enters a subject's distribution when
+    # the metric is actually applicable, so a "not-applicable 0" (zero denominator
+    # / no negative signal) is excluded rather than skewing the distribution as a
+    # real 0. Features absent here are always eligible (raw counts). The 0.0/0 of
+    # an eligible subject is still counted as a genuine 0.
+    ELIGIBILITY = {
+      'negative_response_rate'                  => ->(data) { data['unique_targets'].to_i.positive? },
+      'linked_negative_rate'                    => ->(data) { data['unique_targets'].to_i.positive? },
+      'follow_reject_rate'                      => ->(data) { data['unique_follow_targets'].to_i.positive? },
+      'new_targets_after_first_negative_signal' => ->(data) { data['first_negative_signal_at'].present? },
+      'follows_after_first_negative_signal'     => ->(data) { data['first_negative_signal_at'].present? },
+    }.freeze
+
     def initialize(metrics_service: Moderation::BehavioralMetricsService.new)
       @metrics_service = metrics_service
     end
 
     def call(subjects, now: Time.now.utc, windows: Moderation::BehavioralMetricsService::DEFAULT_WINDOWS, features: DEFAULT_FEATURES)
-      window_names = windows.keys + ['lifetime']
-      collected    = window_names.index_with { |name| features.index_with { [] } }
+      window_names  = windows.keys + ['lifetime']
+      accumulators  = window_names.index_with { features.index_with { { values: [], excluded: 0 } } }
+      seen          = Set.new
       subject_count = 0
 
       subjects.each do |subject|
+        # De-dupe by subject id so a repeated input is not double-counted.
+        next unless seen.add?(subject.id)
+
         subject_count += 1
         metrics = @metrics_service.call(subject, now: now, windows: windows)
 
@@ -54,8 +79,14 @@ module Moderation
           next if data.nil?
 
           features.each do |feature|
-            value = data[feature]
-            collected[name][feature] << value if value.is_a?(Numeric)
+            accumulator = accumulators[name][feature]
+
+            if feature_eligible?(feature, data)
+              value = data[feature]
+              accumulator[:values] << value if value.is_a?(Numeric)
+            else
+              accumulator[:excluded] += 1
+            end
           end
         end
       end
@@ -64,18 +95,26 @@ module Moderation
         'generated_at'  => now.iso8601,
         'subject_count' => subject_count,
         'features'      => features,
-        'windows'       => window_names.index_with { |name| features.index_with { |feature| summarize(collected[name][feature]) } },
+        'windows'       => window_names.index_with { |name| features.index_with { |feature| summarize(accumulators[name][feature]) } },
       }
     end
 
     private
 
-    def summarize(values)
-      return empty_summary if values.empty?
+    def feature_eligible?(feature, data)
+      rule = ELIGIBILITY[feature]
+      rule.nil? || rule.call(data)
+    end
+
+    def summarize(accumulator)
+      values   = accumulator[:values]
+      excluded = accumulator[:excluded]
+      return empty_summary(excluded) if values.empty?
 
       sorted = values.sort
       {
         'n'           => sorted.size,
+        'excluded_n'  => excluded,
         'nonzero'     => sorted.count { |value| value != 0 },
         'min'         => sorted.first,
         'max'         => sorted.last,
@@ -84,8 +123,8 @@ module Moderation
       }
     end
 
-    def empty_summary
-      { 'n' => 0, 'nonzero' => 0, 'min' => nil, 'max' => nil, 'mean' => nil, 'percentiles' => PERCENTILES.index_with { nil } }
+    def empty_summary(excluded = 0)
+      { 'n' => 0, 'excluded_n' => excluded, 'nonzero' => 0, 'min' => nil, 'max' => nil, 'mean' => nil, 'percentiles' => PERCENTILES.index_with { nil } }
     end
 
     # Linear-interpolated percentile over an already-sorted array (numpy-style

--- a/spec/services/moderation/behavioral_metrics_service_spec.rb
+++ b/spec/services/moderation/behavioral_metrics_service_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Moderation::BehavioralMetricsService do
         expect(metrics['contacts_total']).to eq 4
         expect(metrics['unique_targets']).to eq 4
         expect(metrics['follows']).to eq 3
+        expect(metrics['unique_follow_targets']).to eq 3
         expect(metrics['interactions_by_type']).to include('follow' => 3, 'mention' => 1)
       end
 

--- a/spec/services/moderation/metrics_distribution_service_spec.rb
+++ b/spec/services/moderation/metrics_distribution_service_spec.rb
@@ -5,44 +5,46 @@ require 'rails_helper'
 RSpec.describe Moderation::MetricsDistributionService do
   let(:now) { Time.now.utc }
 
-  describe 'distribution summaries over a cohort' do
-    # Five subjects with contacts_total 0,10,20,30,40 and negative_response_rate
-    # 0.0,0.1,0.2,0.3,0.4 in the 24h window, fed through an injected metrics
-    # service so the distribution math is tested in isolation.
-    let(:subjects) { Array.new(5) { |i| Fabricate(:moderation_subject) }.each_with_index.to_a }
+  # A single-window (24h + lifetime) canned metrics payload with all the fields
+  # eligibility depends on, so the distribution logic can be tested in isolation.
+  def canned(**fields)
+    window = {
+      'contacts_total'                          => 0,
+      'unique_targets'                          => 0,
+      'unique_follow_targets'                   => 0,
+      'negative_response_rate'                  => 0.0,
+      'linked_negative_rate'                    => 0.0,
+      'follow_reject_rate'                      => 0.0,
+      'first_negative_signal_at'                => nil,
+      'new_targets_after_first_negative_signal' => 0,
+      'follows_after_first_negative_signal'     => 0,
+    }.merge(fields.transform_keys(&:to_s))
 
-    let(:metrics_service) do
-      canned = {}
-      subjects.each_with_index do |subject_and_index, index|
-        subject, = subject_and_index
-        window = { 'contacts_total' => index * 10, 'negative_response_rate' => index / 10.0, 'first_negative_signal_at' => nil }
-        canned[subject.id] = { 'windows' => { '24h' => window }, 'lifetime' => window }
-      end
+    { 'windows' => { '24h' => window }, 'lifetime' => window }
+  end
 
-      fake = instance_double(Moderation::BehavioralMetricsService)
-      allow(fake).to receive(:call) { |subject, **| canned[subject.id] }
-      fake
+  def fake_service(mapping)
+    fake = instance_double(Moderation::BehavioralMetricsService)
+    allow(fake).to receive(:call) { |subject, **| mapping.fetch(subject.id) }
+    fake
+  end
+
+  def distribution(mapping, features:)
+    subjects = mapping.keys.map { |id| ModerationSubject.new.tap { |s| s.id = id } }
+    described_class.new(metrics_service: fake_service(mapping))
+                   .call(subjects, now: now, windows: { '24h' => 24.hours }, features: features)
+  end
+
+  describe 'distribution math (always-eligible raw count)' do
+    let(:mapping) do
+      (0..4).to_h { |i| [i + 1, canned(contacts_total: i * 10, unique_targets: 4)] }
     end
 
-    subject(:result) do
-      described_class.new(metrics_service: metrics_service).call(
-        subjects.map(&:first),
-        now: now,
-        windows: { '24h' => 24.hours },
-        features: %w(contacts_total negative_response_rate first_negative_signal_at)
-      )
-    end
+    subject(:summary) { distribution(mapping, features: %w(contacts_total)).dig('windows', '24h', 'contacts_total') }
 
-    it 'reports the cohort size and the requested features' do
-      expect(result['subject_count']).to eq 5
-      expect(result['features']).to eq %w(contacts_total negative_response_rate first_negative_signal_at)
-      expect(result['windows'].keys).to contain_exactly('24h', 'lifetime')
-    end
-
-    it 'summarizes count, nonzero, min, max and mean' do
-      summary = result.dig('windows', '24h', 'contacts_total')
-
+    it 'summarizes n/excluded_n/nonzero/min/max/mean' do
       expect(summary['n']).to eq 5
+      expect(summary['excluded_n']).to eq 0
       expect(summary['nonzero']).to eq 4
       expect(summary['min']).to eq 0
       expect(summary['max']).to eq 40
@@ -50,27 +52,90 @@ RSpec.describe Moderation::MetricsDistributionService do
     end
 
     it 'computes linear-interpolated percentiles' do
-      pct = result.dig('windows', '24h', 'contacts_total', 'percentiles')
-
+      pct = summary['percentiles']
       expect(pct[25]).to eq 10.0
       expect(pct[50]).to eq 20.0
-      expect(pct[90]).to be_within(1e-9).of(36.0)  # 30 + 0.6*(40-30)
+      expect(pct[90]).to be_within(1e-9).of(36.0)
       expect(pct[95]).to be_within(1e-9).of(38.0)
     end
+  end
 
-    it 'handles fractional-value features (rates)' do
+  describe 'negative_response_rate eligibility' do
+    it 'excludes a subject with no contacts (not-applicable 0) from the distribution' do
+      mapping = {
+        1 => canned(unique_targets: 0, negative_response_rate: 0.0),
+        2 => canned(unique_targets: 5, negative_response_rate: 0.4),
+      }
+
+      result = distribution(mapping, features: %w(negative_response_rate))
       summary = result.dig('windows', '24h', 'negative_response_rate')
 
+      expect(result['subject_count']).to eq 2
+      expect(summary['n']).to eq 1
+      expect(summary['excluded_n']).to eq 1
       expect(summary['max']).to be_within(1e-9).of(0.4)
-      expect(summary['percentiles'][50]).to be_within(1e-9).of(0.2)
     end
 
-    it 'skips non-numeric feature values entirely' do
-      summary = result.dig('windows', '24h', 'first_negative_signal_at')
+    it 'includes a contacted subject whose rate is a genuine 0.0' do
+      mapping = { 1 => canned(unique_targets: 3, negative_response_rate: 0.0) }
+
+      summary = distribution(mapping, features: %w(negative_response_rate)).dig('windows', '24h', 'negative_response_rate')
+
+      expect(summary['n']).to eq 1
+      expect(summary['excluded_n']).to eq 0
+      expect(summary['nonzero']).to eq 0
+      expect(summary['min']).to eq 0.0
+    end
+  end
+
+  describe 'follow_reject_rate eligibility' do
+    it 'excludes a subject with no followed targets' do
+      mapping = {
+        1 => canned(unique_follow_targets: 0, follow_reject_rate: 0.0),
+        2 => canned(unique_follow_targets: 4, follow_reject_rate: 0.25),
+      }
+
+      summary = distribution(mapping, features: %w(follow_reject_rate)).dig('windows', '24h', 'follow_reject_rate')
+
+      expect(summary['n']).to eq 1
+      expect(summary['excluded_n']).to eq 1
+      expect(summary['max']).to be_within(1e-9).of(0.25)
+    end
+  end
+
+  describe 'continuation eligibility' do
+    it 'excludes a subject that received no negative signal' do
+      mapping = { 1 => canned(first_negative_signal_at: nil, new_targets_after_first_negative_signal: 0) }
+
+      summary = distribution(mapping, features: %w(new_targets_after_first_negative_signal)).dig('windows', '24h', 'new_targets_after_first_negative_signal')
 
       expect(summary['n']).to eq 0
-      expect(summary['min']).to be_nil
-      expect(summary['percentiles'][50]).to be_nil
+      expect(summary['excluded_n']).to eq 1
+    end
+
+    it 'includes a subject with a negative signal but zero continuation as a genuine 0' do
+      mapping = { 1 => canned(first_negative_signal_at: now.iso8601, new_targets_after_first_negative_signal: 0) }
+
+      summary = distribution(mapping, features: %w(new_targets_after_first_negative_signal)).dig('windows', '24h', 'new_targets_after_first_negative_signal')
+
+      expect(summary['n']).to eq 1
+      expect(summary['excluded_n']).to eq 0
+      expect(summary['nonzero']).to eq 0
+      expect(summary['min']).to eq 0
+    end
+  end
+
+  describe 'de-duplication of subjects' do
+    it 'counts a repeated subject only once' do
+      s = ModerationSubject.new.tap { |subject| subject.id = 99 }
+      mapping = { 99 => canned(contacts_total: 7, unique_targets: 2) }
+      service = described_class.new(metrics_service: fake_service(mapping))
+
+      result = service.call([s, s], now: now, windows: { '24h' => 24.hours }, features: %w(contacts_total))
+
+      expect(result['subject_count']).to eq 1
+      expect(result.dig('windows', '24h', 'contacts_total', 'n')).to eq 1
+      expect(result.dig('windows', '24h', 'contacts_total', 'max')).to eq 7
     end
   end
 
@@ -80,6 +145,7 @@ RSpec.describe Moderation::MetricsDistributionService do
 
       expect(result['subject_count']).to eq 0
       expect(result.dig('windows', '24h', 'contacts_total', 'n')).to eq 0
+      expect(result.dig('windows', '24h', 'contacts_total', 'excluded_n')).to eq 0
       expect(result.dig('windows', 'lifetime', 'contacts_total', 'percentiles')[50]).to be_nil
     end
   end
@@ -93,17 +159,21 @@ RSpec.describe Moderation::MetricsDistributionService do
       Moderation::EventRecorder.record_interaction(actor: actor, target: Fabricate(:account), event_type: :favourite, occurred_at: now - 5.minutes, source_event_key: 'd-2')
     end
 
-    it 'aggregates real per-subject metrics into a distribution' do
+    it 'aggregates real per-subject metrics and applies eligibility' do
       subjects = [ModerationSubject.find_by(account_id: actor.id), ModerationSubject.for_account!(other)]
 
       result = described_class.new.call(subjects, now: now, windows: { '24h' => 24.hours })
 
-      # actor has 2 contacts in 24h, other has 0.
-      summary = result.dig('windows', '24h', 'contacts_total')
+      contacts = result.dig('windows', '24h', 'contacts_total')
       expect(result['subject_count']).to eq 2
-      expect(summary['n']).to eq 2
-      expect(summary['max']).to eq 2
-      expect(summary['nonzero']).to eq 1
+      expect(contacts['n']).to eq 2
+      expect(contacts['max']).to eq 2
+      expect(contacts['nonzero']).to eq 1
+
+      # actor has contacts (eligible, rate 0.0); other has none (excluded).
+      rate = result.dig('windows', '24h', 'negative_response_rate')
+      expect(rate['n']).to eq 1
+      expect(rate['excluded_n']).to eq 1
     end
   end
 end

--- a/spec/services/moderation/metrics_distribution_service_spec.rb
+++ b/spec/services/moderation/metrics_distribution_service_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::MetricsDistributionService do
+  let(:now) { Time.now.utc }
+
+  describe 'distribution summaries over a cohort' do
+    # Five subjects with contacts_total 0,10,20,30,40 and negative_response_rate
+    # 0.0,0.1,0.2,0.3,0.4 in the 24h window, fed through an injected metrics
+    # service so the distribution math is tested in isolation.
+    let(:subjects) { Array.new(5) { |i| Fabricate(:moderation_subject) }.each_with_index.to_a }
+
+    let(:metrics_service) do
+      canned = {}
+      subjects.each_with_index do |subject_and_index, index|
+        subject, = subject_and_index
+        window = { 'contacts_total' => index * 10, 'negative_response_rate' => index / 10.0, 'first_negative_signal_at' => nil }
+        canned[subject.id] = { 'windows' => { '24h' => window }, 'lifetime' => window }
+      end
+
+      fake = instance_double(Moderation::BehavioralMetricsService)
+      allow(fake).to receive(:call) { |subject, **| canned[subject.id] }
+      fake
+    end
+
+    subject(:result) do
+      described_class.new(metrics_service: metrics_service).call(
+        subjects.map(&:first),
+        now: now,
+        windows: { '24h' => 24.hours },
+        features: %w(contacts_total negative_response_rate first_negative_signal_at)
+      )
+    end
+
+    it 'reports the cohort size and the requested features' do
+      expect(result['subject_count']).to eq 5
+      expect(result['features']).to eq %w(contacts_total negative_response_rate first_negative_signal_at)
+      expect(result['windows'].keys).to contain_exactly('24h', 'lifetime')
+    end
+
+    it 'summarizes count, nonzero, min, max and mean' do
+      summary = result.dig('windows', '24h', 'contacts_total')
+
+      expect(summary['n']).to eq 5
+      expect(summary['nonzero']).to eq 4
+      expect(summary['min']).to eq 0
+      expect(summary['max']).to eq 40
+      expect(summary['mean']).to eq 20.0
+    end
+
+    it 'computes linear-interpolated percentiles' do
+      pct = result.dig('windows', '24h', 'contacts_total', 'percentiles')
+
+      expect(pct[25]).to eq 10.0
+      expect(pct[50]).to eq 20.0
+      expect(pct[90]).to be_within(1e-9).of(36.0)  # 30 + 0.6*(40-30)
+      expect(pct[95]).to be_within(1e-9).of(38.0)
+    end
+
+    it 'handles fractional-value features (rates)' do
+      summary = result.dig('windows', '24h', 'negative_response_rate')
+
+      expect(summary['max']).to be_within(1e-9).of(0.4)
+      expect(summary['percentiles'][50]).to be_within(1e-9).of(0.2)
+    end
+
+    it 'skips non-numeric feature values entirely' do
+      summary = result.dig('windows', '24h', 'first_negative_signal_at')
+
+      expect(summary['n']).to eq 0
+      expect(summary['min']).to be_nil
+      expect(summary['percentiles'][50]).to be_nil
+    end
+  end
+
+  describe 'empty cohort' do
+    it 'returns zeroed summaries without error' do
+      result = described_class.new.call([], now: now, windows: { '24h' => 24.hours }, features: %w(contacts_total))
+
+      expect(result['subject_count']).to eq 0
+      expect(result.dig('windows', '24h', 'contacts_total', 'n')).to eq 0
+      expect(result.dig('windows', 'lifetime', 'contacts_total', 'percentiles')[50]).to be_nil
+    end
+  end
+
+  describe 'end-to-end wiring with the real metrics service' do
+    let(:actor) { Fabricate(:account, username: 'dist_actor') }
+    let(:other) { Fabricate(:account, username: 'dist_actor_2') }
+
+    before do
+      Moderation::EventRecorder.record_interaction(actor: actor, target: Fabricate(:account), event_type: :follow, occurred_at: now - 10.minutes, source_event_key: 'd-1')
+      Moderation::EventRecorder.record_interaction(actor: actor, target: Fabricate(:account), event_type: :favourite, occurred_at: now - 5.minutes, source_event_key: 'd-2')
+    end
+
+    it 'aggregates real per-subject metrics into a distribution' do
+      subjects = [ModerationSubject.find_by(account_id: actor.id), ModerationSubject.for_account!(other)]
+
+      result = described_class.new.call(subjects, now: now, windows: { '24h' => 24.hours })
+
+      # actor has 2 contacts in 24h, other has 0.
+      summary = result.dig('windows', '24h', 'contacts_total')
+      expect(result['subject_count']).to eq 2
+      expect(summary['n']).to eq 2
+      expect(summary['max']).to eq 2
+      expect(summary['nonzero']).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the Observation / Calibration phase: a **read-only, analysis-only** service, `Moderation::MetricsDistributionService`, that aggregates `Moderation::BehavioralMetricsService` (PR #40) output across a caller-supplied set of subjects into per-window, per-feature **distribution summaries**, so an operator can inspect how each behavioural feature is distributed across a chosen cohort and reason about thresholds later. No scoring yet.

## Guardrails honored

- **Read-only** (reads via `BehavioralMetricsService`, writes nothing); **no scoring/thresholds/labels/recommendations/enforcement**; **no population scan** (caller supplies the subject set); no DB migration.

## Feature eligibility (calibration correctness)

`BehavioralMetricsService` returns `0.0`/`0` for not-applicable metrics (zero denominator, or no negative signal), which would skew a distribution if aggregated as real zeros. This service now applies **per-feature eligibility**, excluding not-applicable values (counted as `excluded_n`) while still keeping an eligible subject's genuine `0`:

- raw counts (`contacts_total`, `unique_targets`, `follows`, `unique_follow_targets`, rejections, responders …): all subjects eligible;
- `negative_response_rate` / `linked_negative_rate`: `unique_targets > 0`;
- `follow_reject_rate`: `unique_follow_targets > 0`;
- `new_targets_after_first_negative_signal` / `follows_after_first_negative_signal`: `first_negative_signal_at` present.

Each summary reports `n` (eligible sample), `excluded_n`, `nonzero`, `min`, `max`, `mean`, and linear-interpolated `percentiles` (p10–p99). `subject_count` is the whole cohort, and **subjects repeated in the input are de-duplicated by id** so they are not double-counted.

`follow_reject_rate` eligibility needs the true denominator, so **`BehavioralMetricsService` now also returns `unique_follow_targets`** (distinct in-window followed targets) rather than reusing the `follows` event count.

## Scope / deferrals (per roadmap)

Provides the calibration *data*. Still deferred: automatic cohort classification, the backtest simulation, risk scoring, and enforcement.

## Testing

```
$ bundle exec rspec spec/services/moderation/metrics_distribution_service_spec.rb \
    spec/services/moderation/behavioral_metrics_service_spec.rb
26 examples, 0 failures

$ bundle exec rspec spec/services/moderation spec/models/moderation
87 examples, 0 failures
```

Covers the distribution math (percentiles p25=10/p50=20/p90=36/p95=38, `excluded_n`=0 for a raw count), and the requested eligibility cases:
1. no-contacts subject excluded from `negative_response_rate`;
2. contacted subject with genuine `0.0` included;
3. no-negative-signal subject excluded from continuation;
4. negative-signal subject with `0` continuation included as a genuine 0;
5. no-followed-targets subject excluded from `follow_reject_rate`.
Plus de-duplication (a repeated subject counted once), the empty cohort, and end-to-end wiring with the real metrics service (eligibility applied on real data). `BehavioralMetricsService` spec now asserts `unique_follow_targets`.

Head: `94efbe1b7530f29434e10941c0fa323517b68356`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

