### PR TITLE
Moderation ledger: shadow-integrate the adaptive follow gate at FollowService (PR 15)

### DIFF
--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -63,6 +63,15 @@ class FollowService < BaseService
         # API / ActivityPub follows leave it nil, so the ledger column stays NULL.
         import_batch_id: @options[:import_batch_id]
       )
+
+      # Shadow observation only (off by default, failure-tolerant, async): records
+      # what friction the adaptive follow gate WOULD propose. It never alters this
+      # follow.
+      Moderation::FollowGateShadowObserver.observe(
+        source_account: @source_account,
+        target_account: @target_account,
+        mechanism: shadow_follow_mechanism
+      )
     end
 
     follow
@@ -80,6 +89,15 @@ class FollowService < BaseService
   def follow_source_event_key(follow)
     uri = follow.try(:uri)
     "activitypub_outbound_follow:#{uri}" if uri.present?
+  end
+
+  # Behaviour-neutral attempt mechanism for the shadow follow-gate observation
+  # (echoed, never used to raise risk). Derived from existing options.
+  def shadow_follow_mechanism
+    return 'follow_import' if @options[:import_batch_id].present?
+    return 'migration' if @options[:tracking_moved_account]
+
+    nil
   end
 
   def mark_home_feed_as_partial!

--- a/app/services/moderation/follow_gate_shadow_observer.rb
+++ b/app/services/moderation/follow_gate_shadow_observer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Shadow-mode entry point for the adaptive follow gate. It observes what friction
+# the gate *would* propose for a follow attempt, without changing anything:
+#
+#   * Shadow only — it NEVER applies friction, blocks, delays, or alters the
+#     follow. It just records a would-be decision for measurement.
+#   * Off by default — gated behind the MODERATION_FOLLOW_GATE_SHADOW flag, so
+#     merging this changes nothing until an operator turns it on to collect data.
+#   * Failure-tolerant — any error is swallowed and logged; it can never break a
+#     follow.
+#   * Off the hot path — the evaluation (which reads the ledger) runs in a
+#     background worker, so it does not add latency to the follow.
+#
+# The attempt context (mechanism, target locality/locked) is behaviour-neutral:
+# it only routes which reversible friction the (shadow) decision would pick.
+module Moderation
+  class FollowGateShadowObserver
+    class << self
+      def observe(source_account:, target_account:, mechanism: nil)
+        return unless enabled?
+        return if source_account.nil? || target_account.nil?
+
+        Moderation::FollowGateShadowWorker.perform_async(source_account.id, shadow_context(target_account, mechanism))
+      rescue StandardError => e
+        Rails.logger.warn("[Moderation::FollowGateShadowObserver] failed to enqueue shadow observation: #{e.class}: #{e.message}")
+        nil
+      end
+
+      def enabled?
+        ENV['MODERATION_FOLLOW_GATE_SHADOW'].to_s == 'true'
+      end
+
+      private
+
+      def shadow_context(target_account, mechanism)
+        {
+          'mechanism'       => mechanism,
+          'target_locality' => target_account.local? ? 'local' : 'remote',
+          'target_locked'   => target_account.locked? ? true : false,
+        }
+      end
+    end
+  end
+end

--- a/app/services/moderation/follow_gate_shadow_observer.rb
+++ b/app/services/moderation/follow_gate_shadow_observer.rb
@@ -21,7 +21,11 @@ module Moderation
         return unless enabled?
         return if source_account.nil? || target_account.nil?
 
-        Moderation::FollowGateShadowWorker.perform_async(source_account.id, shadow_context(target_account, mechanism))
+        # Capture the attempt time now and pass it through, so the (async) shadow
+        # decision is evaluated as of the follow attempt — not as of worker
+        # execution. This prevents later follows/rejections/blocks from leaking
+        # future events into a past attempt's decision during calibration.
+        Moderation::FollowGateShadowWorker.perform_async(source_account.id, shadow_context(target_account, mechanism), Time.now.utc.iso8601)
       rescue StandardError => e
         Rails.logger.warn("[Moderation::FollowGateShadowObserver] failed to enqueue shadow observation: #{e.class}: #{e.message}")
         nil

