### PR TITLE
Moderation ledger: adaptive follow-gate decision (shadow, decision-only) (PR 14)

### DIFF
--- a/app/services/moderation/adaptive_follow_gate_decision_service.rb
+++ b/app/services/moderation/adaptive_follow_gate_decision_service.rb
@@ -39,7 +39,8 @@ module Moderation
       'moderator_review' => { 'rejection_min' => 0.8, 'repeat_behavior_min' => 0.6 },
       # Slow the attempt down so rejection feedback can arrive before more follows.
       'delay' => { 'velocity_min' => 0.6, 'remote_or_unknown_rejection_min' => 0.5 },
-      # Local recipient can confirm; only meaningful for a local target.
+      # Local UNLOCKED recipient can confirm; only meaningful for a target that
+      # would otherwise be followed immediately (locked targets already confirm).
       'confirm_target' => { 'local_rejection_min' => 0.5 },
       # Lightest friction for elevated volume/velocity.
       'rate_limit' => { 'contact_volume_min' => 0.5, 'velocity_min' => 0.5 },
@@ -116,11 +117,17 @@ module Moderation
                       'target_locality' => locality)
       end
 
+      # confirm_target only adds friction to a follow that would otherwise be
+      # immediate: a LOCAL, UNLOCKED target. A locked local target already goes
+      # through follow-request approval, so proposing confirmation there is
+      # redundant (and would inflate shadow counts). Unknown locked state (nil)
+      # is treated as not-applicable, so it does not fire either.
       confirm = @params['confirm_target']
-      if locality == 'local' && scores['rejection'].to_f >= confirm['local_rejection_min']
-        rules << rule('confirm_target', 'elevated_rejection_local_target',
+      if locality == 'local' && context['target_locked'] == false && scores['rejection'].to_f >= confirm['local_rejection_min']
+        rules << rule('confirm_target', 'elevated_rejection_local_unlocked_target',
                       'rejection' => condition(scores['rejection'], confirm['local_rejection_min']),
-                      'target_locality' => 'local')
+                      'target_locality' => 'local',
+                      'target_locked' => false)
       end
 
       rate = @params['rate_limit']

--- a/app/services/moderation/adaptive_follow_gate_decision_service.rb
+++ b/app/services/moderation/adaptive_follow_gate_decision_service.rb
@@ -55,8 +55,11 @@ module Moderation
 
     # +context+ describes the follow attempt. Recognised keys: mechanism,
     # target_locality ('local'/'remote'), target_locked, relationship_context.
-    # Only target_locality influences the proposal (locality routes confirm vs
-    # delay); the rest are echoed for observability but never raise risk.
+    # target_locality and target_locked affect applicability/routing only
+    # (locality routes confirm_target vs delay; target_locked gates confirm_target
+    # to local UNLOCKED targets). mechanism and relationship_context are echoed for
+    # observability but never raise risk. None of these introduce new risk; they
+    # only route/limit which reversible friction applies.
     def call(subject_or_account, context: {}, now: Time.now.utc)
       evaluation = @evaluator.call(subject_or_account, now: now)
       scores     = subscore_map(evaluation)

