### PR TITLE
Moderation ledger: advisory moderator recommendation policy (PR 13)

### DIFF
--- a/app/services/moderation/moderator_recommendation_service.rb
+++ b/app/services/moderation/moderator_recommendation_service.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# Maps a subject's risk *evaluation* (Moderation::RiskEvaluationService sub-scores)
+# to an ADVISORY moderator-review tier. This is the decision-policy layer, kept
+# separate from evaluation and from execution:
+#
+#   * Advisory only — the output is a review recommendation for a human
+#     (normal / watch / review_recommended / urgent_review). It performs NO
+#     enforcement and executes NO action; it just tells a moderator what to look
+#     at first. There is no action/enforcement in the output.
+#   * Read-only — it computes the evaluation (itself read-only) and writes nothing.
+#   * Explainable & auditable — every recommendation lists the matched rules and
+#     the sub-scores that triggered them, and embeds the full evaluation (with its
+#     reason codes). policy_version + params_digest identify the policy.
+#   * No single score — tiers come from transparent rules over individual
+#     sub-scores, not from summing them into one number.
+#
+# The thresholds in DEFAULT_PARAMS are INITIAL and UNCALIBRATED (and injectable),
+# to be tuned from real cohorts before this is wired to anything beyond a review
+# queue. Nothing here escalates on a single block/mute (the rejection sub-score
+# already requires multiple independent responders) and follow-import remains
+# deferred upstream.
+module Moderation
+  class ModeratorRecommendationService
+    POLICY_VERSION = 'reco-policy-v0-2026-09-12'
+
+    # Ordered from least to most urgent; used to pick the highest matched tier.
+    TIERS = %w(normal watch review_recommended urgent_review).freeze
+
+    DEFAULT_PARAMS = {
+      # Strongest collective-harm shape: sustained rejection by multiple
+      # independent responders AND continued contact after the first signal.
+      'urgent_review' => {
+        'rejection_min'       => 0.8,
+        'repeat_behavior_min' => 0.6,
+      },
+      'review_recommended' => {
+        'rejection_min' => 0.5, # multiple independent rejectors present
+        'report_min'    => 0.4, # at least one report
+        'contact_and_velocity' => { 'contact_volume_min' => 0.5, 'velocity_min' => 0.6 },
+      },
+      'watch' => {
+        'any_subscore_min' => 0.5, # any single elevated dimension
+      },
+    }.freeze
+
+    def initialize(evaluator: Moderation::RiskEvaluationService.new, params: DEFAULT_PARAMS, policy_version: nil)
+      @evaluator      = evaluator
+      @params         = params
+      @policy_version = policy_version || (params == DEFAULT_PARAMS ? POLICY_VERSION : 'custom')
+      @params_digest  = digest(@params)
+    end
+
+    def call(subject_or_account, now: Time.now.utc)
+      evaluation = @evaluator.call(subject_or_account, now: now)
+      scores     = subscore_map(evaluation)
+      matched    = matched_rules(scores)
+
+      {
+        'policy_version' => @policy_version,
+        'params_digest'  => @params_digest,
+        'subject_id'     => evaluation['subject_id'],
+        'generated_at'   => now.iso8601,
+        # Advisory review tier for a human queue — NOT an enforcement action.
+        'recommendation' => highest_tier(matched),
+        'advisory'       => true,
+        'matched_rules'  => matched,
+        'evaluation'     => evaluation,
+      }
+    end
+
+    private
+
+    def subscore_map(evaluation)
+      (evaluation['subscores'] || {}).transform_values { |sub| sub['score'].to_f }
+    end
+
+    def matched_rules(scores)
+      rules = []
+
+      urgent = @params['urgent_review']
+      if scores['rejection'].to_f >= urgent['rejection_min'] && scores['repeat_behavior'].to_f >= urgent['repeat_behavior_min']
+        rules << rule('urgent_review', 'sustained_rejection_with_continuation', 'rejection' => scores['rejection'], 'repeat_behavior' => scores['repeat_behavior'])
+      end
+
+      review = @params['review_recommended']
+      rules << rule('review_recommended', 'multiple_independent_rejectors', 'rejection' => scores['rejection']) if scores['rejection'].to_f >= review['rejection_min']
+      rules << rule('review_recommended', 'reports_present', 'report' => scores['report']) if scores['report'].to_f >= review['report_min']
+
+      cv = review['contact_and_velocity']
+      if scores['contact_volume'].to_f >= cv['contact_volume_min'] && scores['velocity'].to_f >= cv['velocity_min']
+        rules << rule('review_recommended', 'high_volume_and_velocity', 'contact_volume' => scores['contact_volume'], 'velocity' => scores['velocity'])
+      end
+
+      watch_min = @params['watch']['any_subscore_min']
+      scores.each do |dimension, score|
+        rules << rule('watch', "elevated_#{dimension}", dimension => score) if score >= watch_min
+      end
+
+      rules
+    end
+
+    def rule(tier, name, subscores)
+      { 'tier' => tier, 'rule' => name, 'subscores' => subscores }
+    end
+
+    def highest_tier(matched)
+      matched.map { |r| r['tier'] }.max_by { |tier| TIERS.index(tier) || -1 } || 'normal'
+    end
+
+    def digest(params)
+      "sha256:#{Digest::SHA256.hexdigest(canonicalize(params).to_json)}"
+    end
+
+    def canonicalize(object)
+      case object
+      when Hash then object.keys.sort_by(&:to_s).to_h { |key| [key.to_s, canonicalize(object[key])] }
+      when Array then object.map { |element| canonicalize(element) }
+      else object
+      end
+    end
+  end
+end