--- a/app/workers/moderation/follow_gate_shadow_worker.rb
+++ b/app/workers/moderation/follow_gate_shadow_worker.rb
@@ -4,17 +4,29 @@
 # what friction WOULD have been proposed. It never applies anything — this is
 # pure observation for measuring firing frequency / timing / false positives
 # before any real friction is ever wired in. Failure-tolerant.
+#
+# The decision is evaluated as of +attempted_at+ (the follow attempt time), so
+# events that happen between the attempt and this worker running are not leaked
+# into the attempt's decision.
+#
+# KNOWN LIMITATION / TODO: the observation is keyed by account_id, so if the
+# account is deleted before this runs the observation is lost. Since the ledger
+# keeps a ModerationSubject after account deletion, higher-risk subjects (more
+# likely to be actioned/deleted) would be dropped disproportionately — a
+# selection bias. A future revision should evaluate by ModerationSubject id so
+# shadow data survives account deletion.
 class Moderation::FollowGateShadowWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: 'pull', retry: false
 
-  def perform(account_id, context = {})
+  def perform(account_id, context = {}, attempted_at = nil)
     account = Account.find_by(id: account_id)
     return if account.nil?
 
-    decision = Moderation::AdaptiveFollowGateDecisionService.new.call(account, context: context)
-    Rails.logger.info("[Moderation::FollowGateShadow] #{observation(decision).to_json}")
+    now      = parse_time(attempted_at)
+    decision = Moderation::AdaptiveFollowGateDecisionService.new.call(account, context: context, now: now)
+    Rails.logger.info("[Moderation::FollowGateShadow] #{observation(decision, now).to_json}")
   rescue StandardError => e
     Rails.logger.warn("[Moderation::FollowGateShadowWorker] failed shadow observation: #{e.class}: #{e.message}")
     nil
@@ -22,7 +34,13 @@ class Moderation::FollowGateShadowWorker
 
   private
 
-  def observation(decision)
+  def parse_time(value)
+    value.present? ? Time.iso8601(value) : Time.now.utc
+  rescue ArgumentError
+    Time.now.utc
+  end
+
+  def observation(decision, attempted_at)
     {
       'shadow'             => true,
       'would_friction'     => decision['proposed_friction'],
@@ -31,6 +49,7 @@ class Moderation::FollowGateShadowWorker
       'subject_id'         => decision['subject_id'],
       'context'            => decision['context'],
       'matched_rule_count' => Array(decision['matched_rules']).size,
+      'attempted_at'       => attempted_at.utc.iso8601,
       'observed_at'        => Time.now.utc.iso8601,
     }
   end

--- a/app/workers/moderation/follow_gate_shadow_worker.rb
+++ b/app/workers/moderation/follow_gate_shadow_worker.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Computes the (shadow) adaptive follow-gate decision off the hot path and logs
+# what friction WOULD have been proposed. It never applies anything — this is
+# pure observation for measuring firing frequency / timing / false positives
+# before any real friction is ever wired in. Failure-tolerant.
+class Moderation::FollowGateShadowWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', retry: false
+
+  def perform(account_id, context = {})
+    account = Account.find_by(id: account_id)
+    return if account.nil?
+
+    decision = Moderation::AdaptiveFollowGateDecisionService.new.call(account, context: context)
+    Rails.logger.info("[Moderation::FollowGateShadow] #{observation(decision).to_json}")
+  rescue StandardError => e
+    Rails.logger.warn("[Moderation::FollowGateShadowWorker] failed shadow observation: #{e.class}: #{e.message}")
+    nil
+  end
+
+  private
+
+  def observation(decision)
+    {
+      'shadow'             => true,
+      'would_friction'     => decision['proposed_friction'],
+      'policy_version'     => decision['policy_version'],
+      'params_digest'      => decision['params_digest'],
+      'subject_id'         => decision['subject_id'],
+      'context'            => decision['context'],
+      'matched_rule_count' => Array(decision['matched_rules']).size,
+      'observed_at'        => Time.now.utc.iso8601,
+    }
+  end
+end

