### PR TITLE
Moderation ledger: cohort follow-gate backtest aggregation (PR 17)

### DIFF
--- a/app/services/moderation/follow_gate_backtest_cohort_service.rb
+++ b/app/services/moderation/follow_gate_backtest_cohort_service.rb
@@ -19,8 +19,12 @@
 # denominator but counted in subject_count.
 module Moderation
   class FollowGateBacktestCohortService
-    # Non-allow friction tiers, aggregated in ladder order.
-    FRICTIONS = %w(rate_limit confirm_target delay moderator_review).freeze
+    # Non-allow friction tiers the backtest can measure, in ladder order.
+    # confirm_target is intentionally excluded: the backtest cannot recover a
+    # target's historical locked state, so it never models confirm_target and
+    # reporting it would read as a misleading "0 reached".
+    FRICTIONS = %w(rate_limit delay moderator_review).freeze
+    UNSUPPORTED_FRICTIONS = { 'confirm_target' => 'target_locked is not historically recoverable, so the backtest does not model confirm_target' }.freeze
     PERCENTILES = [50, 90, 95].freeze
 
     def initialize(backtest_service: Moderation::FollowGateBacktestService.new)
@@ -31,11 +35,11 @@ module Moderation
       seen                  = Set.new
       subject_count         = 0
       subjects_with_follows = 0
-      policy_version        = nil
-      params_digest         = nil
+      policy_versions       = Set.new
+      params_digests        = Set.new
 
-      # friction => { index: [...], minutes: [...], subjects: n }
-      reached = FRICTIONS.index_with { { index: [], minutes: [], subjects: 0 } }
+      # friction => { reached:, eligible:, censored:, index: [...], minutes: [...] }
+      buckets = FRICTIONS.index_with { { reached: 0, eligible: 0, censored: 0, index: [], minutes: [] } }
 
       subjects.each do |subject|
         next unless subject.respond_to?(:id) && seen.add?(subject.id)
@@ -45,16 +49,31 @@ module Moderation
         next if result['follow_attempts'].to_i.zero?
 
         subjects_with_follows += 1
-        policy_version ||= result['gate_policy_version']
-        params_digest  ||= result['gate_params_digest']
+        policy_versions << result['gate_policy_version'] if result['gate_policy_version']
+        params_digests  << result['gate_params_digest'] if result['gate_params_digest']
 
-        (result['first_friction'] || {}).each do |friction, info|
-          bucket = reached[friction]
-          next if bucket.nil?
+        truncated      = result['truncated'] ? true : false
+        first_friction = result['first_friction'] || {}
 
-          bucket[:subjects] += 1
-          bucket[:index]   << info['attempt_index']
-          bucket[:minutes] << info['minutes_from_first_follow']
+        FRICTIONS.each do |friction|
+          bucket = buckets[friction]
+          info   = first_friction[friction]
+
+          if info
+            # Reached before any truncation -> counts as reached and eligible.
+            bucket[:reached]  += 1
+            bucket[:eligible] += 1
+            bucket[:index]    << info['attempt_index']
+            bucket[:minutes]  << info['minutes_from_first_follow']
+          elsif truncated
+            # Right-censored: it might have reached this friction past the cap.
+            # Exclude from the eligible denominator instead of counting a false
+            # "never reached".
+            bucket[:censored] += 1
+          else
+            # Complete run that definitively did not reach this friction.
+            bucket[:eligible] += 1
+          end
         end
       end
 
@@ -62,19 +81,23 @@ module Moderation
         'generated_at'          => Time.now.utc.iso8601,
         'subject_count'         => subject_count,
         'subjects_with_follows' => subjects_with_follows,
-        'gate_policy_version'   => policy_version,
-        'gate_params_digest'    => params_digest,
+        'gate_policy_version'   => policy_versions.size <= 1 ? policy_versions.first : 'mixed',
+        'gate_params_digest'    => params_digests.size <= 1 ? params_digests.first : 'mixed',
+        'mixed_policy'          => policy_versions.size > 1 || params_digests.size > 1,
         'max_events'            => max_events,
