### PR TITLE
Moderation ledger: analysis-only follow-gate backtest/replay (PR 16)

### DIFF
--- a/app/services/moderation/follow_gate_backtest_service.rb
+++ b/app/services/moderation/follow_gate_backtest_service.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# Replays a subject's recorded follow attempts in chronological order and, for
+# each one, asks the adaptive follow gate what it WOULD have proposed as of that
+# attempt's time. It answers the calibration question "at what Nth follow / how
+# many minutes in would the gate first have proposed friction?" from real ledger
+# history.
+#
+# Strictly analysis-only:
+#
+#   * Read-only — reads the ledger via the gate/evaluation services (all
+#     read-only) and writes nothing.
+#   * No enforcement, no friction applied — it only reports what the shadow gate
+#     would have proposed, historically.
+#   * No future leakage — each follow is evaluated with now = that follow's
+#     occurred_at, so later follows/rejections do not influence earlier attempts.
+#   * Offline tool — each replayed attempt runs a full metrics evaluation, so the
+#     replay is capped (max_events) and is meant to be run on a chosen
+#     subject/cohort, not the whole population inline.
+#
+# Note: per-target routing (confirm_target, which needs the specific target's
+# local/unlocked state) is not modeled here; the backtest measures the
+# subject-level, behaviour-driven frictions (rate_limit / delay / moderator_review),
+# which is the calibration question of interest.
+module Moderation
+  class FollowGateBacktestService
+    DEFAULT_MAX_EVENTS = 2_000
+
+    def initialize(gate_service: Moderation::AdaptiveFollowGateDecisionService.new)
+      @gate_service = gate_service
+    end
+
+    def call(subject_or_account, max_events: DEFAULT_MAX_EVENTS)
+      subject = resolve_subject(subject_or_account)
+      return empty_result(subject) if subject.nil?
+
+      follows = follow_events(subject, max_events)
+      return empty_result(subject) if follows.empty?
+
+      first_follow_at = follows.first.occurred_at
+      friction_counts = Hash.new(0)
+      first_friction  = {}
+      policy_version  = nil
+      params_digest   = nil
+
+      follows.each_with_index do |event, offset|
+        decision = @gate_service.call(subject, now: event.occurred_at)
+        policy_version ||= decision['policy_version']
+        params_digest  ||= decision['params_digest']
+
+        friction = decision['proposed_friction']
+        friction_counts[friction] += 1
+
+        next if friction == 'allow' || first_friction.key?(friction)
+
+        first_friction[friction] = {
+          'attempt_index'            => offset + 1,
+          'occurred_at'              => event.occurred_at.utc.iso8601,
+          'minutes_from_first_follow' => ((event.occurred_at - first_follow_at) / 60.0).round(2),
+        }
+      end
+
+      {
+        'subject_id'          => subject.id,
+        'generated_at'        => Time.now.utc.iso8601,
+        'gate_policy_version' => policy_version,
+        'gate_params_digest'  => params_digest,
+        'follow_attempts'     => follows.size,
+        'first_follow_at'     => first_follow_at.utc.iso8601,
+        'last_follow_at'      => follows.last.occurred_at.utc.iso8601,
+        'friction_counts'     => friction_counts,
+        'first_friction'      => first_friction,
+      }
+    end
+
+    private
+
+    def resolve_subject(subject_or_account)
+      return subject_or_account if subject_or_account.is_a?(ModerationSubject)
+      return if subject_or_account.nil?
+
+      ModerationSubject.find_by(account_id: subject_or_account.id)
+    end
+
+    def follow_events(subject, max_events)
+      ModerationInteractionEvent
+        .where(actor_subject_id: subject.id, event_type: :follow)
+        .where.not(occurred_at: nil)
+        .order(:occurred_at, :id)
+        .limit(max_events)
+        .to_a
+    end
+
+    def empty_result(subject)
+      {
+        'subject_id'          => subject&.id,
+        'generated_at'        => Time.now.utc.iso8601,
+        'gate_policy_version' => nil,
+        'gate_params_digest'  => nil,
+        'follow_attempts'     => 0,
+        'first_follow_at'     => nil,
+        'last_follow_at'      => nil,
+        'friction_counts'     => {},
+        'first_friction'      => {},
+      }
+    end
+  end
+end