--- a/spec/services/moderation/follow_gate_shadow_integration_spec.rb
+++ b/spec/services/moderation/follow_gate_shadow_integration_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# FollowService wiring for the shadow follow-gate observation. The observer is
+# stubbed here so we assert only the wiring (arguments + that the follow still
+# succeeds); the observer/worker behaviour is covered in their own specs.
+RSpec.describe 'FollowService shadow follow-gate wiring', type: :service do
+  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:bob)   { Fabricate(:account, username: 'bob', locked: false) }
+
+  it 'observes the created follow with the source, target and derived mechanism' do
+    expect(Moderation::FollowGateShadowObserver).to receive(:observe).with(
+      source_account: alice, target_account: bob, mechanism: nil
+    )
+
+    follow = FollowService.new.call(alice, bob)
+    expect(follow).to be_present
+  end
+
+  it 'derives the follow_import mechanism when an import batch id is passed' do
+    expect(Moderation::FollowGateShadowObserver).to receive(:observe).with(
+      hash_including(mechanism: 'follow_import')
+    )
+
+    FollowService.new.call(alice, bob, import_batch_id: 123)
+  end
+
+  it 'is safe by default (flag off): the follow succeeds and nothing is enqueued' do
+    # Uses the real observer; with the flag off it no-ops.
+    allow(Moderation::FollowGateShadowObserver).to receive(:enabled?).and_return(false)
+    expect(Moderation::FollowGateShadowWorker).to_not receive(:perform_async)
+
+    follow = FollowService.new.call(alice, bob)
+
+    expect(follow).to be_present
+    expect(alice.following?(bob)).to be true
+  end
+end

--- a/spec/services/moderation/follow_gate_shadow_observer_spec.rb
+++ b/spec/services/moderation/follow_gate_shadow_observer_spec.rb
@@ -19,10 +19,11 @@ RSpec.describe Moderation::FollowGateShadowObserver do
     context 'when the shadow flag is on' do
       before { allow(described_class).to receive(:enabled?).and_return(true) }
 
-      it 'enqueues the shadow worker with a behaviour-neutral context' do
+      it 'enqueues the shadow worker with a behaviour-neutral context and the attempt time' do
         expect(Moderation::FollowGateShadowWorker).to receive(:perform_async).with(
           source.id,
-          { 'mechanism' => 'follow_import', 'target_locality' => 'local', 'target_locked' => true }
+          { 'mechanism' => 'follow_import', 'target_locality' => 'local', 'target_locked' => true },
+          a_string_matching(/\A\d{4}-\d{2}-\d{2}T/)
         )
 
         described_class.observe(source_account: source, target_account: target, mechanism: 'follow_import')
@@ -31,7 +32,7 @@ RSpec.describe Moderation::FollowGateShadowObserver do
       it 'marks a remote unlocked target correctly' do
         remote = Fabricate(:account, username: 'shadow_remote', domain: 'remote.example', locked: false, protocol: :activitypub)
         expect(Moderation::FollowGateShadowWorker).to receive(:perform_async).with(
-          source.id, a_hash_including('target_locality' => 'remote', 'target_locked' => false)
+          source.id, a_hash_including('target_locality' => 'remote', 'target_locked' => false), a_kind_of(String)
         )
 
         described_class.observe(source_account: source, target_account: remote)