-        'frictions'             => FRICTIONS.index_with { |friction| friction_summary(reached[friction], subjects_with_follows) },
+        'unsupported_frictions' => UNSUPPORTED_FRICTIONS,
+        'frictions'             => FRICTIONS.index_with { |friction| friction_summary(buckets[friction]) },
       }
     end
 
     private
 
-    def friction_summary(bucket, denominator)
+    def friction_summary(bucket)
       {
-        'subjects_reached'          => bucket[:subjects],
-        'reach_rate'                => ratio(bucket[:subjects], denominator),
+        'subjects_reached'          => bucket[:reached],
+        'subjects_eligible'         => bucket[:eligible],
+        'subjects_censored'         => bucket[:censored],
+        'reach_rate'                => ratio(bucket[:reached], bucket[:eligible]),
         'first_attempt_index'       => distribution(bucket[:index]),
         'first_minutes_from_follow' => distribution(bucket[:minutes]),
       }

--- a/app/services/moderation/follow_gate_backtest_cohort_service.rb
+++ b/app/services/moderation/follow_gate_backtest_cohort_service.rb
@@ -14,9 +14,11 @@
 #   * No population scan — the caller passes the subject set (a sample or a
 #     hand-labelled cohort); subjects repeated in the input are de-duplicated by id.
 #
-# Reach rate denominator is subjects_with_follows (only subjects that made follow
-# attempts can reach a friction); subjects with no follows are excluded from the
-# denominator but counted in subject_count.
+# Reach-rate denominator is friction-specific subjects_eligible.
+# Complete non-reachers and reached subjects are eligible; truncated non-reachers
+# are right-censored and excluded (they might have reached the friction past the
+# max_events cap). Subjects with no follow attempts are excluded from every
+# friction's counts but still counted in subject_count.
 module Moderation
   class FollowGateBacktestCohortService
     # Non-allow friction tiers the backtest can measure, in ladder order.