--- a/app/services/moderation/adaptive_follow_gate_decision_service.rb
+++ b/app/services/moderation/adaptive_follow_gate_decision_service.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+# Proposes an adaptive, REVERSIBLE friction for an individual follow attempt, from
+# a subject's risk evaluation plus the attempt context. This is a decision-only /
+# shadow layer:
+#
+#   * Decision-only, no execution — it returns a *proposed* friction and changes
+#     nothing. It performs no enforcement, executes no action, and never denies or
+#     suspends. FollowService / ImportService are untouched by this PR.
+#   * Reversible frictions only — allow / rate_limit / confirm_target / delay /
+#     moderator_review. No deny/hard-block here.
+#   * Separate policy from Moderation::ModeratorRecommendationService: that ranks
+#     a subject for human review; this proposes friction for one follow attempt.
+#     Both read the same evaluation but are independent, versioned policies.
+#   * Behaviour-centric, mechanism-agnostic — the attempt mechanism (manual_ui /
+#     api / follow_import / migration) is echoed for observability but NEVER
+#     raises risk, because abusers channel-shift between mechanisms. Follow-import
+#     is not itself a risk signal, and unresolved_target_ratio is NOT used as an
+#     unknown-relationship proxy.
+#   * No inference of unimplemented features — relationship context in the attempt
+#     is echoed but not used for risk (relationship-aware scoring is not built yet).
+#   * Read-only, versioned & auditable — policy_version + params_digest identify
+#     the policy; matched_rules carry each firing condition's value + minimum.
+#
+# Thresholds in DEFAULT_PARAMS are INITIAL and UNCALIBRATED (and injectable).
+module Moderation
+  class AdaptiveFollowGateDecisionService
+    POLICY_VERSION = 'follow-gate-decision-v0-2026-09-12'
+
+    # Reversible frictions, ordered least -> most (used to pick the strongest
+    # matched proposal). There is deliberately no "deny".
+    FRICTIONS = %w(allow rate_limit confirm_target delay moderator_review).freeze
+
+    TARGET_LOCALITIES = %w(local remote).freeze
+
+    DEFAULT_PARAMS = {
+      # Strongest reversible friction: sustained rejection by multiple independent
+      # responders AND continued contact after the first negative signal.
+      'moderator_review' => { 'rejection_min' => 0.8, 'repeat_behavior_min' => 0.6 },
+      # Slow the attempt down so rejection feedback can arrive before more follows.
+      'delay' => { 'velocity_min' => 0.6, 'remote_or_unknown_rejection_min' => 0.5 },
+      # Local recipient can confirm; only meaningful for a local target.
+      'confirm_target' => { 'local_rejection_min' => 0.5 },
+      # Lightest friction for elevated volume/velocity.
+      'rate_limit' => { 'contact_volume_min' => 0.5, 'velocity_min' => 0.5 },
+    }.freeze
+
+    def initialize(evaluator: Moderation::RiskEvaluationService.new, params: DEFAULT_PARAMS, policy_version: nil)
+      @evaluator      = evaluator
+      @params         = params
+      @policy_version = policy_version || (params == DEFAULT_PARAMS ? POLICY_VERSION : 'custom')
+      @params_digest  = digest(@params)
+    end
+
+    # +context+ describes the follow attempt. Recognised keys: mechanism,
+    # target_locality ('local'/'remote'), target_locked, relationship_context.
+    # Only target_locality influences the proposal (locality routes confirm vs
+    # delay); the rest are echoed for observability but never raise risk.
+    def call(subject_or_account, context: {}, now: Time.now.utc)
+      evaluation = @evaluator.call(subject_or_account, now: now)
+      scores     = subscore_map(evaluation)
+      normalized = normalize_context(context)
+      matched    = matched_rules(scores, normalized)
+
+      {
+        'policy_version'    => @policy_version,
+        'params_digest'     => @params_digest,
+        'subject_id'        => evaluation['subject_id'],
+        'generated_at'      => now.iso8601,
+        'context'           => normalized,
+        # Shadow proposal only — nothing is executed and nothing is denied.
+        'proposed_friction' => strongest_friction(matched),
+        'shadow'            => true,
+        'matched_rules'     => matched,
+        'evaluation'        => evaluation,
+      }
+    end
+
+    private
+
+    def subscore_map(evaluation)
+      (evaluation['subscores'] || {}).transform_values { |sub| sub['score'].to_f }
+    end
+
+    def normalize_context(context)
+      context ||= {}
+      locality = context['target_locality'] || context[:target_locality]
+      locality = nil unless TARGET_LOCALITIES.include?(locality)
+
+      {
+        # Echoed for observability; mechanism NEVER changes the proposal.
+        'mechanism'            => context['mechanism'] || context[:mechanism],
+        'target_locality'      => locality,
+        'target_locked'        => context['target_locked'].nil? ? context[:target_locked] : context['target_locked'],
+        # Echoed but NOT used for risk (relationship-aware scoring not implemented).
+        'relationship_context' => context['relationship_context'] || context[:relationship_context],
+      }
+    end
+
+    def matched_rules(scores, context)
+      rules    = []
+      locality = context['target_locality']
+
+      review = @params['moderator_review']
+      if scores['rejection'].to_f >= review['rejection_min'] && scores['repeat_behavior'].to_f >= review['repeat_behavior_min']
+        rules << rule('moderator_review', 'sustained_rejection_with_continuation',
+                      'rejection' => condition(scores['rejection'], review['rejection_min']),
+                      'repeat_behavior' => condition(scores['repeat_behavior'], review['repeat_behavior_min']))
+      end
+
+      delay = @params['delay']
+      rules << rule('delay', 'high_velocity', 'velocity' => condition(scores['velocity'], delay['velocity_min'])) if scores['velocity'].to_f >= delay['velocity_min']
+      if locality != 'local' && scores['rejection'].to_f >= delay['remote_or_unknown_rejection_min']
+        rules << rule('delay', 'elevated_rejection_non_local_target',
+                      'rejection' => condition(scores['rejection'], delay['remote_or_unknown_rejection_min']),
+                      'target_locality' => locality)
+      end
+
+      confirm = @params['confirm_target']
+      if locality == 'local' && scores['rejection'].to_f >= confirm['local_rejection_min']
+        rules << rule('confirm_target', 'elevated_rejection_local_target',
+                      'rejection' => condition(scores['rejection'], confirm['local_rejection_min']),
+                      'target_locality' => 'local')
+      end
+
+      rate = @params['rate_limit']
+      rules << rule('rate_limit', 'elevated_contact_volume', 'contact_volume' => condition(scores['contact_volume'], rate['contact_volume_min'])) if scores['contact_volume'].to_f >= rate['contact_volume_min']
+      rules << rule('rate_limit', 'elevated_velocity', 'velocity' => condition(scores['velocity'], rate['velocity_min'])) if scores['velocity'].to_f >= rate['velocity_min']
+
+      rules
+    end
+
+    def rule(friction, name, conditions)
+      { 'friction' => friction, 'rule' => name, 'conditions' => conditions }
+    end
+
+    def condition(value, minimum)
+      { 'value' => value.to_f, 'minimum' => minimum }
+    end
+
+    def strongest_friction(matched)
+      matched.map { |r| r['friction'] }.max_by { |friction| FRICTIONS.index(friction) || -1 } || 'allow'
+    end
+
+    def digest(params)
+      "sha256:#{Digest::SHA256.hexdigest(canonicalize(params).to_json)}"
+    end
+
+    def canonicalize(object)
+      case object
+      when Hash then object.keys.sort_by(&:to_s).to_h { |key| [key.to_s, canonicalize(object[key])] }
+      when Array then object.map { |element| canonicalize(element) }
+      else object
+      end
+    end
+  end
+end