--- a/app/services/moderation/moderator_recommendation_service.rb
+++ b/app/services/moderation/moderator_recommendation_service.rb
@@ -40,7 +40,13 @@ module Moderation
         'contact_and_velocity' => { 'contact_volume_min' => 0.5, 'velocity_min' => 0.6 },
       },
       'watch' => {
-        'any_subscore_min' => 0.5, # any single elevated dimension
+        'any_subscore_min' => 0.5,
+        # Explicit allowlist: only these dimensions can raise a watch. A new
+        # sub-score added upstream (e.g. follow_import once relationship-aware
+        # scoring lands) must be added here — with a policy_version bump — before
+        # it can affect a recommendation. This keeps evaluation and decision
+        # policy decoupled. follow_import is intentionally excluded for now.
+        'dimensions' => %w(contact_volume velocity rejection report repeat_behavior),
       },
     }.freeze
 
@@ -80,28 +86,44 @@ module Moderation
 
       urgent = @params['urgent_review']
       if scores['rejection'].to_f >= urgent['rejection_min'] && scores['repeat_behavior'].to_f >= urgent['repeat_behavior_min']
-        rules << rule('urgent_review', 'sustained_rejection_with_continuation', 'rejection' => scores['rejection'], 'repeat_behavior' => scores['repeat_behavior'])
+        rules << rule('urgent_review', 'sustained_rejection_with_continuation',
+                      'rejection' => condition(scores['rejection'], urgent['rejection_min']),
+                      'repeat_behavior' => condition(scores['repeat_behavior'], urgent['repeat_behavior_min']))
       end
 
       review = @params['review_recommended']
-      rules << rule('review_recommended', 'multiple_independent_rejectors', 'rejection' => scores['rejection']) if scores['rejection'].to_f >= review['rejection_min']
-      rules << rule('review_recommended', 'reports_present', 'report' => scores['report']) if scores['report'].to_f >= review['report_min']
+      rules << rule('review_recommended', 'multiple_independent_rejectors', 'rejection' => condition(scores['rejection'], review['rejection_min'])) if scores['rejection'].to_f >= review['rejection_min']
+      rules << rule('review_recommended', 'reports_present', 'report' => condition(scores['report'], review['report_min'])) if scores['report'].to_f >= review['report_min']
 
       cv = review['contact_and_velocity']
       if scores['contact_volume'].to_f >= cv['contact_volume_min'] && scores['velocity'].to_f >= cv['velocity_min']
-        rules << rule('review_recommended', 'high_volume_and_velocity', 'contact_volume' => scores['contact_volume'], 'velocity' => scores['velocity'])
+        rules << rule('review_recommended', 'high_volume_and_velocity',
+                      'contact_volume' => condition(scores['contact_volume'], cv['contact_volume_min']),
+                      'velocity' => condition(scores['velocity'], cv['velocity_min']))
       end
 