--- a/app/services/moderation/follow_gate_backtest_cohort_service.rb
+++ b/app/services/moderation/follow_gate_backtest_cohort_service.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Aggregates Moderation::FollowGateBacktestService results across a caller-supplied
+# cohort of subjects, so an operator can compare, say, a known-legitimate
+# high-volume cohort against a known-problematic one and see how often each
+# friction tier would fire and how early (attempt index / minutes in).
+#
+# Strictly analysis-only, mirroring the calibration services:
+#
+#   * Read-only — reads via the backtest service (itself read-only); writes
+#     nothing.
+#   * No scoring/thresholds/labels/enforcement — reports reach rates and
+#     first-friction distributions only.
+#   * No population scan — the caller passes the subject set (a sample or a
+#     hand-labelled cohort); subjects repeated in the input are de-duplicated by id.
+#
+# Reach rate denominator is subjects_with_follows (only subjects that made follow
+# attempts can reach a friction); subjects with no follows are excluded from the
+# denominator but counted in subject_count.
+module Moderation
+  class FollowGateBacktestCohortService
+    # Non-allow friction tiers, aggregated in ladder order.
+    FRICTIONS = %w(rate_limit confirm_target delay moderator_review).freeze
+    PERCENTILES = [50, 90, 95].freeze
+
+    def initialize(backtest_service: Moderation::FollowGateBacktestService.new)
+      @backtest_service = backtest_service
+    end
+
+    def call(subjects, max_events: Moderation::FollowGateBacktestService::DEFAULT_MAX_EVENTS)
+      seen                  = Set.new
+      subject_count         = 0
+      subjects_with_follows = 0
+      policy_version        = nil
+      params_digest         = nil
+
+      # friction => { index: [...], minutes: [...], subjects: n }
+      reached = FRICTIONS.index_with { { index: [], minutes: [], subjects: 0 } }
+
+      subjects.each do |subject|
+        next unless subject.respond_to?(:id) && seen.add?(subject.id)
+
+        subject_count += 1
+        result = @backtest_service.call(subject, max_events: max_events)
+        next if result['follow_attempts'].to_i.zero?
+
+        subjects_with_follows += 1
+        policy_version ||= result['gate_policy_version']
+        params_digest  ||= result['gate_params_digest']
+
+        (result['first_friction'] || {}).each do |friction, info|
+          bucket = reached[friction]
+          next if bucket.nil?
+
+          bucket[:subjects] += 1
+          bucket[:index]   << info['attempt_index']
+          bucket[:minutes] << info['minutes_from_first_follow']
+        end
+      end
+
+      {
+        'generated_at'          => Time.now.utc.iso8601,
+        'subject_count'         => subject_count,
+        'subjects_with_follows' => subjects_with_follows,
+        'gate_policy_version'   => policy_version,
+        'gate_params_digest'    => params_digest,
+        'max_events'            => max_events,
+        'frictions'             => FRICTIONS.index_with { |friction| friction_summary(reached[friction], subjects_with_follows) },
+      }
+    end
+
+    private
+
+    def friction_summary(bucket, denominator)
+      {
+        'subjects_reached'          => bucket[:subjects],
+        'reach_rate'                => ratio(bucket[:subjects], denominator),
+        'first_attempt_index'       => distribution(bucket[:index]),
+        'first_minutes_from_follow' => distribution(bucket[:minutes]),
+      }
+    end
+
+    def distribution(values)
+      compact = values.compact
+      return { 'n' => 0, 'min' => nil, 'max' => nil, 'mean' => nil, 'percentiles' => PERCENTILES.index_with { nil } } if compact.empty?
+
+      sorted = compact.sort
+      {
+        'n'           => sorted.size,
+        'min'         => sorted.first,
+        'max'         => sorted.last,
+        'mean'        => sorted.sum.to_f / sorted.size,
+        'percentiles' => PERCENTILES.index_with { |p| percentile(sorted, p) },
+      }
+    end
+
+    def percentile(sorted, percent)
+      return sorted.first.to_f if sorted.size == 1
+
+      rank  = (percent / 100.0) * (sorted.size - 1)
+      lower = rank.floor
+      upper = rank.ceil
+      return sorted[lower].to_f if lower == upper
+
+      weight = rank - lower
+      (sorted[lower] * (1 - weight)) + (sorted[upper] * weight)
+    end
+
+    def ratio(numerator, denominator)
+      return 0.0 if denominator.nil? || denominator.zero?
+
+      numerator.to_f / denominator
+    end
+  end
+end