--- a/spec/services/moderation/adaptive_follow_gate_decision_service_spec.rb
+++ b/spec/services/moderation/adaptive_follow_gate_decision_service_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::AdaptiveFollowGateDecisionService do
+  let(:now) { Time.now.utc }
+
+  GATE_DIMENSIONS = %w(contact_volume velocity rejection report follow_import repeat_behavior).freeze
+
+  def evaluation(**scores)
+    subscores = GATE_DIMENSIONS.index_with do |dimension|
+      { 'score' => scores.fetch(dimension.to_sym, 0.0), 'reason_codes' => [] }
+    end
+    { 'policy_version' => 'risk-eval-v0-test', 'params_digest' => 'sha256:test', 'subject_id' => 1, 'generated_at' => now.iso8601, 'subscores' => subscores }
+  end
+
+  def decide(canned, context: {}, params: described_class::DEFAULT_PARAMS, policy_version: nil)
+    evaluator = instance_double(Moderation::RiskEvaluationService, call: canned)
+    described_class.new(evaluator: evaluator, params: params, policy_version: policy_version)
+                   .call(ModerationSubject.new.tap { |s| s.id = 1 }, context: context, now: now)
+  end
+
+  describe 'output shape' do
+    it 'is a shadow, versioned proposal with no execution/deny/action' do
+      result = decide(evaluation)
+
+      expect(result['policy_version']).to eq described_class::POLICY_VERSION
+      expect(result['params_digest']).to start_with('sha256:')
+      expect(result['shadow']).to be true
+      expect(result['proposed_friction']).to eq 'allow'
+      expect(described_class::FRICTIONS).to_not include('deny')
+      expect(result).to_not have_key('action')
+      expect(result).to_not have_key('enforcement')
+      expect(result).to_not have_key('overall_score')
+      expect(result['evaluation']['subscores']).to be_present
+    end
+  end
+
+  describe 'friction ladder' do
+    it 'proposes allow when nothing is elevated' do
+      expect(decide(evaluation)['proposed_friction']).to eq 'allow'
+    end
+
+    it 'proposes rate_limit for elevated contact volume' do
+      result = decide(evaluation(contact_volume: 0.5))
+      expect(result['proposed_friction']).to eq 'rate_limit'
+      expect(result['matched_rules']).to include(a_hash_including('friction' => 'rate_limit', 'rule' => 'elevated_contact_volume'))
+    end
+
+    it 'proposes confirm_target for a local target with multiple independent rejectors' do
+      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'local' })
+      expect(result['proposed_friction']).to eq 'confirm_target'
+      expect(result['matched_rules']).to include(
+        a_hash_including('rule' => 'elevated_rejection_local_target', 'conditions' => a_hash_including('rejection' => { 'value' => 0.5, 'minimum' => 0.5 }))
+      )
+    end
+
+    it 'proposes delay for a remote target with elevated rejection' do
+      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'remote' })
+      expect(result['proposed_friction']).to eq 'delay'
+    end
+
+    it 'proposes delay on high velocity regardless of locality' do
+      expect(decide(evaluation(velocity: 0.6), context: { 'target_locality' => 'local' })['proposed_friction']).to eq 'delay'
+    end
+
+    it 'proposes moderator_review for sustained rejection with continuation' do
+      result = decide(evaluation(rejection: 0.8, repeat_behavior: 0.6))
+      expect(result['proposed_friction']).to eq 'moderator_review'
+      expect(result['matched_rules']).to include(a_hash_including('friction' => 'moderator_review', 'rule' => 'sustained_rejection_with_continuation'))
+    end
+
+    it 'picks the strongest matched friction when several apply' do
+      # elevated volume (rate_limit) + high velocity (delay) + sustained rejection (moderator_review)
+      result = decide(evaluation(contact_volume: 0.6, velocity: 0.7, rejection: 0.9, repeat_behavior: 0.7))
+      expect(result['proposed_friction']).to eq 'moderator_review'
+    end
+  end
+
+  describe 'behaviour-centric / mechanism-agnostic' do
+    it 'does not raise friction based on the follow_import mechanism' do
+      result = decide(evaluation, context: { 'mechanism' => 'follow_import', 'target_locality' => 'remote' })
+      expect(result['proposed_friction']).to eq 'allow'
+      expect(result['context']['mechanism']).to eq 'follow_import'
+    end
+
+    it 'echoes but does not use relationship_context for risk' do
+      result = decide(evaluation, context: { 'relationship_context' => 'migration_known_follow' })
+      expect(result['proposed_friction']).to eq 'allow'
+      expect(result['context']['relationship_context']).to eq 'migration_known_follow'
+    end
+
+    it 'ignores an unrecognized target_locality value' do
+      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'bogus' })
+      # Unknown locality is treated as non-local -> delay (not confirm_target).
+      expect(result['context']['target_locality']).to be_nil
+      expect(result['proposed_friction']).to eq 'delay'
+    end
+  end
+
+  describe 'guardrails' do
+    it 'never escalates on a single block/mute (rejection stays 0)' do
+      expect(decide(evaluation(rejection: 0.0), context: { 'target_locality' => 'local' })['proposed_friction']).to eq 'allow'
+    end
+
+    it 'never proposes deny' do
+      result = decide(evaluation(rejection: 1.0, repeat_behavior: 1.0, velocity: 1.0, contact_volume: 1.0))
+      expect(described_class::FRICTIONS).to include(result['proposed_friction'])
+      expect(result['proposed_friction']).to eq 'moderator_review'
+    end
+  end
+
+  describe 'policy versioning' do
+    let(:custom_params) do
+      params = Marshal.load(Marshal.dump(described_class::DEFAULT_PARAMS))
+      params['rate_limit']['contact_volume_min'] = 0.1
+      params
+    end
+
+    it 'marks custom params and changes the digest' do
+      default = decide(evaluation)
+      custom  = decide(evaluation, params: custom_params)
+      expect(custom['policy_version']).to eq 'custom'
+      expect(custom['params_digest']).to_not eq default['params_digest']
+    end
+
+    it 'honors an explicit policy_version' do
+      expect(decide(evaluation, params: custom_params, policy_version: 'gate-experiment-A')['policy_version']).to eq 'gate-experiment-A'
+    end
+  end
+
+  describe 'read-only over a real account' do
+    it 'proposes allow for an account with no history without writing' do
+      account = Fabricate(:account, username: 'gate_fresh')
+
+      result = nil
+      expect { result = described_class.new.call(account, context: { 'target_locality' => 'remote' }, now: now) }.to_not change(ModerationSubject, :count)
+
+      expect(result['proposed_friction']).to eq 'allow'
+      expect(result['subject_id']).to be_nil
+    end
+  end
+end