-      watch_min = @params['watch']['any_subscore_min']
-      scores.each do |dimension, score|
-        rules << rule('watch', "elevated_#{dimension}", dimension => score) if score >= watch_min
+      watch     = @params['watch']
+      watch_min = watch['any_subscore_min']
+      # Only allowlisted dimensions can raise a watch; unknown/new dimensions are
+      # ignored until the policy explicitly adds them (with a version bump).
+      Array(watch['dimensions']).each do |dimension|
+        next unless scores.key?(dimension)
+
+        score = scores[dimension].to_f
+        rules << rule('watch', "elevated_#{dimension}", dimension => condition(score, watch_min)) if score >= watch_min
       end
 
       rules
     end
 
-    def rule(tier, name, subscores)
-      { 'tier' => tier, 'rule' => name, 'subscores' => subscores }
+    def rule(tier, name, conditions)
+      { 'tier' => tier, 'rule' => name, 'conditions' => conditions }
+    end
+
+    # A firing condition surfaced for audit/UI: the observed value and the
+    # minimum it had to meet.
+    def condition(value, minimum)
+      { 'value' => value.to_f, 'minimum' => minimum }
     end
 
     def highest_tier(matched)

--- a/spec/services/moderation/moderator_recommendation_service_spec.rb
+++ b/spec/services/moderation/moderator_recommendation_service_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::ModeratorRecommendationService do
+  let(:now) { Time.now.utc }
+
+  DIMENSIONS = %w(contact_volume velocity rejection report follow_import repeat_behavior).freeze
+
+  # Build a canned RiskEvaluationService output with the given sub-score values.
+  def evaluation(**scores)
+    subscores = DIMENSIONS.index_with do |dimension|
+      { 'score' => scores.fetch(dimension.to_sym, 0.0), 'reason_codes' => [] }
+    end
+
+    {
+      'policy_version' => 'risk-eval-v0-test',
+      'params_digest'  => 'sha256:test',
+      'subject_id'     => 1,
+      'generated_at'   => now.iso8601,
+      'subscores'      => subscores,
+    }
+  end
+
+  def recommend(canned, params: described_class::DEFAULT_PARAMS, policy_version: nil)
+    evaluator = instance_double(Moderation::RiskEvaluationService, call: canned)
+    described_class.new(evaluator: evaluator, params: params, policy_version: policy_version)
+                   .call(ModerationSubject.new.tap { |s| s.id = 1 }, now: now)
+  end
+
+  describe 'output shape' do
+    it 'is advisory, versioned, and carries no enforcement/action' do
+      result = recommend(evaluation)
+
+      expect(result['policy_version']).to eq described_class::POLICY_VERSION
+      expect(result['params_digest']).to start_with('sha256:')
+      expect(result['advisory']).to be true
+      expect(result['recommendation']).to eq 'normal'
+      expect(result).to_not have_key('action')
+      expect(result).to_not have_key('enforcement')
+      expect(result).to_not have_key('overall_score')
+      # The full evaluation is embedded for auditability.
+      expect(result['evaluation']['subscores']).to be_present
+    end
+  end
+
+  describe 'tiers' do
+    it 'recommends normal when nothing is elevated' do
+      expect(recommend(evaluation)['recommendation']).to eq 'normal'
+    end
+
+    it 'recommends watch for a single elevated dimension' do
+      result = recommend(evaluation(contact_volume: 0.5))
+      expect(result['recommendation']).to eq 'watch'
+      expect(result['matched_rules']).to include(a_hash_including('tier' => 'watch', 'rule' => 'elevated_contact_volume'))
+    end
+
+    it 'recommends review_recommended when multiple independent rejectors are present' do
+      result = recommend(evaluation(rejection: 0.5))
+      expect(result['recommendation']).to eq 'review_recommended'
+      expect(result['matched_rules']).to include(a_hash_including('rule' => 'multiple_independent_rejectors', 'subscores' => { 'rejection' => 0.5 }))
+    end
+
+    it 'recommends review_recommended when a report is present' do
+      expect(recommend(evaluation(report: 0.4))['recommendation']).to eq 'review_recommended'
+    end
+
+    it 'recommends review_recommended for high volume AND velocity together' do
+      result = recommend(evaluation(contact_volume: 0.6, velocity: 0.6))
+      expect(result['recommendation']).to eq 'review_recommended'
+      expect(result['matched_rules'].map { |r| r['rule'] }).to include('high_volume_and_velocity')
+    end
+
+    it 'recommends urgent_review for sustained rejection with continuation' do
+      result = recommend(evaluation(rejection: 0.8, repeat_behavior: 0.6))
+      expect(result['recommendation']).to eq 'urgent_review'
+      expect(result['matched_rules']).to include(a_hash_including('tier' => 'urgent_review', 'rule' => 'sustained_rejection_with_continuation'))
+    end
+
+    it 'picks the highest matched tier when several rules fire' do
+      # Also matches watch (elevated) and review (multiple rejectors), but urgent wins.
+      result = recommend(evaluation(rejection: 0.9, repeat_behavior: 0.7))
+      tiers = result['matched_rules'].map { |r| r['tier'] }
+      expect(tiers).to include('urgent_review', 'review_recommended', 'watch')
+      expect(result['recommendation']).to eq 'urgent_review'
+    end
+  end
+
+  describe 'guardrails' do
+    it 'does not escalate on a single block/mute (rejection sub-score stays 0)' do
+      # A single block never raises the rejection sub-score above 0 upstream, so
+      # here rejection is 0 and nothing else fires -> normal.
+      expect(recommend(evaluation(rejection: 0.0))['recommendation']).to eq 'normal'
+    end
+
+    it 'never recommends off the deferred follow_import dimension alone' do
+      # follow_import is deferred upstream (always 0); even if some value leaked in
+      # it would only reach watch, never review/urgent, and here it is 0 -> normal.
+      expect(recommend(evaluation(follow_import: 0.0))['recommendation']).to eq 'normal'
+    end
+  end
+
+  describe 'policy versioning' do
+    let(:custom_params) do
+      params = Marshal.load(Marshal.dump(described_class::DEFAULT_PARAMS))
+      params['watch']['any_subscore_min'] = 0.1
+      params
+    end
+
+    it 'marks custom params and changes the digest' do
+      default = recommend(evaluation)
+      custom  = recommend(evaluation, params: custom_params)
+
+      expect(custom['policy_version']).to eq 'custom'
+      expect(custom['params_digest']).to_not eq default['params_digest']
+    end
+
+    it 'honors an explicit policy_version' do
+      expect(recommend(evaluation, params: custom_params, policy_version: 'reco-experiment-A')['policy_version']).to eq 'reco-experiment-A'
+    end
+  end
+
+  describe 'read-only over a real account' do
+    it 'recommends normal for an account with no history without writing' do
+      account = Fabricate(:account, username: 'reco_fresh')
+
+      result = nil
+      expect { result = described_class.new.call(account, now: now) }.to_not change(ModerationSubject, :count)
+
+      expect(result['recommendation']).to eq 'normal'
+      expect(result['subject_id']).to be_nil
+    end
+  end
+end