--- a/spec/services/moderation/follow_gate_backtest_cohort_service_spec.rb
+++ b/spec/services/moderation/follow_gate_backtest_cohort_service_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moderation::FollowGateBacktestCohortService do
+  # A per-subject backtest result, keyed by subject id via an injected backtest.
+  def backtest_result(follow_attempts:, first_friction: {})
+    {
+      'follow_attempts'     => follow_attempts,
+      'first_friction'      => first_friction,
+      'gate_policy_version' => 'gate-test',
+      'gate_params_digest'  => 'sha256:test',
+    }
+  end
+
+  def friction_at(index, minutes)
+    { 'attempt_index' => index, 'minutes_from_first_follow' => minutes }
+  end
+
+  def cohort(results_by_id)
+    subjects = results_by_id.keys.map { |id| ModerationSubject.new.tap { |s| s.id = id } }
+    backtest = instance_double(Moderation::FollowGateBacktestService)
+    allow(backtest).to receive(:call) { |subject, **| results_by_id.fetch(subject.id) }
+    described_class.new(backtest_service: backtest).call(subjects)
+  end
+
+  describe 'reach rates and first-friction distributions' do
+    subject(:result) do
+      cohort(
+        1 => backtest_result(follow_attempts: 100, first_friction: { 'delay' => friction_at(10, 5.0) }),
+        2 => backtest_result(follow_attempts: 100, first_friction: { 'delay' => friction_at(30, 25.0), 'moderator_review' => friction_at(50, 60.0) }),
+        3 => backtest_result(follow_attempts: 100, first_friction: {}) # never reaches friction
+      )
+    end
+
+    it 'counts the cohort and subjects with follows' do
+      expect(result['subject_count']).to eq 3
+      expect(result['subjects_with_follows']).to eq 3
+      expect(result['gate_policy_version']).to eq 'gate-test'
+    end
+
+    it 'reports reach counts and rates per friction (denominator = subjects with follows)' do
+      delay = result['frictions']['delay']
+      expect(delay['subjects_reached']).to eq 2
+      expect(delay['reach_rate']).to be_within(1e-9).of(2.0 / 3)
+
+      review = result['frictions']['moderator_review']
+      expect(review['subjects_reached']).to eq 1
+      expect(review['reach_rate']).to be_within(1e-9).of(1.0 / 3)
+
+      expect(result['frictions']['rate_limit']['subjects_reached']).to eq 0
+      expect(result['frictions']['rate_limit']['reach_rate']).to eq 0.0
+    end
+
+    it 'summarizes first-friction attempt index and timing distributions' do
+      delay = result['frictions']['delay']
+      expect(delay['first_attempt_index']).to include('n' => 2, 'min' => 10, 'max' => 30, 'mean' => 20.0)
+      expect(delay['first_minutes_from_follow']).to include('min' => 5.0, 'max' => 25.0)
+    end
+  end
+
+  describe 'subjects with no follows' do
+    it 'excludes them from the reach-rate denominator but counts them in subject_count' do
+      result = cohort(
+        1 => backtest_result(follow_attempts: 0, first_friction: {}),
+        2 => backtest_result(follow_attempts: 40, first_friction: { 'rate_limit' => friction_at(5, 2.0) })
+      )
+
+      expect(result['subject_count']).to eq 2
+      expect(result['subjects_with_follows']).to eq 1
+      expect(result['frictions']['rate_limit']['reach_rate']).to eq 1.0
+    end
+  end
+
+  describe 'de-duplication' do
+    it 'counts a repeated subject once' do
+      backtest = instance_double(Moderation::FollowGateBacktestService)
+      allow(backtest).to receive(:call).and_return(backtest_result(follow_attempts: 10, first_friction: { 'delay' => friction_at(3, 1.0) }))
+      s = ModerationSubject.new.tap { |subject| subject.id = 7 }
+
+      result = described_class.new(backtest_service: backtest).call([s, s])
+
+      expect(result['subject_count']).to eq 1
+      expect(result['subjects_with_follows']).to eq 1
+      expect(result['frictions']['delay']['subjects_reached']).to eq 1
+    end
+  end
+
+  describe 'empty cohort' do
+    it 'returns zeroed aggregates without error' do
+      result = described_class.new.call([])
+
+      expect(result['subject_count']).to eq 0
+      expect(result['subjects_with_follows']).to eq 0
+      expect(result['frictions']['delay']['subjects_reached']).to eq 0
+      expect(result['frictions']['delay']['first_attempt_index']['n']).to eq 0
+    end
+  end
+
+  describe 'end-to-end with the real backtest service' do
+    it 'aggregates a low-risk cohort as never reaching friction' do
+      actor = Fabricate(:account, username: 'cohort_real')
+      Moderation::EventRecorder.record_interaction(actor: actor, target: Fabricate(:account), event_type: :follow, occurred_at: 1.hour.ago, source_event_key: 'c-1')
+      subject = ModerationSubject.find_by(account_id: actor.id)
+
+      result = described_class.new.call([subject])
+
+      expect(result['subjects_with_follows']).to eq 1
+      expect(result['frictions'].values.map { |f| f['subjects_reached'] }).to all(eq(0))
+    end
+  end
+end