--- a/app/services/moderation/follow_gate_backtest_service.rb
+++ b/app/services/moderation/follow_gate_backtest_service.rb
@@ -32,10 +32,13 @@ module Moderation
 
     def call(subject_or_account, max_events: DEFAULT_MAX_EVENTS)
       subject = resolve_subject(subject_or_account)
-      return empty_result(subject) if subject.nil?
+      return empty_result(subject, max_events) if subject.nil?
 
-      follows = follow_events(subject, max_events)
-      return empty_result(subject) if follows.empty?
+      total_follows = follow_events_count(subject)
+      follows       = follow_events(subject, max_events)
+      return empty_result(subject, max_events) if follows.empty?
+
+      locality_by_subject_id = target_locality_map(follows)
 
       first_follow_at = follows.first.occurred_at
       friction_counts = Hash.new(0)
@@ -44,7 +47,12 @@ module Moderation
       params_digest   = nil
 
       follows.each_with_index do |event, offset|
-        decision = @gate_service.call(subject, now: event.occurred_at)
+        # Reconstruct the target's locality so the gate's locality-based routing
+        # (local vs remote/unknown) matches what it would have done at attempt
+        # time. target_locked is not historically recoverable, so confirm_target
+        # remains out of scope.
+        context  = { 'target_locality' => locality_by_subject_id[event.target_subject_id] }
+        decision = @gate_service.call(subject, context: context, now: event.occurred_at)
         policy_version ||= decision['policy_version']
         params_digest  ||= decision['params_digest']
 
@@ -61,15 +69,21 @@ module Moderation
       end
 
       {
-        'subject_id'          => subject.id,
-        'generated_at'        => Time.now.utc.iso8601,
-        'gate_policy_version' => policy_version,
-        'gate_params_digest'  => params_digest,
-        'follow_attempts'     => follows.size,
-        'first_follow_at'     => first_follow_at.utc.iso8601,
-        'last_follow_at'      => follows.last.occurred_at.utc.iso8601,
-        'friction_counts'     => friction_counts,
-        'first_friction'      => first_friction,
+        'subject_id'             => subject.id,
+        'generated_at'           => Time.now.utc.iso8601,
+        'gate_policy_version'    => policy_version,
+        'gate_params_digest'     => params_digest,
+        # Only the analyzed (possibly truncated) window is summarized below; do not
+        # read these as the whole campaign when truncated is true.
+        'total_follow_events'    => total_follows,
+        'analyzed_follow_events' => follows.size,
+        'max_events'             => max_events,
+        'truncated'              => total_follows > follows.size,
+        'follow_attempts'        => follows.size,
+        'first_follow_at'        => first_follow_at.utc.iso8601,
+        'last_follow_at'         => follows.last.occurred_at.utc.iso8601,
+        'friction_counts'        => friction_counts,
+        'first_friction'         => first_friction,
       }
     end
 
@@ -82,26 +96,47 @@ module Moderation
       ModerationSubject.find_by(account_id: subject_or_account.id)
     end
 
-    def follow_events(subject, max_events)
+    def follow_events_scope(subject)
       ModerationInteractionEvent
         .where(actor_subject_id: subject.id, event_type: :follow)
         .where.not(occurred_at: nil)
-        .order(:occurred_at, :id)
-        .limit(max_events)
-        .to_a
     end
 