--- a/spec/services/moderation/moderator_recommendation_service_spec.rb
+++ b/spec/services/moderation/moderator_recommendation_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Moderation::ModeratorRecommendationService do
   DIMENSIONS = %w(contact_volume velocity rejection report follow_import repeat_behavior).freeze
 
   # Build a canned RiskEvaluationService output with the given sub-score values.
-  def evaluation(**scores)
+  # +extra+ injects additional (possibly unknown) dimensions.
+  def evaluation(extra: {}, **scores)
     subscores = DIMENSIONS.index_with do |dimension|
       { 'score' => scores.fetch(dimension.to_sym, 0.0), 'reason_codes' => [] }
     end
+    extra.each { |dimension, score| subscores[dimension.to_s] = { 'score' => score, 'reason_codes' => [] } }
 
     {
       'policy_version' => 'risk-eval-v0-test',
@@ -58,7 +60,9 @@ RSpec.describe Moderation::ModeratorRecommendationService do
     it 'recommends review_recommended when multiple independent rejectors are present' do
       result = recommend(evaluation(rejection: 0.5))
       expect(result['recommendation']).to eq 'review_recommended'
-      expect(result['matched_rules']).to include(a_hash_including('rule' => 'multiple_independent_rejectors', 'subscores' => { 'rejection' => 0.5 }))
+      expect(result['matched_rules']).to include(
+        a_hash_including('rule' => 'multiple_independent_rejectors', 'conditions' => { 'rejection' => { 'value' => 0.5, 'minimum' => 0.5 } })
+      )
     end
 
     it 'recommends review_recommended when a report is present' do
@@ -93,10 +97,20 @@ RSpec.describe Moderation::ModeratorRecommendationService do
       expect(recommend(evaluation(rejection: 0.0))['recommendation']).to eq 'normal'
     end
 
-    it 'never recommends off the deferred follow_import dimension alone' do
-      # follow_import is deferred upstream (always 0); even if some value leaked in
-      # it would only reach watch, never review/urgent, and here it is 0 -> normal.
-      expect(recommend(evaluation(follow_import: 0.0))['recommendation']).to eq 'normal'
+    it 'never recommends off the deferred follow_import dimension, even if it scored high' do
+      # follow_import is not in the watch allowlist and is used by no rule, so even
+      # a leaked high score must not affect the recommendation.
+      result = recommend(evaluation(follow_import: 1.0))
+      expect(result['recommendation']).to eq 'normal'
+      expect(result['matched_rules']).to be_empty
+    end
+
+    it 'ignores an unknown/new sub-score dimension until the policy allowlists it' do
+      # A brand-new dimension added upstream must not auto-fire watch without a
+      # policy change/version bump.
+      result = recommend(evaluation(extra: { 'brand_new_signal' => 1.0 }))
+      expect(result['recommendation']).to eq 'normal'
+      expect(result['matched_rules']).to be_empty
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Moderation::ModeratorRecommendationService` — the decision-policy layer, kept separate from evaluation and execution. It maps `Moderation::RiskEvaluationService` (PR #43) sub-scores to an **advisory** moderator-review tier: `normal` / `watch` / `review_recommended` / `urgent_review`. It only tells a human what to look at first; it performs **no enforcement and executes no action**.

## Design & guardrails

- **Advisory only, no enforcement.** The output's `recommendation` is a review tier for a human queue (`advisory: true`). There is no `action`/`enforcement`/`overall_score` key. Execution (friction/rate-limit/gate) is a later, separate layer.
- **No single score.** Tiers come from transparent rules over individual sub-scores, not from summing them.
- **Read-only.** Computes the evaluation (itself read-only); writes nothing; creates no `ModerationSubject`.
- **Explainable & auditable.** Every result lists `matched_rules` (tier + rule name + the triggering sub-scores) and embeds the full `evaluation` (with its reason codes). `policy_version` + `params_digest` identify the policy; custom params become `"custom"` unless an explicit `policy_version:` is injected.
- **UNCALIBRATED, injectable thresholds** in `DEFAULT_PARAMS`, to be tuned from real cohorts before this is wired past a review queue.

Tier rules (initial):
- **urgent_review**: `rejection >= 0.8` AND `repeat_behavior >= 0.6` (sustained rejection by multiple independent responders + continued contact after the first signal).
- **review_recommended**: `rejection >= 0.5` (multiple independent rejectors), OR `report >= 0.4`, OR `contact_volume >= 0.5` AND `velocity >= 0.6`.
- **watch**: any single sub-score `>= 0.5`.
- **normal**: otherwise.

Guardrails preserved from upstream: a single block/mute never escalates (the rejection sub-score requires multiple independent responders, so it stays 0), and `follow_import` remains deferred (always 0) so it never drives a recommendation.

## Scope / deferrals (per roadmap)

Recommendation only. Deferred: the Adaptive Follow Gate (PR 14), any enforcement/friction, threshold calibration, an admin queue UI, and Move-aware relationship confidence.

## Testing

```
$ bundle exec rspec spec/services/moderation/moderator_recommendation_service_spec.rb
13 examples, 0 failures

$ bundle exec rspec spec/services/moderation
104 examples, 0 failures
```

Covers: the advisory/versioned output shape (no action/enforcement/overall key; evaluation embedded); each tier (normal/watch/review_recommended via each of its rules/urgent_review); highest-tier-wins when several rules fire; guardrails (single block → normal; deferred follow_import → normal); policy versioning (custom digest + `"custom"`/explicit version); and read-only over a real account with no history.

Head: `c8ddf1c1c6a4338d4828764868cc1af9f30c79b7`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