--- a/spec/services/moderation/follow_gate_backtest_cohort_service_spec.rb
+++ b/spec/services/moderation/follow_gate_backtest_cohort_service_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Moderation::FollowGateBacktestCohortService do
   # A per-subject backtest result, keyed by subject id via an injected backtest.
-  def backtest_result(follow_attempts:, first_friction: {})
+  def backtest_result(follow_attempts:, first_friction: {}, truncated: false, gate_policy_version: 'gate-test', gate_params_digest: 'sha256:test')
     {
       'follow_attempts'     => follow_attempts,
       'first_friction'      => first_friction,
-      'gate_policy_version' => 'gate-test',
-      'gate_params_digest'  => 'sha256:test',
+      'truncated'           => truncated,
+      'gate_policy_version' => gate_policy_version,
+      'gate_params_digest'  => gate_params_digest,
     }
   end
 
@@ -39,9 +40,11 @@ RSpec.describe Moderation::FollowGateBacktestCohortService do
       expect(result['gate_policy_version']).to eq 'gate-test'
     end
 
-    it 'reports reach counts and rates per friction (denominator = subjects with follows)' do
+    it 'reports reach counts and rates per friction (denominator = eligible subjects)' do
       delay = result['frictions']['delay']
       expect(delay['subjects_reached']).to eq 2
+      expect(delay['subjects_eligible']).to eq 3
+      expect(delay['subjects_censored']).to eq 0
       expect(delay['reach_rate']).to be_within(1e-9).of(2.0 / 3)
 
       review = result['frictions']['moderator_review']
@@ -50,6 +53,11 @@ RSpec.describe Moderation::FollowGateBacktestCohortService do
 
       expect(result['frictions']['rate_limit']['subjects_reached']).to eq 0
       expect(result['frictions']['rate_limit']['reach_rate']).to eq 0.0
+    end
+
+    it 'does not report the unsupported confirm_target as a friction tier' do
+      expect(result['frictions']).to_not have_key('confirm_target')
+      expect(result['unsupported_frictions']).to have_key('confirm_target')
     end
 
     it 'summarizes first-friction attempt index and timing distributions' do
@@ -69,6 +77,48 @@ RSpec.describe Moderation::FollowGateBacktestCohortService do
       expect(result['subject_count']).to eq 2
       expect(result['subjects_with_follows']).to eq 1
       expect(result['frictions']['rate_limit']['reach_rate']).to eq 1.0