-    def empty_result(subject)
+    def follow_events_count(subject)
+      follow_events_scope(subject).count
+    end
+
+    def follow_events(subject, max_events)
+      follow_events_scope(subject).order(:occurred_at, :id).limit(max_events).to_a
+    end
+
+    # Reconstruct target locality from each target's ModerationSubject origin.
+    # A missing target subject (nullified after deletion) yields nil, which the
+    # gate treats as non-local/unknown.
+    def target_locality_map(follows)
+      ids = follows.map(&:target_subject_id).compact.uniq
+      return {} if ids.empty?
+
+      ModerationSubject.where(id: ids).each_with_object({}) do |subject, map|
+        map[subject.id] = subject.origin
+      end
+    end
+
+    def empty_result(subject, max_events)
       {
-        'subject_id'          => subject&.id,
-        'generated_at'        => Time.now.utc.iso8601,
-        'gate_policy_version' => nil,
-        'gate_params_digest'  => nil,
-        'follow_attempts'     => 0,
-        'first_follow_at'     => nil,
-        'last_follow_at'      => nil,
-        'friction_counts'     => {},
-        'first_friction'      => {},
+        'subject_id'             => subject&.id,
+        'generated_at'           => Time.now.utc.iso8601,
+        'gate_policy_version'    => nil,
+        'gate_params_digest'     => nil,
+        'total_follow_events'    => 0,
+        'analyzed_follow_events' => 0,
+        'max_events'             => max_events,
+        'truncated'              => false,
+        'follow_attempts'        => 0,
+        'first_follow_at'        => nil,
+        'last_follow_at'         => nil,
+        'friction_counts'        => {},
+        'first_friction'         => {},
       }
     end
   end

--- a/spec/services/moderation/follow_gate_backtest_service_spec.rb
+++ b/spec/services/moderation/follow_gate_backtest_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Moderation::FollowGateBacktestService do
 
     let(:gate_service) do
       fake = instance_double(Moderation::AdaptiveFollowGateDecisionService)
-      allow(fake).to receive(:call) do |_subject, now:|
+      allow(fake).to receive(:call) do |_subject, now:, **|
         friction =
           if now >= t0 + 90.minutes then 'delay'
           elsif now >= t0 + 30.minutes then 'rate_limit'
@@ -47,7 +47,7 @@ RSpec.describe Moderation::FollowGateBacktestService do
 
     it 'evaluates each attempt as of its own occurred_at (no future leakage)' do
       seen_nows = []
-      allow(gate_service).to receive(:call) do |_subject, now:|
+      allow(gate_service).to receive(:call) do |_subject, now:, **|
         seen_nows << now
         { 'proposed_friction' => 'allow', 'policy_version' => 'gate-test', 'params_digest' => 'sha256:test' }
       end
@@ -55,6 +55,59 @@ RSpec.describe Moderation::FollowGateBacktestService do
       described_class.new(gate_service: gate_service).call(actor)
 
       expect(seen_nows.map(&:to_i)).to eq [t0, t0 + 30.minutes, t0 + 90.minutes].map(&:to_i)
+    end
+  end
+
+  describe 'target locality reconstruction' do
+    let(:local_target)  { Fabricate(:account, username: 'bt_local') }
+    let(:remote_target) { Fabricate(:account, username: 'bt_remote', domain: 'remote.example', protocol: :activitypub) }
+
+    let!(:local_follow)  { record_follow(local_target, t0, 'loc-1') }
+    let!(:remote_follow) { record_follow(remote_target, t0 + 10.minutes, 'loc-2') }
+
+    it 'passes each attempt the target locality restored from the target subject origin' do
+      seen = []
+      gate = instance_double(Moderation::AdaptiveFollowGateDecisionService)
+      allow(gate).to receive(:call) do |_subject, context:, now:|
+        seen << [now.to_i, context['target_locality']]
+        { 'proposed_friction' => 'allow', 'policy_version' => 'g', 'params_digest' => 's' }
+      end
+
+      described_class.new(gate_service: gate).call(actor)
+
+      expect(seen).to eq [[t0.to_i, 'local'], [(t0 + 10.minutes).to_i, 'remote']]
+    end
+
+    context 'with the real gate under elevated rejection' do
+      # Inject an evaluator into the real gate so rejection is elevated; then the
+      # locality-based delay rule must fire for the remote target but NOT the local.
+      let(:evaluator) do
+        subscores = %w(contact_volume velocity rejection report follow_import repeat_behavior).index_with { |d| { 'score' => d == 'rejection' ? 0.6 : 0.0, 'reason_codes' => [] } }
+        instance_double(Moderation::RiskEvaluationService, call: { 'subject_id' => 1, 'subscores' => subscores, 'policy_version' => 'risk-test', 'params_digest' => 'sha256:t' })
+      end
+
+      it 'does not fire locality-based delay for a local target, but does for a remote target' do
+        gate   = Moderation::AdaptiveFollowGateDecisionService.new(evaluator: evaluator)
+        result = described_class.new(gate_service: gate).call(actor)
+
+        # local follow at t0 -> allow (no locality delay); remote follow -> delay.
+        expect(result['friction_counts']).to eq('allow' => 1, 'delay' => 1)
+        expect(result['first_friction']['delay']).to include('attempt_index' => 2)
+      end
+    end
+  end
+
+  describe 'truncation reporting' do
+    it 'reports total vs analyzed and the truncated flag when capped' do
+      3.times { |i| record_follow(Fabricate(:account, username: "bt_trunc_#{i}"), t0 + i.minutes, "trunc-#{i}") }
+
+      result = described_class.new.call(actor, max_events: 2)
+
+      expect(result['total_follow_events']).to eq 3
+      expect(result['analyzed_follow_events']).to eq 2
+      expect(result['follow_attempts']).to eq 2
+      expect(result['max_events']).to eq 2
+      expect(result['truncated']).to be true
     end
   end
 