--- a/spec/services/moderation/follow_gate_shadow_observer_spec.rb
+++ b/spec/services/moderation/follow_gate_shadow_observer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::FollowGateShadowObserver do
+  let(:source) { Fabricate(:account, username: 'shadow_source') }
+  let(:target) { Fabricate(:account, username: 'shadow_target', locked: true) }
+
+  describe '.observe' do
+    context 'when the shadow flag is off (default)' do
+      it 'does not enqueue anything' do
+        allow(described_class).to receive(:enabled?).and_return(false)
+        expect(Moderation::FollowGateShadowWorker).to_not receive(:perform_async)
+
+        described_class.observe(source_account: source, target_account: target)
+      end
+    end
+
+    context 'when the shadow flag is on' do
+      before { allow(described_class).to receive(:enabled?).and_return(true) }
+
+      it 'enqueues the shadow worker with a behaviour-neutral context' do
+        expect(Moderation::FollowGateShadowWorker).to receive(:perform_async).with(
+          source.id,
+          { 'mechanism' => 'follow_import', 'target_locality' => 'local', 'target_locked' => true }
+        )
+
+        described_class.observe(source_account: source, target_account: target, mechanism: 'follow_import')
+      end
+
+      it 'marks a remote unlocked target correctly' do
+        remote = Fabricate(:account, username: 'shadow_remote', domain: 'remote.example', locked: false, protocol: :activitypub)
+        expect(Moderation::FollowGateShadowWorker).to receive(:perform_async).with(
+          source.id, a_hash_including('target_locality' => 'remote', 'target_locked' => false)
+        )
+
+        described_class.observe(source_account: source, target_account: remote)
+      end
+
+      it 'is failure-tolerant: a raising enqueue never propagates' do
+        allow(Moderation::FollowGateShadowWorker).to receive(:perform_async).and_raise(StandardError, 'boom')
+
+        expect { described_class.observe(source_account: source, target_account: target) }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/workers/moderation/follow_gate_shadow_worker_spec.rb
+++ b/spec/workers/moderation/follow_gate_shadow_worker_spec.rb
@@ -30,5 +30,30 @@ describe Moderation::FollowGateShadowWorker do
 
       expect { described_class.new.perform(account.id, {}) }.to_not raise_error
     end
+
+    it 'evaluates as of the attempt time, excluding events that happened after it' do
+      t0     = 90.minutes.ago.change(usec: 0)
+      before = Fabricate(:account, username: 'shadow_before')
+      after  = Fabricate(:account, username: 'shadow_after')
+
+      # One contact before the attempt, one after it.
+      Moderation::EventRecorder.record_interaction(actor: account, target: before, event_type: :follow, occurred_at: t0 - 10.minutes, source_event_key: 's-before')
+      Moderation::EventRecorder.record_interaction(actor: account, target: after, event_type: :follow, occurred_at: t0 + 30.minutes, source_event_key: 's-after')
+
+      # The worker threads the attempt time through to the gate decision as `now`.
+      captured_now = nil
+      allow_any_instance_of(Moderation::AdaptiveFollowGateDecisionService).to receive(:call).and_wrap_original do |method, *args, **kwargs|
+        captured_now = kwargs[:now]
+        method.call(*args, **kwargs)
+      end
+
+      described_class.new.perform(account.id, {}, t0.utc.iso8601)
+      expect(captured_now.to_i).to eq t0.to_i
+
+      # And at that `now`, the underlying metrics exclude the post-attempt contact
+      # (1), while evaluating now would include both (2) — i.e. no future leakage.
+      expect(Moderation::BehavioralMetricsService.new.call(account, now: t0).dig('windows', '24h', 'contacts_total')).to eq 1
+      expect(Moderation::BehavioralMetricsService.new.call(account, now: Time.now.utc).dig('windows', '24h', 'contacts_total')).to eq 2
+    end
   end
 end