+    end
+  end
+
+  describe 'right-censoring of truncated backtests' do
+    # A: complete run, delay not reached  -> eligible, definitive non-reach
+    # B: truncated run, delay not reached  -> censored, excluded from denominator
+    # C: truncated run, delay reached       -> reached + eligible
+    subject(:delay) do
+      cohort(
+        1 => backtest_result(follow_attempts: 50, truncated: false, first_friction: {}),
+        2 => backtest_result(follow_attempts: 2000, truncated: true, first_friction: {}),
+        3 => backtest_result(follow_attempts: 2000, truncated: true, first_friction: { 'delay' => friction_at(120, 40.0) })
+      )['frictions']['delay']
+    end
+
+    it 'excludes the truncated non-reacher and keeps reached/complete as eligible' do
+      expect(delay['subjects_reached']).to eq 1   # C
+      expect(delay['subjects_eligible']).to eq 2  # A + C
+      expect(delay['subjects_censored']).to eq 1  # B
+      expect(delay['reach_rate']).to be_within(1e-9).of(1.0 / 2)
+    end
+  end
+
+  describe 'policy consistency' do
+    it 'flags a mixed policy across the cohort' do
+      result = cohort(
+        1 => backtest_result(follow_attempts: 10, gate_policy_version: 'gate-A', gate_params_digest: 'sha256:a'),
+        2 => backtest_result(follow_attempts: 10, gate_policy_version: 'gate-B', gate_params_digest: 'sha256:b')
+      )
+
+      expect(result['mixed_policy']).to be true
+      expect(result['gate_policy_version']).to eq 'mixed'
+    end
+
+    it 'reports the single policy when consistent' do
+      result = cohort(
+        1 => backtest_result(follow_attempts: 10),
+        2 => backtest_result(follow_attempts: 10)
+      )
+
+      expect(result['mixed_policy']).to be false
+      expect(result['gate_policy_version']).to eq 'gate-test'
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Moderation::FollowGateBacktestCohortService` aggregates `Moderation::FollowGateBacktestService` (PR #47) results across a caller-supplied cohort of subjects. This is the calibration capstone from the design memo: compare a known-legitimate high-volume cohort against a known-problematic one and see **how often each friction tier would fire and how early** (attempt index / minutes in) — the input for choosing thresholds that catch abusers without catching normal users.

## Guardrails

- **Analysis-only, read-only.** Reads via the (read-only) backtest service; writes nothing.
- **No scoring / thresholds / labels / enforcement.** Reports reach rates and first-friction distributions only.
- **No population scan.** The caller supplies the subject set (a sample, or a hand-labelled cohort); subjects repeated in the input are de-duplicated by id.

## Output

- `subject_count` (deduped cohort), `subjects_with_follows`, `gate_policy_version`/`gate_params_digest`, `mixed_policy`, `max_events`, `unsupported_frictions`.
- Per measurable non-allow friction tier — `rate_limit`, `delay`, `moderator_review` — `subjects_reached`, `subjects_eligible`, `subjects_censored`, `reach_rate`, and distributions (`n`/`min`/`max`/`mean`/percentiles p50/p90/p95) of `first_attempt_index` and `first_minutes_from_follow`.

### Right-censoring (per friction)

`reach_rate = subjects_reached / subjects_eligible`, computed per friction so truncated backtests are not misread as non-reachers:
- reached the friction → counted in `subjects_reached` **and** `subjects_eligible`;
- **complete** run that did not reach it → `subjects_eligible` (definitive non-reach);
- **truncated** (`max_events`-capped) run that did not reach it → `subjects_censored`, **excluded** from the eligible denominator (it might have reached the friction past the cap).

Subjects with no follow attempts are excluded from every friction's counts but still counted in `subject_count`.

### confirm_target is not aggregated

The backtest cannot recover a target's historical `target_locked` state, so it never models `confirm_target`. Reporting it would read as a misleading "0 reached", so it is **excluded from the aggregated frictions** and instead listed under `unsupported_frictions` (with a reason).

### Policy consistency

If subjects in the cohort were evaluated under different gate policies, `gate_policy_version`/`gate_params_digest` are reported as `'mixed'` and `mixed_policy` is `true`; otherwise the single values are reported.

## Scope / deferrals

Provides the cohort calibration data. Still deferred: automatic cohort labelling, threshold tuning from the results, and any real friction (only after this calibration + shadow observation).

## Testing

```
$ bundle exec rspec spec/services/moderation/follow_gate_backtest_cohort_service_spec.rb
11 examples, 0 failures

$ bundle exec rspec spec/services/moderation
151 examples, 0 failures
```

Covers: reach counts/rates per tier with the per-friction `subjects_eligible` denominator; first-friction index/timing distributions; right-censoring (complete-non-reach → eligible, truncated-non-reach → censored/excluded, truncated-reached → reached+eligible); `confirm_target` excluded from `frictions` and listed in `unsupported_frictions`; mixed vs single gate policy; subjects with no follows excluded from friction counts but counted in `subject_count`; de-duplication; the empty cohort; and end-to-end with the real backtest service (a low-risk cohort never reaching friction).

Head: `3dbb4dd77d71473e5761ef804f7b913c116df184`

Do not merge — for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd578df-9205-4b21-8889-fb0cb9ca56f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