--- a/spec/services/moderation/follow_gate_backtest_service_spec.rb
+++ b/spec/services/moderation/follow_gate_backtest_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::FollowGateBacktestService do
+  let(:actor) { Fabricate(:account, username: 'backtest_actor') }
+  let(:t0)    { 3.hours.ago.change(usec: 0) }
+
+  def record_follow(target, at, key)
+    Moderation::EventRecorder.record_interaction(actor: actor, target: target, event_type: :follow, occurred_at: at, source_event_key: key)
+  end
+
+  describe 'replaying follow attempts as of their own time' do
+    # Three follows at t0, t0+30m, t0+90m. An injected gate returns a friction
+    # based on the evaluation time, so we can assert timing/index deterministically.
+    let!(:follow1) { record_follow(Fabricate(:account, username: 'bt1'), t0, 'bt-1') }
+    let!(:follow2) { record_follow(Fabricate(:account, username: 'bt2'), t0 + 30.minutes, 'bt-2') }
+    let!(:follow3) { record_follow(Fabricate(:account, username: 'bt3'), t0 + 90.minutes, 'bt-3') }
+
+    let(:gate_service) do
+      fake = instance_double(Moderation::AdaptiveFollowGateDecisionService)
+      allow(fake).to receive(:call) do |_subject, now:|
+        friction =
+          if now >= t0 + 90.minutes then 'delay'
+          elsif now >= t0 + 30.minutes then 'rate_limit'
+          else 'allow'
+          end
+        { 'proposed_friction' => friction, 'policy_version' => 'gate-test', 'params_digest' => 'sha256:test' }
+      end
+      fake
+    end
+
+    subject(:result) { described_class.new(gate_service: gate_service).call(actor) }
+
+    it 'reports the attempts and per-friction counts' do
+      expect(result['subject_id']).to eq ModerationSubject.find_by(account_id: actor.id).id
+      expect(result['follow_attempts']).to eq 3
+      expect(result['friction_counts']).to eq('allow' => 1, 'rate_limit' => 1, 'delay' => 1)
+      expect(result['gate_policy_version']).to eq 'gate-test'
+    end
+
+    it 'records when each friction tier is first reached (index + time)' do
+      expect(result['first_friction']['rate_limit']).to include('attempt_index' => 2, 'minutes_from_first_follow' => 30.0)
+      expect(result['first_friction']['delay']).to include('attempt_index' => 3, 'minutes_from_first_follow' => 90.0)
+      expect(result['first_friction']).to_not have_key('allow')
+    end
+
+    it 'evaluates each attempt as of its own occurred_at (no future leakage)' do
+      seen_nows = []
+      allow(gate_service).to receive(:call) do |_subject, now:|
+        seen_nows << now
+        { 'proposed_friction' => 'allow', 'policy_version' => 'gate-test', 'params_digest' => 'sha256:test' }
+      end
+
+      described_class.new(gate_service: gate_service).call(actor)
+
+      expect(seen_nows.map(&:to_i)).to eq [t0, t0 + 30.minutes, t0 + 90.minutes].map(&:to_i)
+    end
+  end
+
+  describe 'a subject with no follows' do
+    it 'returns a zeroed result' do
+      ModerationSubject.for_account!(actor)
+      result = described_class.new.call(actor)
+
+      expect(result['follow_attempts']).to eq 0
+      expect(result['friction_counts']).to eq({})
+      expect(result['first_friction']).to eq({})
+      expect(result['first_follow_at']).to be_nil
+    end
+  end
+
+  describe 'a low-risk subject with the real gate' do
+    it 'proposes allow throughout (no friction ever reached)' do
+      record_follow(Fabricate(:account, username: 'bt_real1'), t0, 'btr-1')
+      record_follow(Fabricate(:account, username: 'bt_real2'), t0 + 5.minutes, 'btr-2')
+
+      result = described_class.new.call(actor)
+
+      expect(result['follow_attempts']).to eq 2
+      expect(result['friction_counts']).to eq('allow' => 2)
+      expect(result['first_friction']).to be_empty
+    end
+  end
+
+  describe 'read-only' do
+    it 'does not create a ModerationSubject for an account with no history' do
+      fresh = Fabricate(:account, username: 'bt_fresh')
+
+      result = nil
+      expect { result = described_class.new.call(fresh) }.to_not change(ModerationSubject, :count)
+
+      expect(result['subject_id']).to be_nil
+      expect(result['follow_attempts']).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Moderation::FollowGateBacktestService` replays a subject's recorded follow attempts in chronological order and, for each one, asks the adaptive follow gate (PR #45) what it *would* have proposed **as of that attempt's time**. This answers the design memo's highest-value calibration question — "at what Nth follow / how many minutes in would the gate first have proposed friction?" — from real ledger history, before any real friction is ever wired in.

## Guardrails

- **Analysis-only, read-only.** Reads the ledger via the (read-only) gate/evaluation services; writes nothing; creates no `ModerationSubject`.
- **No enforcement, no friction applied.** It only reports what the shadow gate would have proposed, historically.
- **No future leakage.** Each follow is evaluated with `now = that follow's occurred_at`, so later follows/rejections/blocks do not influence earlier attempts.
- **Offline tool.** Each replayed attempt runs a full metrics evaluation, so the replay is capped (`max_events`, default 2000) and is meant to be run on a chosen subject/cohort — not the whole population inline.
- Per-target `confirm_target` routing (which needs a specific target's local/unlocked state) is out of scope; the backtest measures the subject-level, behaviour-driven frictions (`rate_limit` / `delay` / `moderator_review`), which is the calibration question of interest.

## Output

`subject_id`, `gate_policy_version`/`gate_params_digest`, `follow_attempts`, `first_follow_at`/`last_follow_at`, `friction_counts` (attempts that would get each friction), and `first_friction` per non-allow tier (`attempt_index` + `occurred_at` + `minutes_from_first_follow`).

## Scope / next steps

Provides the backtest data for calibration. Still deferred: cohort-level backtest aggregation, threshold tuning from the results, and any real (even light/reversible) friction — which only comes after this calibration and the shadow-observation data.

## Testing

```
$ bundle exec rspec spec/services/moderation/follow_gate_backtest_service_spec.rb
6 examples, 0 failures

$ bundle exec rspec spec/services/moderation
130 examples, 0 failures
```

Covers: per-friction counts and first-friction timing/index (rate_limit at attempt 2 / +30m, delay at attempt 3 / +90m via an injected gate); each attempt evaluated as of its own `occurred_at` (no future leakage); a low-risk subject with the real gate (allow throughout); an empty subject; and read-only (no `ModerationSubject` created for a no-history account).

Head: `e475a64e964034c26c9750aa59ed6dc490ddf782`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