--- a/spec/workers/moderation/follow_gate_shadow_worker_spec.rb
+++ b/spec/workers/moderation/follow_gate_shadow_worker_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Moderation::FollowGateShadowWorker do
+  let(:account) { Fabricate(:account, username: 'shadow_worker_actor') }
+
+  describe '#perform' do
+    it 'logs the would-be friction from the shadow decision without applying anything' do
+      logged = nil
+      allow(Rails.logger).to receive(:info) { |msg| logged = msg }
+
+      described_class.new.perform(account.id, { 'mechanism' => 'api', 'target_locality' => 'remote' })
+
+      expect(logged).to include('[Moderation::FollowGateShadow]')
+      payload = JSON.parse(logged.sub('[Moderation::FollowGateShadow] ', ''))
+      expect(payload['shadow']).to be true
+      # No ledger history -> the gate would propose allow.
+      expect(payload['would_friction']).to eq 'allow'
+      expect(payload['policy_version']).to eq Moderation::AdaptiveFollowGateDecisionService::POLICY_VERSION
+      expect(payload['context']).to include('mechanism' => 'api', 'target_locality' => 'remote')
+    end
+
+    it 'returns quietly for a missing account' do
+      expect { described_class.new.perform(0, {}) }.to_not raise_error
+    end
+
+    it 'is failure-tolerant if the decision service raises' do
+      allow_any_instance_of(Moderation::AdaptiveFollowGateDecisionService).to receive(:call).and_raise(StandardError, 'boom')
+
+      expect { described_class.new.perform(account.id, {}) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires the adaptive follow gate (PR #45) into the follow flow in **shadow mode**: on a created follow, `FollowService` records what friction the gate *would* propose, without changing the follow. This is the observation step from the plan — measure firing frequency / timing / false positives before any real friction is ever applied.

## Design & safety

- **Shadow only, no execution.** Nothing is blocked, delayed, converted, or denied. `FollowService`'s behaviour is unchanged; the gate decision is only recorded.
- **Off by default.** Gated behind `MODERATION_FOLLOW_GATE_SHADOW` (env, default off), so merging changes nothing until an operator turns it on to collect data.
- **Failure-tolerant.** `Moderation::FollowGateShadowObserver.observe` swallows/logs any error and can never break a follow.
- **Off the hot path.** The observer only enqueues; the ledger-reading evaluation runs in `Moderation::FollowGateShadowWorker` (async, `retry: false`), which logs a structured `[Moderation::FollowGateShadow]` line (`would_friction`, `policy_version`, `params_digest`, `subject_id`, `context`, `matched_rule_count`).
- **Behaviour-neutral context.** Attempt context (`mechanism`, `target_locality`, `target_locked`) only routes which reversible friction the shadow decision would pick; `mechanism` is derived from existing options (`follow_import` when an import batch id is present, `migration` for move tracking) purely for observability and never raises risk.

## What changed

- `Moderation::FollowGateShadowObserver` (flag-gated, failure-tolerant enqueue).
- `Moderation::FollowGateShadowWorker` (async, computes `AdaptiveFollowGateDecisionService`, logs the would-be decision).
- `FollowService#call` calls the observer on the created-follow path with the derived mechanism.

## Scope / next steps

Observation plumbing only. Next: collect shadow data (enable the flag in an environment), review firing frequency / false positives / timing, then calibrate thresholds before ever applying a real, light, reversible friction (rate_limit / delay first). `ImportService`-side observation is already covered because follow imports flow through `FollowService`.

## Testing

```
$ bundle exec rspec spec/services/moderation/follow_gate_shadow_observer_spec.rb \
    spec/workers/moderation/follow_gate_shadow_worker_spec.rb \
    spec/services/moderation/follow_gate_shadow_integration_spec.rb
10 examples, 0 failures

$ bundle exec rspec spec/services/moderation
# (all moderation service specs pass)
```

Covers: observer no-ops when the flag is off; enqueues a behaviour-neutral context when on (local/remote + locked flags, derived mechanism); failure-tolerance (a raising enqueue never propagates); the worker logs the `would_friction` (allow for a no-history account) and is safe for a missing account / a raising decision; and `FollowService` wiring (observes source/target/mechanism, still creates the follow, enqueues nothing when off).

Note: `follow_service_spec:16,:28` fail on the base too (pre-existing webpack-manifest render of the locked-account notification mailer) — unrelated to this change.

Head: `f95872db0df1426c823d4306af5169523b1c1c94`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