--- a/spec/services/moderation/adaptive_follow_gate_decision_service_spec.rb
+++ b/spec/services/moderation/adaptive_follow_gate_decision_service_spec.rb
@@ -47,12 +47,28 @@ RSpec.describe Moderation::AdaptiveFollowGateDecisionService do
       expect(result['matched_rules']).to include(a_hash_including('friction' => 'rate_limit', 'rule' => 'elevated_contact_volume'))
     end
 
-    it 'proposes confirm_target for a local target with multiple independent rejectors' do
-      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'local' })
+    it 'proposes confirm_target for a local UNLOCKED target with multiple independent rejectors' do
+      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'local', 'target_locked' => false })
       expect(result['proposed_friction']).to eq 'confirm_target'
       expect(result['matched_rules']).to include(
-        a_hash_including('rule' => 'elevated_rejection_local_target', 'conditions' => a_hash_including('rejection' => { 'value' => 0.5, 'minimum' => 0.5 }))
+        a_hash_including('rule' => 'elevated_rejection_local_unlocked_target', 'conditions' => a_hash_including('rejection' => { 'value' => 0.5, 'minimum' => 0.5 }))
       )
+    end
+
+    it 'does NOT propose confirm_target for a locked local target (already approval-gated)' do
+      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'local', 'target_locked' => true })
+      expect(result['proposed_friction']).to eq 'allow'
+      expect(result['matched_rules'].map { |r| r['rule'] }).to_not include('elevated_rejection_local_unlocked_target')
+    end
+
+    it 'does NOT propose confirm_target when locked state is unknown (nil)' do
+      result = decide(evaluation(rejection: 0.5), context: { 'target_locality' => 'local' })
+      expect(result['matched_rules'].map { |r| r['rule'] }).to_not include('elevated_rejection_local_unlocked_target')
+    end
+
+    it 'still applies other frictions to a locked local target (e.g. delay on high velocity)' do
+      result = decide(evaluation(velocity: 0.6), context: { 'target_locality' => 'local', 'target_locked' => true })
+      expect(result['proposed_friction']).to eq 'delay'
     end
 
     it 'proposes delay for a remote target with elevated rejection' do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Moderation::AdaptiveFollowGateDecisionService` proposes an adaptive, **reversible** friction for an individual follow attempt from the risk evaluation (PR #43) plus the attempt context. Per the plan, this is **decision-only + shadow**: it returns a *proposed* friction and changes nothing — no live follow flow is touched in this PR.

## Design & guardrails

- **Decision-only / shadow.** Output is a `proposed_friction` with `shadow: true`. No enforcement, no execution, and **no deny/suspend**. `FollowService` / `ImportService` are untouched.
- **Reversible frictions only:** `allow` → `rate_limit` → `confirm_target` → `delay` → `moderator_review` (strongest matched wins). `FRICTIONS` deliberately contains no `deny`.
- **Separate policy** from `Moderation::ModeratorRecommendationService` (PR #44): that ranks a subject for human review; this proposes friction for one follow attempt. Same evaluation input, independent versioned policies.
- **Attempt context, behaviour-centric & mechanism-agnostic.** Accepts `mechanism` (manual_ui/api/follow_import/migration), `target_locality`, `target_locked`, `relationship_context`. Only `target_locality` influences the proposal (routes `confirm_target` for local vs `delay` for remote/unknown). **Mechanism never raises risk** (abusers channel-shift), follow-import is not itself a signal, and `unresolved_target_ratio` is not used as an unknown-relationship proxy.
- **No inference of unimplemented features.** `relationship_context` is echoed for observability but not used for risk (relationship-aware scoring isn't built yet).
- **Read-only, versioned & auditable.** `policy_version` + `params_digest`; custom params → `"custom"` unless an explicit `policy_version:` is injected. `matched_rules` carry each firing condition's value + minimum.
- **UNCALIBRATED, injectable thresholds** (`DEFAULT_PARAMS`).

Rules (initial): `moderator_review` = rejection≥0.8 AND repeat_behavior≥0.6; `delay` = velocity≥0.6, or non-local target with rejection≥0.5; `confirm_target` = local target with rejection≥0.5; `rate_limit` = contact_volume≥0.5 or velocity≥0.5.

## Scope / next steps (per plan)

This PR stops at the shadow decision output. Next: shadow integration at the `FollowService` / `ImportService` entry points (evaluate and observe as `would_*`, still no execution) to measure firing frequency / false positives / timing. Real friction only after calibration, starting with the light reversible ones (rate_limit / delay); `confirm_target` / `moderator_review` later; `deny` not implemented.

## Testing

```
$ bundle exec rspec spec/services/moderation/adaptive_follow_gate_decision_service_spec.rb
16 examples, 0 failures

$ bundle exec rspec spec/services/moderation
121 examples, 0 failures
```

Covers: shadow/versioned output shape (no action/enforcement/overall key; `FRICTIONS` has no deny); the friction ladder (allow/rate_limit/confirm_target/delay/moderator_review) incl. locality routing (local→confirm_target, remote/unknown→delay) and high-velocity→delay; strongest-matched-wins; mechanism-agnostic (follow_import mechanism → allow); relationship_context echoed-not-used; unrecognized locality ignored; guardrails (single block → allow; never deny even at all-1.0); policy versioning; read-only over a real account.

Head: `81d389444ff8078ac9d01cdc9fd42178fc834bc4`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

